### PR TITLE
chore: update nodemon@2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1774,22 +1774,10 @@
                 }
             }
         },
-        "arr-diff": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-            "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-            "dev": true
-        },
         "arr-flatten": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
             "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-            "dev": true
-        },
-        "arr-union": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
             "dev": true
         },
         "array-find-index": {
@@ -1823,12 +1811,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-2.1.0.tgz",
             "integrity": "sha512-bdHxtev7FN6+MXI1YFW0Q8mQ8dTJc2S8AMfju+ZR77pbg2yAdVyDlwkaUI7Har0LyOMRFPHrJ9lYdyjZZswdlQ==",
-            "dev": true
-        },
-        "array-unique": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-            "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
             "dev": true
         },
         "arrify": {
@@ -1873,22 +1855,10 @@
                 }
             }
         },
-        "assign-symbols": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-            "dev": true
-        },
         "astral-regex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
             "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
-            "dev": true
-        },
-        "async-each": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
-            "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
             "dev": true
         },
         "asynckit": {
@@ -1896,12 +1866,6 @@
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
             "optional": true
-        },
-        "atob": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-            "dev": true
         },
         "ava": {
             "version": "2.4.0",
@@ -2233,67 +2197,6 @@
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
             "dev": true
         },
-        "base": {
-            "version": "0.11.2",
-            "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-            "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
-            "dev": true,
-            "requires": {
-                "cache-base": "^1.0.1",
-                "class-utils": "^0.3.5",
-                "component-emitter": "^1.2.1",
-                "define-property": "^1.0.0",
-                "isobject": "^3.0.1",
-                "mixin-deep": "^1.2.0",
-                "pascalcase": "^0.1.1"
-            },
-            "dependencies": {
-                "define-property": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                    "dev": true,
-                    "requires": {
-                        "is-descriptor": "^1.0.0"
-                    }
-                },
-                "is-accessor-descriptor": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^6.0.0"
-                    }
-                },
-                "is-data-descriptor": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^6.0.0"
-                    }
-                },
-                "is-descriptor": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "dev": true,
-                    "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
-                    }
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
-                }
-            }
-        },
         "bcrypt-pbkdf": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -2422,31 +2325,6 @@
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
             "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
             "dev": true
-        },
-        "cache-base": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-            "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
-            "dev": true,
-            "requires": {
-                "collection-visit": "^1.0.0",
-                "component-emitter": "^1.2.1",
-                "get-value": "^2.0.6",
-                "has-value": "^1.0.0",
-                "isobject": "^3.0.1",
-                "set-value": "^2.0.0",
-                "to-object-path": "^0.3.0",
-                "union-value": "^1.0.0",
-                "unset-value": "^1.0.0"
-            },
-            "dependencies": {
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
-                }
-            }
         },
         "cacheable-request": {
             "version": "6.1.0",
@@ -2673,35 +2551,6 @@
             "integrity": "sha512-u6dx20FBXm+apMi+5x7UVm6EH7BL1gc4XrcnQewjcB7HWRcor/V5qWc3RG2HwpgDJ26gIi2DSEu3B7sXynAw/g==",
             "dev": true
         },
-        "class-utils": {
-            "version": "0.3.6",
-            "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-            "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
-            "dev": true,
-            "requires": {
-                "arr-union": "^3.1.0",
-                "define-property": "^0.2.5",
-                "isobject": "^3.0.0",
-                "static-extend": "^0.1.1"
-            },
-            "dependencies": {
-                "define-property": {
-                    "version": "0.2.5",
-                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
-                    "requires": {
-                        "is-descriptor": "^0.1.0"
-                    }
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
-                }
-            }
-        },
         "clean-stack": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -2802,16 +2651,6 @@
             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
             "dev": true
         },
-        "collection-visit": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-            "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-            "dev": true,
-            "requires": {
-                "map-visit": "^1.0.0",
-                "object-visit": "^1.0.0"
-            }
-        },
         "color": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
@@ -2861,12 +2700,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-1.0.0.tgz",
             "integrity": "sha1-zVL28HEuC6q5fW+XModPIvR3UsA=",
-            "dev": true
-        },
-        "component-emitter": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-            "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
             "dev": true
         },
         "concat-map": {
@@ -2966,12 +2799,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz",
             "integrity": "sha1-fj5Iu+bZl7FBfdyihoIEtNPYVxU=",
-            "dev": true
-        },
-        "copy-descriptor": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
             "dev": true
         },
         "core-js": {
@@ -3313,12 +3140,6 @@
                 }
             }
         },
-        "decode-uri-component": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-            "dev": true
-        },
         "decompress-response": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
