### PR TITLE
docs: document api with https scheme for production

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -49,6 +49,7 @@ const OpenAPI = {
     plugin: HapiSwagger,
     options: {
         host: process.env.NODE_ENV === 'development' ? `${host}:${port}` : host,
+        schemes: process.env.NODE_ENV === 'development' ? ['http'] : ['https'],
         info: {
             title: 'Datawrapper API v3 Documentation',
             version: pkg.version,


### PR DESCRIPTION
After changing the API docs to crawl the open api json from production, I realised that all API reference endpoints and examples used `http`. The API actually uses http but is accessed through nginx which correctly serves it through `https` to the outside. This change fixes the documentation issue.