### PR TITLE
use config schema from @datawrapper/schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -624,6 +624,28 @@
                 "underscore": "^1.9.1"
             }
         },
+        "@datawrapper/schemas": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@datawrapper/schemas/-/schemas-1.0.0.tgz",
+            "integrity": "sha512-vWgEXoFyhJEc8URlQEcs9kiThMIVJsvE/fiVF78e1Cs2uDE4vGw9l0Vzu8qqoimCEfuxhBdqarBzX4RzwmsJzA==",
+            "requires": {
+                "@hapi/joi": "^15.1.0",
+                "chalk": "^2.4.2"
+            },
+            "dependencies": {
+                "@hapi/joi": {
+                    "version": "15.1.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.0.tgz",
+                    "integrity": "sha512-n6kaRQO8S+kepUTbXL9O/UOL788Odqs38/VOfoCrATDtTvyfiO3fgjlSRaNkHabpTLgM7qru9ifqXlXbXk8SeQ==",
+                    "requires": {
+                        "@hapi/address": "2.x.x",
+                        "@hapi/hoek": "6.x.x",
+                        "@hapi/marker": "1.x.x",
+                        "@hapi/topo": "3.x.x"
+                    }
+                }
+            }
+        },
         "@datawrapper/shared": {
             "version": "0.9.8",
             "resolved": "https://registry.npmjs.org/@datawrapper/shared/-/shared-0.9.8.tgz",
@@ -808,6 +830,11 @@
                 "@hapi/hoek": "6.x.x",
                 "@hapi/topo": "3.x.x"
             }
+        },
+        "@hapi/marker": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@hapi/marker/-/marker-1.0.0.tgz",
+            "integrity": "sha512-JOfdekTXnJexfE8PyhZFyHvHjt81rBFSAbTIRAhF2vv/2Y1JzoKsGqxH/GpZJoF7aEfYok8JVcAHmSz1gkBieA=="
         },
         "@hapi/mimos": {
             "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     },
     "dependencies": {
         "@datawrapper/orm": "3.2.1",
+        "@datawrapper/schemas": "1.0.0",
         "@datawrapper/shared": "0.9.8",
         "@hapi/boom": "7.4.2",
         "@hapi/hapi": "18.3.1",

--- a/src/server.js
+++ b/src/server.js
@@ -5,7 +5,7 @@ const get = require('lodash/get');
 const ORM = require('@datawrapper/orm');
 const fs = require('fs');
 const path = require('path');
-const { validateAPI, validateORM, validateFrontend } = require('@datawrapper/shared/configSchema');
+const { validateAPI, validateORM, validateFrontend } = require('@datawrapper/schemas/config');
 
 const { generateToken } = require('./utils');
 const { ApiEventEmitter, eventList } = require('./utils/events');


### PR DESCRIPTION
the configSchema is about to be moved out of `@datawrapper/shared` and into `@datawrapper/schemas` (see https://github.com/datawrapper/shared/pull/9)

this PR makes sure the API loads the config schema from the new location