@@ -3387,53 +3208,6 @@
             "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
             "requires": {
                 "object-keys": "^1.0.12"
-            }
-        },
-        "define-property": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-            "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
-            "dev": true,
-            "requires": {
-                "is-descriptor": "^1.0.2",
-                "isobject": "^3.0.1"
-            },
-            "dependencies": {
-                "is-accessor-descriptor": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^6.0.0"
-                    }
-                },
-                "is-data-descriptor": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^6.0.0"
-                    }
-                },
-                "is-descriptor": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "dev": true,
-                    "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
-                    }
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
-                }
             }
         },
         "deglob": {
@@ -4392,97 +4166,11 @@
                 }
             }
         },
-        "expand-brackets": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-            "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-            "dev": true,
-            "requires": {
-                "debug": "^2.3.3",
-                "define-property": "^0.2.5",
-                "extend-shallow": "^2.0.1",
-                "posix-character-classes": "^0.1.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "define-property": {
-                    "version": "0.2.5",
-                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
-                    "requires": {
-                        "is-descriptor": "^0.1.0"
-                    }
-                },
-                "extend-shallow": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
-                    "requires": {
-                        "is-extendable": "^0.1.0"
-                    }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
-                }
-            }
-        },
         "extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
             "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
             "optional": true
-        },
-        "extend-shallow": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-            "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-            "dev": true,
-            "requires": {
-                "assign-symbols": "^1.0.0",
-                "is-extendable": "^1.0.1"
-            },
-            "dependencies": {
-                "is-extendable": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-                    "dev": true,
-                    "requires": {
-                        "is-plain-object": "^2.0.4"
-                    }
-                },
-                "is-plain-object": {
-                    "version": "2.0.4",
-                    "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-                    "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-                    "dev": true,
-                    "requires": {
-                        "isobject": "^3.0.1"
-                    }
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
-                }
-            }
         },
         "external-editor": {
             "version": "3.1.0",
@@ -4493,71 +4181,6 @@
                 "chardet": "^0.7.0",
                 "iconv-lite": "^0.4.24",
                 "tmp": "^0.0.33"
-            }
-        },
-        "extglob": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-            "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-            "dev": true,
-            "requires": {
-                "array-unique": "^0.3.2",
-                "define-property": "^1.0.0",
-                "expand-brackets": "^2.1.4",
-                "extend-shallow": "^2.0.1",
-                "fragment-cache": "^0.2.1",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
-            },
-            "dependencies": {
-                "define-property": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                    "dev": true,
-                    "requires": {
-                        "is-descriptor": "^1.0.0"
-                    }
-                },
-                "extend-shallow": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
-                    "requires": {
-                        "is-extendable": "^0.1.0"
-                    }
-                },
-                "is-accessor-descriptor": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^6.0.0"
-                    }
-                },
-                "is-data-descriptor": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^6.0.0"
-                    }
-                },
-                "is-descriptor": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "dev": true,
-                    "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
-                    }
-                }
             }
         },
         "extsprintf": {
@@ -4696,12 +4319,6 @@
             "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
             "dev": true
         },
-        "for-in": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-            "dev": true
-        },
         "forever-agent": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -4723,15 +4340,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.3.tgz",
             "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU="
-        },
-        "fragment-cache": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-            "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-            "dev": true,
-            "requires": {
-                "map-cache": "^0.2.2"
-            }
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -4801,12 +4409,6 @@
             "requires": {
                 "pump": "^3.0.0"
             }
-        },
-        "get-value": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-            "dev": true
         },
         "getpass": {
             "version": "0.1.7",
@@ -5039,66 +4641,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
             "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
-        },
-        "has-value": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
-            "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-            "dev": true,
-            "requires": {
-                "get-value": "^2.0.6",
-                "has-values": "^1.0.0",
-                "isobject": "^3.0.0"
-            },
-            "dependencies": {
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
-                }
-            }
-        },
-        "has-values": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
-            "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-            "dev": true,
-            "requires": {
-                "is-number": "^3.0.0",
-                "kind-of": "^4.0.0"
-            },
-            "dependencies": {
-                "is-number": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true,
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
-                "kind-of": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                }
-            }
         },
         "has-yarn": {
             "version": "2.1.0",
@@ -5450,26 +4992,6 @@
             "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
             "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY="
         },
-        "is-accessor-descriptor": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-            "dev": true,
-            "requires": {
-                "kind-of": "^3.0.2"
-            },
-            "dependencies": {
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                }
-            }
-        },
         "is-arguments": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
@@ -5489,12 +5011,6 @@
             "requires": {
                 "binary-extensions": "^2.0.0"
             }
