### PR TITLE
fix: use result

### DIFF
--- a/src/routes/charts.js
+++ b/src/routes/charts.js
@@ -434,7 +434,7 @@ function register(server, options) {
             payload: request.payload
         });
 
-        return h.response(res).code(res.statusCode);
+        return h.response(res.result).code(res.statusCode);
     }
 
     const { events, event } = server.app;


### PR DESCRIPTION
Need to send the actual result. This caused some errors on production (but not staging for some reason).