### PR TITLE
tooling: use new API DB

### DIFF
--- a/test/_config.ci.js
+++ b/test/_config.ci.js
@@ -23,7 +23,7 @@ module.exports = {
             port: process.env.DB_PORT,
             user: process.env.DB_USER,
             password: process.env.DB_PASSWORD,
-            database: process.env.DB_NAME
+            database: process.env.DB_NAME_API
         }
     }
 };


### PR DESCRIPTION
To remove the possibility that ORM and API tests interfere with each other, the API repo now uses it's own DB on CircleCI. 