-        },
-        "is-buffer": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-            "dev": true
         },
         "is-callable": {
             "version": "1.1.4",
@@ -5523,49 +5039,10 @@
                 "rgba-regex": "^1.0.0"
             }
         },
-        "is-data-descriptor": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-            "dev": true,
-            "requires": {
-                "kind-of": "^3.0.2"
-            },
-            "dependencies": {
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                }
-            }
-        },
         "is-date-object": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
             "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
-        },
-        "is-descriptor": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-            "dev": true,
-            "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
-            },
-            "dependencies": {
-                "kind-of": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-                    "dev": true
-                }
-            }
         },
         "is-directory": {
             "version": "0.3.1",
@@ -5576,12 +5053,6 @@
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.2.tgz",
             "integrity": "sha512-IOQqts/aHWbiisY5DuPJQ0gcbvaLFCa7fBa9xoLfxBZvQ+ZI/Zh9xoI7Gk+G64N0FdK4AbibytHht2tWgpJWLg==",
-            "dev": true
-        },
-        "is-extendable": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
             "dev": true
         },
         "is-extglob": {
@@ -5769,12 +5240,6 @@
             "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
             "dev": true
         },
-        "is-windows": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-            "dev": true
-        },
         "is-yarn-global": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
@@ -5932,12 +5397,6 @@
             "requires": {
                 "json-buffer": "3.0.0"
             }
-        },
-        "kind-of": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-            "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-            "dev": true
         },
         "latest-version": {
             "version": "5.1.0",
@@ -6630,26 +6089,11 @@
                 }
             }
         },
-        "map-cache": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-            "dev": true
-        },
         "map-obj": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
             "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
             "dev": true
-        },
-        "map-visit": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
-            "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-            "dev": true,
-            "requires": {
-                "object-visit": "^1.0.0"
-            }
         },
         "matcher": {
             "version": "2.0.0",
@@ -6810,42 +6254,6 @@
                 }
             }
         },
-        "mixin-deep": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
-            "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
-            "dev": true,
-            "requires": {
-                "for-in": "^1.0.2",
-                "is-extendable": "^1.0.1"
-            },
-            "dependencies": {
-                "is-extendable": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-                    "dev": true,
-                    "requires": {
-                        "is-plain-object": "^2.0.4"
-                    }
-                },
-                "is-plain-object": {
-                    "version": "2.0.4",
-                    "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-                    "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-                    "dev": true,
-                    "requires": {
-                        "isobject": "^3.0.1"
-                    }
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
-                }
-            }
-        },
         "mkdirp": {
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -6936,36 +6344,10 @@
                 "lru-cache": "^4.1.3"
             }
         },
-        "nan": {
-            "version": "2.14.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-            "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-            "dev": true,
-            "optional": true
-        },
         "nanoid": {
             "version": "2.1.7",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.7.tgz",
             "integrity": "sha512-fmS3qwDldm4bE01HCIRqNk+f255CNjnAoeV3Zzzv0KemObHKqYgirVaZA9DtKcjogicWjYcHkJs4D5A8CjnuVQ=="
-        },
-        "nanomatch": {
-            "version": "1.2.13",
-            "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
-            "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
-            "dev": true,
-            "requires": {
-                "arr-diff": "^4.0.0",
-                "array-unique": "^0.3.2",
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "fragment-cache": "^0.2.1",
-                "is-windows": "^1.0.2",
-                "kind-of": "^6.0.2",
-                "object.pick": "^1.3.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
-            }
         },
         "natural-compare": {
             "version": "1.4.0",
@@ -7012,12 +6394,12 @@
             }
         },
         "nodemon": {
-            "version": "1.19.4",
-            "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.19.4.tgz",
-            "integrity": "sha512-VGPaqQBNk193lrJFotBU8nvWZPqEZY2eIzymy2jjY0fJ9qIsxA0sxQ8ATPl0gZC645gijYEc1jtZvpS8QWzJGQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.0.tgz",
+            "integrity": "sha512-hs+lNmZc6pIamxCTDrOhMccqSsGjZENGZ/40etM/Zc3aoR4UTvwMH38XOnhD5pmU+Jn2u1OGOC5hZF2tjCHJMA==",
             "dev": true,
             "requires": {
-                "chokidar": "^2.1.8",
+                "chokidar": "^3.2.2",
                 "debug": "^3.2.6",
                 "ignore-by-default": "^1.0.1",
                 "minimatch": "^3.0.4",
@@ -7044,33 +6426,6 @@
                     "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
                     "dev": true
                 },
-                "anymatch": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-                    "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-                    "dev": true,
-                    "requires": {
-                        "micromatch": "^3.1.4",
-                        "normalize-path": "^2.1.1"
-                    },
-                    "dependencies": {
-                        "normalize-path": {
-                            "version": "2.1.1",
-                            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-                            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-                            "dev": true,
-                            "requires": {
-                                "remove-trailing-separator": "^1.0.1"
-                            }
-                        }
-                    }
-                },
-                "binary-extensions": {
-                    "version": "1.13.1",
-                    "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-                    "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
-                    "dev": true
-                },
                 "boxen": {
                     "version": "1.3.0",
                     "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
@@ -7084,68 +6439,17 @@
                         "string-width": "^2.0.0",
                         "term-size": "^1.2.0",
                         "widest-line": "^2.0.0"
-                    },
-                    "dependencies": {
-                        "chalk": {
-                            "version": "2.4.2",
-                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-                            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-                            "dev": true,
-                            "requires": {
-                                "ansi-styles": "^3.2.1",
-                                "escape-string-regexp": "^1.0.5",
-                                "supports-color": "^5.3.0"
-                            }
-                        }
                     }
                 },
