### PR TITLE
fix(dev): better error handling when accessing files locally

### DIFF
--- a/src/routes/charts.js
+++ b/src/routes/charts.js
@@ -779,7 +779,16 @@ async function getChartAsset(request, h) {
 
     try {
         const eventResults = await events.emit(event.GET_CHART_ASSET, { chart, filename });
-        const contentStream = eventResults.find(e => e.status === 'success').data;
+        const successResult = eventResults.find(e => e.status === 'success');
+
+        if (!successResult) {
+            const errorResult = eventResults.find(e => e.status === 'error');
+            throw errorResult
+                ? errorResult.error
+                : new Error(`${event.GET_CHART_ASSET} event failed`);
+        }
+
+        const contentStream = successResult.data;
 
         const contentType =
             chart.type === 'locator-map' && path.extname(filename) === '.csv'


### PR DESCRIPTION
This bug fix is mainly relevant for local development.

When switching from `fs.readFile` to `fs.createReadStream` a check if the desired file actually exists was missing. That means the stream got created but as soon as the api actually wanted to read it, an error was thrown because the file doesn't exist. (Happens when you create a chart but have no data uploaded)

This PR fixes it.