### PR TITLE
fix: cleanup even if tests fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ jobs:
                       mv test/_config.ci.js config.js
                       mkdir -p ~/reports/ava
                       npm test -- --tap | npx tap-xunit > ~/reports/ava/results.xml
+            - run: npm run clean:db
             - store_test_results:
                   path: ~/reports
             - store_artifacts:

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
         "format": "prettier '**/*.js' --write",
         "lint": "prettier --check '**/*.js' && healthier '**/*.js'",
         "test": "ava --verbose",
-        "posttest": "node test/helpers/teardown.js",
+        "clean:db": "node test/helpers/teardown.js",
+        "posttest": "npm run clean:db",
         "dev": "NODE_ENV=development nodemon src/index.js",
         "api": "node src/index.js",
         "start": "node src/index.js"

--- a/test/helpers/teardown.js
+++ b/test/helpers/teardown.js
@@ -19,12 +19,20 @@ async function main() {
     const models = require('@datawrapper/orm/models');
     const { Op } = ORM.db;
 
-    const csv = fs.readFileSync(cleanupFile, { encoding: 'utf-8' });
+    let csv;
+    try {
+        csv = fs.readFileSync(cleanupFile, { encoding: 'utf-8' });
+    } catch (error) {
+        log('Nothing to clean up.');
+        process.exit(0);
+    }
+
     const list = {
         team: [],
         session: [],
         user: []
     };
+
     csv.split('\n').forEach(line => {
         const row = line.split(';');
         if (list[row[0]]) {


### PR DESCRIPTION
I recently pushed the publish-chart branch, which has failing test. That meant the CI build fails, which I expected, but it also didn't cleanup the db since `posttest` does not run if `test` fails. This will hopefully fix it.