-                "braces": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "^1.1.0",
-                        "array-unique": "^0.3.2",
-                        "extend-shallow": "^2.0.1",
-                        "fill-range": "^4.0.0",
-                        "isobject": "^3.0.1",
-                        "repeat-element": "^1.1.2",
-                        "snapdragon": "^0.8.1",
-                        "snapdragon-node": "^2.0.1",
-                        "split-string": "^3.0.2",
-                        "to-regex": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "dev": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "chokidar": {
-                    "version": "2.1.8",
-                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
-                    "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
-                    "dev": true,
-                    "requires": {
-                        "anymatch": "^2.0.0",
-                        "async-each": "^1.0.1",
-                        "braces": "^2.3.2",
-                        "fsevents": "^1.2.7",
-                        "glob-parent": "^3.1.0",
-                        "inherits": "^2.0.3",
-                        "is-binary-path": "^1.0.0",
-                        "is-glob": "^4.0.0",
-                        "normalize-path": "^3.0.0",
-                        "path-is-absolute": "^1.0.0",
-                        "readdirp": "^2.2.1",
-                        "upath": "^1.1.1"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "ci-info": {
@@ -7174,603 +6478,11 @@
                         "xdg-basedir": "^3.0.0"
                     }
                 },
-                "fill-range": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-                    "dev": true,
-                    "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1",
-                        "to-regex-range": "^2.1.0"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "dev": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "fsevents": {
-                    "version": "1.2.9",
-                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-                    "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "nan": "^2.12.1",
-                        "node-pre-gyp": "^0.12.0"
-                    },
-                    "dependencies": {
-                        "abbrev": {
-                            "version": "1.1.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "ansi-regex": {
-                            "version": "2.1.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "aproba": {
-                            "version": "1.2.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "are-we-there-yet": {
-                            "version": "1.1.5",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "delegates": "^1.0.0",
-                                "readable-stream": "^2.0.6"
-                            }
-                        },
-                        "balanced-match": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "brace-expansion": {
-                            "version": "1.1.11",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "balanced-match": "^1.0.0",
-                                "concat-map": "0.0.1"
-                            }
-                        },
-                        "chownr": {
-                            "version": "1.1.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "code-point-at": {
-                            "version": "1.1.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "concat-map": {
-                            "version": "0.0.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "console-control-strings": {
-                            "version": "1.1.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "core-util-is": {
-                            "version": "1.0.2",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "debug": {
-                            "version": "4.1.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "ms": "^2.1.1"
-                            }
-                        },
-                        "deep-extend": {
-                            "version": "0.6.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "delegates": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "detect-libc": {
-                            "version": "1.0.3",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "fs-minipass": {
-                            "version": "1.2.5",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "minipass": "^2.2.1"
-                            }
-                        },
-                        "fs.realpath": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "gauge": {
-                            "version": "2.7.4",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "aproba": "^1.0.3",
-                                "console-control-strings": "^1.0.0",
-                                "has-unicode": "^2.0.0",
-                                "object-assign": "^4.1.0",
-                                "signal-exit": "^3.0.0",
-                                "string-width": "^1.0.1",
-                                "strip-ansi": "^3.0.1",
-                                "wide-align": "^1.1.0"
-                            }
-                        },
-                        "glob": {
-                            "version": "7.1.3",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "fs.realpath": "^1.0.0",
-                                "inflight": "^1.0.4",
-                                "inherits": "2",
-                                "minimatch": "^3.0.4",
-                                "once": "^1.3.0",
-                                "path-is-absolute": "^1.0.0"
-                            }
-                        },
-                        "has-unicode": {
-                            "version": "2.0.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "iconv-lite": {
-                            "version": "0.4.24",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "safer-buffer": ">= 2.1.2 < 3"
-                            }
-                        },
-                        "ignore-walk": {
-                            "version": "3.0.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "minimatch": "^3.0.4"
-                            }
-                        },
-                        "inflight": {
-                            "version": "1.0.6",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "once": "^1.3.0",
-                                "wrappy": "1"
-                            }
-                        },
-                        "inherits": {
-                            "version": "2.0.3",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "ini": {
-                            "version": "1.3.5",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "is-fullwidth-code-point": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "number-is-nan": "^1.0.0"
-                            }
-                        },
-                        "isarray": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "minimatch": {
-                            "version": "3.0.4",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "brace-expansion": "^1.1.7"
-                            }
-                        },
-                        "minimist": {
-                            "version": "0.0.8",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "minipass": {
-                            "version": "2.3.5",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "safe-buffer": "^5.1.2",
-                                "yallist": "^3.0.0"
-                            }
-                        },
-                        "minizlib": {
-                            "version": "1.2.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "minipass": "^2.2.1"
-                            }
-                        },
-                        "mkdirp": {
-                            "version": "0.5.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "minimist": "0.0.8"
-                            }
-                        },
-                        "ms": {
-                            "version": "2.1.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "needle": {
-                            "version": "2.3.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "debug": "^4.1.0",
-                                "iconv-lite": "^0.4.4",
-                                "sax": "^1.2.4"
-                            }
-                        },
-                        "node-pre-gyp": {
-                            "version": "0.12.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "detect-libc": "^1.0.2",
-                                "mkdirp": "^0.5.1",
-                                "needle": "^2.2.1",
-                                "nopt": "^4.0.1",
-                                "npm-packlist": "^1.1.6",
-                                "npmlog": "^4.0.2",
-                                "rc": "^1.2.7",
-                                "rimraf": "^2.6.1",
-                                "semver": "^5.3.0",
-                                "tar": "^4"
-                            }
-                        },
-                        "nopt": {
-                            "version": "4.0.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "abbrev": "1",
-                                "osenv": "^0.1.4"
-                            }
-                        },
-                        "npm-bundled": {
-                            "version": "1.0.6",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "npm-packlist": {
-                            "version": "1.4.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "ignore-walk": "^3.0.1",
-                                "npm-bundled": "^1.0.1"
-                            }
-                        },
-                        "npmlog": {
-                            "version": "4.1.2",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "are-we-there-yet": "~1.1.2",
-                                "console-control-strings": "~1.1.0",
-                                "gauge": "~2.7.3",
-                                "set-blocking": "~2.0.0"
-                            }
-                        },
-                        "number-is-nan": {
-                            "version": "1.0.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "object-assign": {
-                            "version": "4.1.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "once": {
-                            "version": "1.4.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "wrappy": "1"
-                            }
-                        },
-                        "os-homedir": {
-                            "version": "1.0.2",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "os-tmpdir": {
-                            "version": "1.0.2",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "osenv": {
-                            "version": "0.1.5",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "os-homedir": "^1.0.0",
-                                "os-tmpdir": "^1.0.0"
-                            }
-                        },
-                        "path-is-absolute": {
-                            "version": "1.0.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "process-nextick-args": {
-                            "version": "2.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "rc": {
-                            "version": "1.2.8",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "deep-extend": "^0.6.0",
-                                "ini": "~1.3.0",
-                                "minimist": "^1.2.0",
-                                "strip-json-comments": "~2.0.1"
-                            },
-                            "dependencies": {
-                                "minimist": {
-                                    "version": "1.2.0",
-                                    "bundled": true,
-                                    "dev": true,
-                                    "optional": true
-                                }
-                            }
-                        },
-                        "readable-stream": {
-                            "version": "2.3.6",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.3",
-                                "isarray": "~1.0.0",
-                                "process-nextick-args": "~2.0.0",
-                                "safe-buffer": "~5.1.1",
-                                "string_decoder": "~1.1.1",
-                                "util-deprecate": "~1.0.1"
-                            }
-                        },
-                        "rimraf": {
-                            "version": "2.6.3",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "glob": "^7.1.3"
-                            }
-                        },
-                        "safe-buffer": {
-                            "version": "5.1.2",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "safer-buffer": {
-                            "version": "2.1.2",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "sax": {
-                            "version": "1.2.4",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "semver": {
-                            "version": "5.7.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "set-blocking": {
-                            "version": "2.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "signal-exit": {
-                            "version": "3.0.2",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "string-width": {
-                            "version": "1.0.2",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "code-point-at": "^1.0.0",
-                                "is-fullwidth-code-point": "^1.0.0",
-                                "strip-ansi": "^3.0.0"
-                            }
-                        },
-                        "string_decoder": {
-                            "version": "1.1.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "safe-buffer": "~5.1.0"
-                            }
-                        },
-                        "strip-ansi": {
-                            "version": "3.0.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "ansi-regex": "^2.0.0"
-                            }
-                        },
-                        "strip-json-comments": {
-                            "version": "2.0.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "tar": {
-                            "version": "4.4.8",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "chownr": "^1.1.1",
-                                "fs-minipass": "^1.2.5",
-                                "minipass": "^2.3.4",
-                                "minizlib": "^1.1.1",
-                                "mkdirp": "^0.5.0",
-                                "safe-buffer": "^5.1.2",
-                                "yallist": "^3.0.2"
-                            }
-                        },
-                        "util-deprecate": {
-                            "version": "1.0.2",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "wide-align": {
-                            "version": "1.1.3",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "string-width": "^1.0.2 || 2"
-                            }
-                        },
-                        "wrappy": {
-                            "version": "1.0.2",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "yallist": {
-                            "version": "3.0.3",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        }
-                    }
-                },
                 "get-stream": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
                     "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
                     "dev": true
