### PR TITLE
feat: register plugins again with database

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -112,6 +112,11 @@ async function configure(options = { usePlugins: true, useOpenAPI: true }) {
     server.logger().info({ file: configPath }, '[Initialize] config.js');
 
     await ORM.init(config);
+    /* register api plugins with core db */
+    require('@datawrapper/orm/models/Plugin').register(
+        'datawrapper-api',
+        Object.keys(config.plugins)
+    );
 
     server.app.event = eventList;
     server.app.events = new ApiEventEmitter({ logger: server.logger });


### PR DESCRIPTION
This got lost from the express API code and is now back.

Thank you @gka to explain the behaviour for me.