### PR TITLE
Better chart data error handling

### DIFF
--- a/src/routes/charts.js
+++ b/src/routes/charts.js
@@ -433,12 +433,11 @@ function register(server, options) {
 
     const { events, event } = server.app;
     const { localChartAssetRoot } = server.methods.config('general');
+    const hasRegisteredDataPlugins =
+        events.eventNames().includes(event.GET_CHART_ASSET) &&
+        events.eventNames().includes(event.PUT_CHART_ASSET);
 
-    if (
-        localChartAssetRoot === undefined &&
-        (!events.eventNames().includes(event.GET_CHART_ASSET) ||
-            !!events.eventNames().includes(event.PUT_CHART_ASSET))
-    ) {
+    if (localChartAssetRoot === undefined && !hasRegisteredDataPlugins) {
         server
             .logger()
             .error(
@@ -447,15 +446,13 @@ function register(server, options) {
         process.exit(1);
     }
 
-    if (!events.eventNames().includes(event.GET_CHART_ASSET)) {
+    if (!hasRegisteredDataPlugins) {
         events.on(event.GET_CHART_ASSET, async function({ chart, filename }) {
             return fs.createReadStream(
                 path.join(localChartAssetRoot, getDataPath(chart.dataValues.created_at), filename)
             );
         });
-    }
 
-    if (!events.eventNames().includes(event.PUT_CHART_ASSET)) {
         events.on(event.PUT_CHART_ASSET, async function({ chart, data, filename }) {
             const outPath = path.join(
                 localChartAssetRoot,

--- a/src/routes/charts.js
+++ b/src/routes/charts.js
@@ -332,6 +332,10 @@ function register(server, options) {
             auth: request.auth
         });
 
+        if (res.result.error) {
+            return new Boom.Boom(res.result.message, res.result);
+        }
+
         let contentType = 'text/csv';
 
         try {


### PR DESCRIPTION
I fixed the error propagation from errors the chart data plugins can produce and a small logic error that slipped through in my previous PR review.

```diff
- (!events.eventNames().includes(event.GET_CHART_ASSET) || !!events.eventNames().includes(event.PUT_CHART_ASSET)))
+ (!events.eventNames().includes(event.GET_CHART_ASSET) || !events.eventNames().includes(event.PUT_CHART_ASSET)))
```

After checking out my server stopped even though I had a data plugin installed. The `!!` caused that.

I split up the PR in 2 commits to make it possible, to check each change individually. 