-                },
-                "glob-parent": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-                    "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-                    "dev": true,
-                    "requires": {
-                        "is-glob": "^3.1.0",
-                        "path-dirname": "^1.0.0"
-                    },
-                    "dependencies": {
-                        "is-glob": {
-                            "version": "3.1.0",
-                            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-                            "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-                            "dev": true,
-                            "requires": {
-                                "is-extglob": "^2.1.0"
-                            }
-                        }
-                    }
                 },
                 "got": {
                     "version": "6.7.1",
@@ -7791,15 +6503,6 @@
                         "url-parse-lax": "^1.0.0"
                     }
                 },
-                "is-binary-path": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-                    "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-                    "dev": true,
-                    "requires": {
-                        "binary-extensions": "^1.0.0"
-                    }
-                },
                 "is-ci": {
                     "version": "1.2.1",
                     "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
@@ -7815,36 +6518,10 @@
                     "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
                     "dev": true
                 },
-                "is-number": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true,
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
                 "is-stream": {
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
                     "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-                    "dev": true
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
                     "dev": true
                 },
                 "latest-version": {
@@ -7863,27 +6540,6 @@
                     "dev": true,
                     "requires": {
                         "pify": "^3.0.0"
-                    }
-                },
-                "micromatch": {
-                    "version": "3.1.10",
-                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-                    "dev": true,
-                    "requires": {
-                        "arr-diff": "^4.0.0",
-                        "array-unique": "^0.3.2",
-                        "braces": "^2.3.1",
-                        "define-property": "^2.0.2",
-                        "extend-shallow": "^3.0.2",
-                        "extglob": "^2.0.4",
-                        "fragment-cache": "^0.2.1",
-                        "kind-of": "^6.0.2",
-                        "nanomatch": "^1.2.9",
-                        "object.pick": "^1.3.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.2"
                     }
                 },
                 "package-json": {
@@ -7909,17 +6565,6 @@
                     "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
                     "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
                     "dev": true
-                },
-                "readdirp": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-                    "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.11",
-                        "micromatch": "^3.1.10",
-                        "readable-stream": "^2.0.2"
-                    }
                 },
                 "registry-auth-token": {
                     "version": "3.4.0",
@@ -7965,16 +6610,6 @@
                         "ansi-regex": "^3.0.0"
                     }
                 },
