### PR TITLE
fix: correctly implement local config loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,11 @@ This repository contains the new Node.js API that is the backbone of Datawrapper
 
 ## Installation
 
-To run a production instance of this API, a `npm` initialization script is available with `npm init @datawrapper/api`. In it's essence, the following 3 commands are the setup. To get a more in depth look, read the sections about [configuration](#configuration) and [plugins](#plugins). That is the real strength of the API.
+To run a production instance of this API, clone the repository from Github. In it's essence, the following 3 commands are the setup. To get a more in depth look, read the sections about [configuration](#configuration) and [plugins](#plugins). That is the real strength of the API.
 
 ```sh
-# Create an empty folder where you want the API to initialize
-> mkdir new-api && cd new-api
-
-# Copy config (not needed if `config.js` is anywhere up in the tree from `new-api/`)
-> cp ./secret/config.js config.js
-
-# Initialize API with npm
-> npm init @datawrapper/api
+# Clone repository
+> git clone git@github.com:datawrapper/api.git
 ```
 
 You can start the server using:
@@ -94,7 +88,7 @@ After running these commands you will see something like this:
 
 ## Configuration
 
-The API will not start without a valid `config.js`. The repository includes a template `config.tpl.js` that can be used to create the configuration file.
+The API will not start without a valid `config.js`. The repository includes a template `config.tpl.js` that can be used to create the configuration file. `config.js` can either be located next to `config.tpl.js` or in `/etc/datawrapper/config.js`.
 
 `config.js` exports a javascript object with various configuration objects that are used by this project, as well as others, like the `render-client` or `render-server`.
 The following objects are used by the API.

--- a/src/server.js
+++ b/src/server.js
@@ -4,6 +4,7 @@ const HapiSwagger = require('hapi-swagger');
 const get = require('lodash/get');
 const ORM = require('@datawrapper/orm');
 const fs = require('fs');
+const path = require('path');
 const { validateAPI, validateORM, validateFrontend } = require('@datawrapper/shared/configSchema');
 
 const { generateToken } = require('./utils');
@@ -11,11 +12,26 @@ const { ApiEventEmitter, eventList } = require('./utils/events');
 
 const pkg = require('../package.json');
 
-const configPath = [process.cwd() + 'config.js', '/etc/datawrapper/config.js'].reduce(
-    (path, test) => {
-        return path || fs.existsSync(test) ? test : false;
-    }
+const configPath = [path.join(process.cwd(), 'config.js'), '/etc/datawrapper/config.js'].reduce(
+    (path, test) => path || (fs.existsSync(test) ? test : undefined),
+    ''
 );
+
+if (!configPath) {
+    process.stderr.write(`
+❌ No config.js found!
+
+Not starting the API server.
+Please check if there is a \`config.js\` file in either
+
+\`/etc/datawrapper\` or \`${path.join(process.cwd(), 'confasig.js')}\`
+
+https://github.com/datawrapper/api#configuration
+
+`);
+
+    process.exit(1);
+}
 
 const config = require(configPath);
 


### PR DESCRIPTION
The API will start again with a `config.js` in the repositories root. There were several issues which caused the initialization to always load the configuration from `etc/datawrapper`. Similar issues exist in other services like `crons`.

---

```bash
❯ node
> process.cwd()
'/Users/fabian/code/api'
```

### Problem
`process.cwd()` does **not** have a trailing slash. This means `process.cwd() + 'config.js'` results in `'/Users/fabian/code/apiconfig.js'` which is not a valid config path.

### Solution

Always use `path.join()` when working on file paths. It automatically adds the systems delimiting character and makes it clear to the reader that this is a file operation.

---

```js
path || fs.existsSync(test) ? test : false;
```

### Problem

The above operation evaluates `path || fs.existsSync(test)` and since path was always a non empty string and therefore truthy, the result of `fs.existsSync` is irrelevant. Since the `reduce` didn't use a default value, the first item of the array was used which then got immediately overwritten with `/etc/datawrapper/config.js`

### Solution

Use parens `path || (fs.existsSync(test) ? test : false);` to correctly check the logic and use a default value in `reduce` to correctly check and consider the first array value. Ideally I would extract the `fs` check into a variable.

---

I updated the documentation too to reflect the new installation method and added a message if no config is found.

Please don't ignore tests, especially if all of them fail.