### PR TITLE
feat: include teams in single user endpoints

### DIFF
--- a/test/helpers/setup.js
+++ b/test/helpers/setup.js
@@ -15,11 +15,11 @@ export async function setup(options) {
     const server = await init(options);
     const models = require('@datawrapper/orm/models');
 
-    async function getUser() {
+    async function getUser(role = 'editor') {
         let user = await models.User.create({
             email: getCredentials().email,
             pwd: passwordHash,
-            role: 'editor'
+            role
         });
 
         let session = await models.Session.create({


### PR DESCRIPTION
Single user endpoints like `GET /v3/users/1` now include `teams` in their response like `GET /v3/users` already did. That brings both endpoints in line.

Example response:

```json
{
  "id": 1,
  "email": "foo@datawrapper.de",
  ...
  "teams": [
    {
      "id": "abc",
      "name": "lol",
      "url": "/v3/teams/abc"
    }
  ],
  "chartCount": 71,
  "url": "/v3/users/1"
}
```