-                "to-regex-range": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-                    "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-                    "dev": true,
-                    "requires": {
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1"
-                    }
-                },
                 "update-notifier": {
                     "version": "2.5.0",
                     "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
@@ -7991,19 +6626,6 @@
                         "latest-version": "^3.0.0",
                         "semver-diff": "^2.0.0",
                         "xdg-basedir": "^3.0.0"
-                    },
-                    "dependencies": {
-                        "chalk": {
-                            "version": "2.4.2",
-                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-                            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-                            "dev": true,
-                            "requires": {
-                                "ansi-styles": "^3.2.1",
-                                "escape-string-regexp": "^1.0.5",
-                                "supports-color": "^5.3.0"
-                            }
-                        }
                     }
                 },
                 "url-parse-lax": {
@@ -8095,37 +6717,6 @@
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
             "dev": true
         },
-        "object-copy": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
-            "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-            "dev": true,
-            "requires": {
-                "copy-descriptor": "^0.1.0",
-                "define-property": "^0.2.5",
-                "kind-of": "^3.0.3"
-            },
-            "dependencies": {
-                "define-property": {
-                    "version": "0.2.5",
-                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
-                    "requires": {
-                        "is-descriptor": "^0.1.0"
-                    }
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                }
-            }
-        },
         "object-inspect": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
