### PR TITLE
refactor: remove npm plugin functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,9 @@ This repository contains the new Node.js API that is the backbone of Datawrapper
 1. [Local development](#local-development)
 1. [Configuration](#configuration)
 1. [Plugins](#plugins)
-    1. [`npm` plugins](#npm-plugins)
-    1. [Local plugins](#local-plugins)
-        1. [`hello-world`](#hello-world)
-        1. [`email-local`](#email-local)
-        1. [`chart-data-local`](#chart-data-local)
+    1. [`hello-world`](#hello-world)
+    1. [`email-local`](#email-local)
+    1. [`chart-data-local`](#chart-data-local)
 1. [`create-api` script](./create-api/Readme.md)
 1. [REST API with JSON](#rest-api-with-json)
 
@@ -140,14 +138,13 @@ Key | Example Value | Description
 Key | Example key | Example Value |  Description
 ---------|----------| --------- | ---------
 `plugin.<plugin-name>` | `plugin[my-plugin]` | `{}` | Configuration options for plugin
-|| `plugin[my-plugin].version` | `1.0.0` | Plugin version to install from `npm`
 || `plugin[my-plugin].apiKey` | `agamotto` | Configuration key passed to the plugins register function when server starts.
 
 ## Plugins
 
 The API is extensible to match customers and Datawrappers needs. By default the API has endpoints for basic functionality like user and chart management. This functionality can be extended with the use of plugins. Since the API is built on top of the [Hapi](https://hapijs.com) server framework, it uses [Hapis plugin system](https://hapijs.com/api#plugins). Everything a Hapi plugin can do, an API plugin can, too.
 
-For production use, it is recommended to install plugins with `npm`. The `create-api` script will try to automatically install all plugins that are configured in `config.js`. When starting the API server, it will check which plugins are configured in `config.js` and pass the configuration objects to the plugins `register` function with `options.config`. Plugins will have access to ORM models through `options.models`.
+When starting the API server, it will check which plugins are configured in `config.js` and pass the configuration objects to the plugins `register` function with `options.config`. Plugins will have access to ORM models through `options.models`.
 
 In its simplest form, an API plugin is a node module that exports an object with `name`, `version` and `register` keys.
 
@@ -170,16 +167,6 @@ module.exports = {
     }
 }
 ```
-
-### `npm` plugins
-
-Plugins can be installed from `npm`. Even though they can have any name, it is recommended to follow a naming guideline. Plugins developed by Datawrapper will follow the naming convention `@datawrapper/plugin-{name}`. Community or customer developed plugins should be named `dw-plugin-{name}` to make them easy to find on `npm`.
-
-#### Datawrapper plugins
-
-* [@datawrapper/plugin-export-pdf](https://www.npmjs.com/package/@datawrapper/plugin-export-pdf) - Adds file export methods
-* [@datawrapper/plugin-random-data](https://www.npmjs.com/package/@datawrapper/plugin-random-data) - Adds endpoint to generate random CSV data
-* [@datawrapper/plugin-email-postmark](https://www.npmjs.com/package/@datawrapper/plugin-email-postmark) - Adds email functionality with [Postmark](https://postmarkapp.com) API
 
 ### Local plugins
 

--- a/create-api/index.js
+++ b/create-api/index.js
@@ -1,14 +1,9 @@
 #! /usr/bin/env node
 /* eslint no-console: "off" */
 const fs = require('fs');
-const glob = require('glob');
 const path = require('path');
-const difference = require('lodash/difference');
 const { spawn } = require('child_process');
 const findUp = require('find-up');
-
-const localPluginPaths = glob.sync('plugins/*/index.js', { absolute: true });
-const localPlugins = localPluginPaths.map(p => require(p).name);
 
 const CWD = process.env.INIT_CWD || process.cwd();
 let tag = process.argv.find(arg => arg.includes('--tag')) || '--tag=latest';
@@ -45,22 +40,15 @@ async function main() {
         process.exit(1);
     }
 
-    const { plugins = {} } = require(configPath);
-
-    const packages = difference(Object.keys(plugins), localPlugins).map(name =>
-        plugins[name].version ? `${name}@${plugins[name].version}` : name
-    );
-
     fs.writeFileSync(path.join(CWD, 'package.json'), JSON.stringify(pkg, null, 4), {
         encoding: 'utf-8'
     });
 
     console.log('[npm] Start package installation.');
-    const npm = spawn(
-        'npm',
-        ['install', '-SE', '--production', `@datawrapper/api@${tag}`].concat(packages),
-        { cwd: CWD, env: process.env }
-    );
+    const npm = spawn('npm', ['install', '-SE', '--production', `@datawrapper/api@${tag}`], {
+        cwd: CWD,
+        env: process.env
+    });
 
     npm.stdout.on('data', data => process.stdout.write(data));
     npm.stderr.on('data', data => process.stderr.write(data));

--- a/create-api/index.test.js
+++ b/create-api/index.test.js
@@ -9,9 +9,7 @@ const testDir = path.resolve(dir, 'api-test');
 const configJS = `
 module.exports = {
   plugins: {
-      '@datawrapper/plugin-random-data': {
-        version: 'next'
-      }
+      'hello-world': {}
   }
 };
 `;
@@ -36,7 +34,5 @@ test('should run create-api script', t => {
     t.truthy(pkg.scripts['api']);
     t.truthy(pkg.scripts['sync']);
     t.truthy(pkg.dependencies['@datawrapper/api']);
-    t.truthy(pkg.dependencies['@datawrapper/plugin-random-data']);
     t.true(dwPackages.includes('api'));
-    t.true(dwPackages.includes('plugin-random-data'));
 });

--- a/create-api/package-lock.json
+++ b/create-api/package-lock.json
@@ -4,25 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
     "find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -30,38 +11,6 @@
       "requires": {
         "locate-path": "^3.0.0"
       }
-    },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-      "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "locate-path": {
       "version": "3.0.0",
@@ -76,22 +25,6 @@
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-    },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "requires": {
-        "brace-expansion": "^1.1.7"
-      }
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
-        "wrappy": "1"
-      }
     },
     "p-limit": {
       "version": "2.2.0",
@@ -118,16 +51,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     }
   }
 }

--- a/create-api/package.json
+++ b/create-api/package.json
@@ -30,7 +30,6 @@
     "homepage": "https://github.com/datawrapper/datawrapper-api#readme",
     "dependencies": {
         "find-up": "3.0.0",
-        "glob": "7.1.3",
         "lodash": "4.17.11"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1208,7 +1208,8 @@
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
         },
         "base": {
             "version": "0.11.2",
@@ -1323,6 +1324,7 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -1710,7 +1712,8 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
         },
         "concordance": {
             "version": "4.0.0",
@@ -2910,7 +2913,8 @@
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
         },
         "fsevents": {
             "version": "1.2.7",
@@ -3533,6 +3537,7 @@
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
             "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+            "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -4306,6 +4311,7 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -5351,6 +5357,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -5925,7 +5932,8 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
         },
         "path-is-inside": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
         "boom": "7.3.0",
         "chalk": "2.4.2",
         "find-up": "3.0.0",
-        "glob": "7.1.3",
         "hapi": "18.1.0",
         "hapi-auth-bearer-token": "6.1.1",
         "hapi-pino": "5.4.1",


### PR DESCRIPTION
NPM plugins are not needed anymore. With that change we can get rid of some dependencies and code.
Plugins now get loaded when they are defined in `config.js` and are located in `api.localPluginRoot`.
If a plugin doesn't exist locally but is defined in `config.js`, the server will exit with a non
zero exit code and print an error with tips on how to resolve the error.