### PR TITLE
fix: add `plugin.json` files for PHP app

### DIFF
--- a/plugins/chart-data-local/plugin.json
+++ b/plugins/chart-data-local/plugin.json
@@ -1,0 +1,5 @@
+{
+    "name": "chart-data-local",
+    "description": "This plugin hookes into the new v3 API to read and write chart data to a local directory.",
+    "version": "1.0.0"
+}

--- a/plugins/email-local/plugin.json
+++ b/plugins/email-local/plugin.json
@@ -1,0 +1,5 @@
+{
+    "name": "email-local",
+    "description": "This plugin hookes into the new v3 API to use a fake mail service for development.",
+    "version": "1.0.0"
+}

--- a/plugins/hello-world/plugin.json
+++ b/plugins/hello-world/plugin.json
@@ -1,0 +1,5 @@
+{
+    "name": "hello-world",
+    "description": "This is a simple API plugin based on Hapi's plugin convention.",
+    "version": "1.0.0"
+}


### PR DESCRIPTION
This adds `plugin.json` files to the development plugins that are included in this repository. It should remove the yellow banner in local instances (thanks @ilokhov for writing me).