@@ -8142,23 +6733,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
             "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg=="
-        },
-        "object-visit": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
-            "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-            "dev": true,
-            "requires": {
-                "isobject": "^3.0.0"
-            },
-            "dependencies": {
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
-                }
-            }
         },
         "object.assign": {
             "version": "4.1.0",
@@ -8229,23 +6803,6 @@
             "requires": {
                 "define-properties": "^1.1.2",
                 "es-abstract": "^1.5.1"
-            }
-        },
-        "object.pick": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
-            "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-            "dev": true,
-            "requires": {
-                "isobject": "^3.0.1"
-            },
-            "dependencies": {
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
-                }
             }
         },
         "object.values": {
@@ -8513,18 +7070,6 @@
             "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
             "dev": true
         },
-        "pascalcase": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-            "dev": true
-        },
-        "path-dirname": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-            "dev": true
-        },
         "path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -8774,12 +7319,6 @@
             "requires": {
                 "irregular-plurals": "^2.0.0"
             }
-        },
-        "posix-character-classes": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-            "dev": true
         },
         "postcss": {
             "version": "7.0.18",
@@ -9562,16 +8101,6 @@
                 "regenerate": "^1.4.0"
             }
         },
-        "regex-not": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-            "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-            "dev": true,
-            "requires": {
-                "extend-shallow": "^3.0.2",
-                "safe-regex": "^1.1.0"
-            }
-        },
         "regexp.prototype.flags": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
@@ -9652,24 +8181,6 @@
                 "es6-error": "^4.0.1"
             }
         },
-        "remove-trailing-separator": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-            "dev": true
-        },
-        "repeat-element": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-            "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
-            "dev": true
-        },
-        "repeat-string": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-            "dev": true
-        },
         "request": {
             "version": "2.88.0",
             "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
@@ -9728,12 +8239,6 @@
             "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
             "dev": true
         },
-        "resolve-url": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-            "dev": true
-        },
         "responselike": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
@@ -9751,12 +8256,6 @@
                 "onetime": "^5.1.0",
                 "signal-exit": "^3.0.2"
             }
-        },
-        "ret": {
-            "version": "0.1.15",
-            "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-            "dev": true
         },
         "retry-as-promised": {
             "version": "3.2.0",
@@ -9825,15 +8324,6 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "safe-regex": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
-            "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-            "dev": true,
-            "requires": {
-                "ret": "~0.1.10"
-            }
         },
         "safer-buffer": {
             "version": "2.1.2",
@@ -9911,44 +8401,6 @@
             "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
             "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go=",
             "dev": true
-        },
-        "set-value": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
-            "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
-            "dev": true,
-            "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-extendable": "^0.1.1",
-                "is-plain-object": "^2.0.3",
-                "split-string": "^3.0.1"
-            },
-            "dependencies": {
-                "extend-shallow": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
-                    "requires": {
-                        "is-extendable": "^0.1.0"
-                    }
-                },
-                "is-plain-object": {
-                    "version": "2.0.4",
-                    "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-                    "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-                    "dev": true,
-                    "requires": {
-                        "isobject": "^3.0.1"
-                    }
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
-                }
-            }
         },
         "shebang-command": {
             "version": "1.2.0",
@@ -10028,134 +8480,6 @@
                 "is-fullwidth-code-point": "^2.0.0"
             }
         },
