### PR TITLE
test: improve test setup to clean up after all tests where run

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "format": "prettier '**/*.js' --write",
         "lint": "prettier --check '**/*.js' && healthier '**/*.js'",
         "test": "ava --verbose",
+        "posttest": "node test/helpers/teardown.js",
         "dev": "NODE_ENV=development nodemon src/index.js",
         "api": "node src/index.js",
         "start": "node src/index.js"

--- a/src/routes/auth.test.js
+++ b/src/routes/auth.test.js
@@ -14,17 +14,13 @@ function parseSetCookie(string) {
 }
 
 test.before(async t => {
-    const { server, getUser } = await setup({ usePlugins: false });
+    const { server, getUser, addToCleanup } = await setup({ usePlugins: false });
 
     t.context.server = server;
 
-    const { user, cleanup } = await getUser();
+    const { user } = await getUser();
     t.context.user = user;
-    t.context.cleanup = cleanup;
-});
-
-test.after.always(async t => {
-    await t.context.cleanup();
+    t.context.addToCleanup = addToCleanup;
 });
 
 test('Login and logout work with correct credentials', async t => {
@@ -79,6 +75,8 @@ test("Login set's correct cookie", async t => {
     });
 
     let cookie = parseSetCookie(res.headers['set-cookie'][0]);
+    t.log('session', cookie['DW-SESSION']);
+    await t.context.addToCleanup('session', cookie['DW-SESSION']);
     let maxAge = cookie['Max-Age'] / 24 / 60 / 60; // convert to seconds
 
     t.true(cookie['HttpOnly']);
@@ -95,6 +93,8 @@ test("Login set's correct cookie", async t => {
     });
 
     cookie = parseSetCookie(res.headers['set-cookie'][0]);
+    t.log('session', cookie['DW-SESSION']);
+    await t.context.addToCleanup('session', cookie['DW-SESSION']);
     maxAge = cookie['Max-Age'] / 24 / 60 / 60; // convert to seconds
 
     t.is(maxAge, 30);

--- a/src/routes/charts.test.js
+++ b/src/routes/charts.test.js
@@ -14,10 +14,6 @@ test.before(async t => {
     };
 });
 
-test.after.always(async t => {
-    await t.context.data.cleanup();
-});
-
 test('It should be possible to create, fetch, edit and delete charts', async t => {
     let chart = await t.context.server.inject({
         method: 'POST',

--- a/src/routes/teams.test.js
+++ b/src/routes/teams.test.js
@@ -16,10 +16,6 @@ test.before(async t => {
     };
 });
 
-test.after.always(async t => {
-    await t.context.data.cleanup();
-});
-
 test('user can fetch their teams', async t => {
     let teams = await t.context.server.inject({
         method: 'GET',
@@ -81,7 +77,6 @@ test('user can not fetch teams they are not a part of', async t => {
     });
 
     t.is(teams.statusCode, 401);
-    await data.cleanup();
 });
 
 test('user can fetch their team members', async t => {
@@ -110,7 +105,6 @@ test('user can not fetch team members of team they are not a part of', async t =
     });
 
     t.is(teams.statusCode, 401);
-    await data.cleanup();
 });
 
 test('owner can remove team members', async t => {
@@ -259,8 +253,6 @@ test('owners can invite new members to a team', async t => {
             email: data.user.email
         }
     });
-
-    await data.cleanup();
 
     t.is(team.statusCode, 201);
 });

--- a/src/routes/users.test.js
+++ b/src/routes/users.test.js
@@ -13,12 +13,10 @@ test.before(async t => {
     t.context.Product = Product;
     t.context.UserProduct = UserProduct;
     t.context.deleteUserFromDB = async email => {
-        const user = await User.findOne({
+        await User.destroy({
             where: { email },
             attributes: ['id']
         });
-
-        await user.destroy();
     };
 
     t.context.getUser = getUser;
@@ -105,7 +103,7 @@ test('New user passwords should be saved as bcrypt hash', async t => {
 
 test('GET /users/:id - should include teams when fetched as admin', async t => {
     /* create admin user to fetch different user with team */
-    const { user, session, cleanup } = await t.context.getUser('admin');
+    const { user, session } = await t.context.getUser('admin');
 
     /* create a team with user to fetch */
     const team = await t.context.getTeamWithUser();
@@ -124,14 +122,10 @@ test('GET /users/:id - should include teams when fetched as admin', async t => {
     t.is(res.result.teams[0].id, team.team.id);
     t.is(res.result.teams[0].name, team.team.name);
     t.is(res.result.teams[0].url, `/v3/teams/${team.team.id}`);
-
-    /* cleanup db entries */
-    await cleanup();
-    await team.cleanup();
 });
 
 test('Users endpoints should return 404 if no user was found', async t => {
-    const { user, session, cleanup } = await t.context.getUser('admin');
+    const { user, session } = await t.context.getUser('admin');
     const res = await t.context.server.inject({
         method: 'GET',
         url: '/v3/users/12345678',
@@ -143,9 +137,6 @@ test('Users endpoints should return 404 if no user was found', async t => {
     });
 
     t.is(res.statusCode, 404);
-
-    /* cleanup db entries */
-    await cleanup();
 });
 
 test('Users endpoints should return products for admins', async t => {
@@ -180,10 +171,9 @@ test('Users endpoints should return products for admins', async t => {
     /* cleanup db entries */
     await userProduct.destroy();
     await product.destroy();
-    await Promise.all([admin.cleanup(), user.cleanup()]);
 });
 
-test.skip('Admin can sort users by creation date - Ascending', async t => {
+test('Admin can sort users by creation date - Ascending', async t => {
     const admin = await t.context.getUser('admin');
 
     const res = await t.context.server.inject({
@@ -199,12 +189,9 @@ test.skip('Admin can sort users by creation date - Ascending', async t => {
     const sortedDates = sortBy(res.result.list.map(d => d.createdAt));
     t.is(res.statusCode, 200);
     t.deepEqual(res.result.list.map(d => d.createdAt), sortedDates);
-
-    /* cleanup db entries */
-    await admin.cleanup();
 });
 
-test.skip('Admin can sort users by creation date - Descending', async t => {
+test('Admin can sort users by creation date - Descending', async t => {
     const admin = await t.context.getUser('admin');
 
     const res = await t.context.server.inject({
@@ -222,12 +209,9 @@ test.skip('Admin can sort users by creation date - Descending', async t => {
 
     t.is(res.statusCode, 200);
     t.deepEqual(res.result.list.map(d => d.createdAt), sortedDates);
-
-    /* cleanup db entries */
-    await admin.cleanup();
 });
 
-test.skip('Admin can sort users by chart count - Ascending', async t => {
+test('Admin can sort users by chart count - Ascending', async t => {
     const admin = await t.context.getUser('admin');
 
     const res = await t.context.server.inject({
@@ -243,12 +227,9 @@ test.skip('Admin can sort users by chart count - Ascending', async t => {
     const sortedChartCount = sortBy(res.result.list.map(d => d.chartCount));
     t.is(res.statusCode, 200);
     t.deepEqual(res.result.list.map(d => d.chartCount), sortedChartCount);
-
-    /* cleanup db entries */
-    await admin.cleanup();
 });
 
-test.skip('Admin can sort users by chart count - Descending', async t => {
+test('Admin can sort users by chart count - Descending', async t => {
     const admin = await t.context.getUser('admin');
 
     const res = await t.context.server.inject({
@@ -266,12 +247,9 @@ test.skip('Admin can sort users by chart count - Descending', async t => {
 
     t.is(res.statusCode, 200);
     t.deepEqual(res.result.list.map(d => d.chartCount), sortedChartCount);
-
-    /* cleanup db entries */
-    await admin.cleanup();
 });
 
-test.skip('Users endpoint searches in name field', async t => {
+test('Users endpoint searches in name field', async t => {
     const search = 'editor';
     const admin = await t.context.getUser('admin');
 
@@ -290,9 +268,6 @@ test.skip('Users endpoint searches in name field', async t => {
     t.truthy(user);
     t.true(user.name.includes(search));
     t.false(user.email.includes(search));
-
-    /* cleanup db entries */
-    await admin.cleanup();
 });
 
 test('Users endpoint searches in email field', async t => {
@@ -315,7 +290,4 @@ test('Users endpoint searches in email field', async t => {
     t.truthy(user);
     t.true(user.email.includes(search));
     t.false(name.includes(search));
-
-    /* cleanup db entries */
-    await admin.cleanup();
 });

--- a/test/helpers/teardown.js
+++ b/test/helpers/teardown.js
@@ -1,0 +1,58 @@
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+const chalk = require('chalk');
+const ORM = require('@datawrapper/orm');
+
+const log = str => process.stdout.write(str + '\n');
+const cleanupFile = path.join(os.tmpdir(), 'cleanup.csv');
+
+const configPath = [path.join(process.cwd(), 'config.js'), '/etc/datawrapper/config.js'].reduce(
+    (path, test) => path || (fs.existsSync(test) ? test : undefined),
+    ''
+);
+const config = require(configPath);
+
+async function main() {
+    await ORM.init(config);
+
+    const models = require('@datawrapper/orm/models');
+    const { Op } = ORM.db;
+
+    const csv = fs.readFileSync(cleanupFile, { encoding: 'utf-8' });
+    const list = {
+        team: [],
+        session: [],
+        user: []
+    };
+    csv.split('\n').forEach(line => {
+        const row = line.split(';');
+        if (list[row[0]]) {
+            list[row[0]].push(row[1]);
+        }
+    });
+
+    const [, , sessions] = await Promise.all([
+        models.Chart.destroy({ where: { author_id: { [Op.in]: list.user } } }),
+        models.UserTeam.destroy({ where: { organization_id: { [Op.in]: list.team } } }),
+        models.Session.destroy({ where: { session_id: { [Op.in]: list.session } } })
+    ]);
+
+    log(chalk.magenta(`🧹 Cleaned ${sessions} sessions`));
+
+    const teams = await models.Team.destroy({ where: { id: { [Op.in]: list.team } } });
+    log(chalk.magenta(`🧹 Cleaned ${teams} teams`));
+
+    const users = await models.User.destroy({ where: { id: { [Op.in]: list.user } } });
+    log(chalk.magenta(`🧹 Cleaned ${users} users`));
+
+    fs.unlinkSync(cleanupFile);
+    process.exit(0);
+}
+
+try {
+    main();
+} catch (error) {
+    log(error);
+    process.exit(1);
+}


### PR DESCRIPTION
Changes the test setup to run cleanup after `ava` has completed. That reduces database queries and makes tests more predictable.

`test/helpers/setup.js` now provides a new function called `addToCleanup`. This is sometimes useful if an API endpoint creates a new ressource that wasn't created with `getUser` or `getTeamWithUser`.