-        "snapdragon": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-            "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
-            "dev": true,
-            "requires": {
-                "base": "^0.11.1",
-                "debug": "^2.2.0",
-                "define-property": "^0.2.5",
-                "extend-shallow": "^2.0.1",
-                "map-cache": "^0.2.2",
-                "source-map": "^0.5.6",
-                "source-map-resolve": "^0.5.0",
-                "use": "^3.1.0"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "define-property": {
-                    "version": "0.2.5",
-                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
-                    "requires": {
-                        "is-descriptor": "^0.1.0"
-                    }
-                },
-                "extend-shallow": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
-                    "requires": {
-                        "is-extendable": "^0.1.0"
-                    }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
-                }
-            }
-        },
-        "snapdragon-node": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-            "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-            "dev": true,
-            "requires": {
-                "define-property": "^1.0.0",
-                "isobject": "^3.0.0",
-                "snapdragon-util": "^3.0.1"
-            },
-            "dependencies": {
-                "define-property": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                    "dev": true,
-                    "requires": {
-                        "is-descriptor": "^1.0.0"
-                    }
-                },
-                "is-accessor-descriptor": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^6.0.0"
-                    }
-                },
-                "is-data-descriptor": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^6.0.0"
-                    }
-                },
-                "is-descriptor": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "dev": true,
-                    "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
-                    }
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
-                }
-            }
-        },
-        "snapdragon-util": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-            "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-            "dev": true,
-            "requires": {
-                "kind-of": "^3.2.0"
-            },
-            "dependencies": {
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                }
-            }
-        },
         "sonic-boom": {
             "version": "0.7.6",
             "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.6.tgz",
@@ -10168,25 +8492,6 @@
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
             "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-            "dev": true
-        },
-        "source-map-resolve": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-            "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
-            "dev": true,
-            "requires": {
-                "atob": "^2.1.1",
-                "decode-uri-component": "^0.2.0",
-                "resolve-url": "^0.2.1",
-                "source-map-url": "^0.4.0",
-                "urix": "^0.1.0"
-            }
-        },
-        "source-map-url": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
             "dev": true
         },
         "spdx-correct": {
@@ -10220,15 +8525,6 @@
             "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
             "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
             "dev": true
-        },
-        "split-string": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-            "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-            "dev": true,
-            "requires": {
-                "extend-shallow": "^3.0.0"
-            }
         },
         "split2": {
             "version": "3.1.1",
@@ -10298,27 +8594,6 @@
                 "get-stdin": "^7.0.0",
                 "minimist": "^1.1.0",
                 "pkg-conf": "^3.1.0"
-            }
-        },
-        "static-extend": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
-            "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-            "dev": true,
-            "requires": {
-                "define-property": "^0.2.5",
-                "object-copy": "^0.1.0"
-            },
-            "dependencies": {
-                "define-property": {
-                    "version": "0.2.5",
-                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
-                    "requires": {
-                        "is-descriptor": "^0.1.0"
-                    }
-                }
             }
         },
         "string-argv": {
@@ -10734,42 +9009,10 @@
             "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
             "dev": true
         },
-        "to-object-path": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
-            "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-            "dev": true,
-            "requires": {
-                "kind-of": "^3.0.2"
-            },
-            "dependencies": {
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                }
-            }
-        },
         "to-readable-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
             "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
-        },
-        "to-regex": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-            "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
-            "dev": true,
-            "requires": {
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "regex-not": "^1.0.2",
-                "safe-regex": "^1.1.0"
-            }
         },
         "to-regex-range": {
             "version": "5.0.1",
@@ -10963,18 +9206,6 @@
             "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
             "dev": true
         },
-        "union-value": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
-            "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
-            "dev": true,
-            "requires": {
-                "arr-union": "^3.1.0",
-                "get-value": "^2.0.6",
-                "is-extendable": "^0.1.1",
-                "set-value": "^2.0.1"
-            }
-        },
         "uniq": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
@@ -11010,62 +9241,10 @@
             "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
             "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
         },
-        "unset-value": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
-            "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-            "dev": true,
-            "requires": {
-                "has-value": "^0.3.1",
-                "isobject": "^3.0.0"
-            },
-            "dependencies": {
-                "has-value": {
-                    "version": "0.3.1",
-                    "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-                    "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-                    "dev": true,
-                    "requires": {
-                        "get-value": "^2.0.3",
-                        "has-values": "^0.1.4",
-                        "isobject": "^2.0.0"
-                    },
-                    "dependencies": {
-                        "isobject": {
-                            "version": "2.1.0",
-                            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-                            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-                            "dev": true,
-                            "requires": {
-                                "isarray": "1.0.0"
-                            }
-                        }
-                    }
-                },
-                "has-values": {
-                    "version": "0.1.4",
-                    "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-                    "dev": true
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
-                }
-            }
-        },
         "unzip-response": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
             "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-            "dev": true
-        },
-        "upath": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
-            "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
             "dev": true
         },
         "update-notifier": {
@@ -11109,12 +9288,6 @@
                 "punycode": "^2.1.0"
             }
         },
-        "urix": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-            "dev": true
-        },
         "url-parse-lax": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
@@ -11122,12 +9295,6 @@
             "requires": {
                 "prepend-http": "^2.0.0"
             }
-        },
-        "use": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-            "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
-            "dev": true
         },
         "util-deprecate": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "healthier": "~3.2.0",
         "husky": "~3.1.0",
         "lint-staged": "~9.4.3",
-        "nodemon": "~1.19.2",
+        "nodemon": "~2.0.0",
         "openapi-schema-validator": "~3.0.3",
         "prettier": "~1.19.1",
         "shelljs": "~0.8.3",


### PR DESCRIPTION
So `nodemon` dropped Node 4 and 6 support for massive CPU/RAM usage improvements. Also a bunch of dependencies are gone. This is pretty cool :) 

```diff
- 23K node_modules/
+ 21K node_modules/
-512K package-lock.json
+434K package-lock.json
```