### PR TITLE
fix: use default salt if not configured

### DIFF
--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -72,7 +72,7 @@ module.exports = {
     name: 'auth-routes',
     version: '1.0.0',
     register: (server, options) => {
-        /* server.route({
+        server.route({
             method: 'POST',
             path: '/login',
             options: {
@@ -94,7 +94,7 @@ module.exports = {
                 }
             },
             handler: login
-        }); */
+        });
 
         server.route({
             method: 'POST',
@@ -181,7 +181,7 @@ module.exports = {
             handler: deleteToken
         });
 
-        /* server.route({
+        server.route({
             method: 'POST',
             path: '/signup',
             options: {
@@ -209,7 +209,7 @@ module.exports = {
                 }
             },
             handler: signup
-        }); */
+        });
 
         server.route({
             method: 'POST',
@@ -325,6 +325,9 @@ async function createSession(id, userId, keepSession = true) {
 }
 
 async function associateChartsWithUser(sessionId, userId) {
+    /* Sequelize returns [0] when no row was updated */
+    if (!sessionId) return [0];
+
     return Chart.update(
         {
             author_id: userId,
@@ -332,6 +335,7 @@ async function associateChartsWithUser(sessionId, userId) {
         },
         {
             where: {
+                author_id: null,
                 guest_session: sessionId
             }
         }
@@ -358,7 +362,6 @@ async function handleSession(request, h) {
         });
 }
 
-// eslint-disable-next-line
 async function login(request, h) {
     const { email, password, keepSession } = request.payload;
     const user = await User.findOne({
@@ -537,7 +540,6 @@ async function deleteToken(request, h) {
     return h.response().code(204);
 }
 
-// eslint-disable-next-line
 async function signup(request, h) {
     let session;
 

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -20,7 +20,7 @@ const DEFAULT_SALT = 'uRPAqgUJqNuBdW62bmq3CLszRFkvq4RW';
  * @param {string} secret - salt to hash the value with
  * @returns {string}
  */
-function legacyHash(pwhash, secret) {
+function legacyHash(pwhash, secret = DEFAULT_SALT) {
     const hmac = crypto.createHmac('sha256', secret);
     hmac.update(pwhash);
     return hmac.digest('hex');
@@ -45,7 +45,7 @@ function legacyLogin(password, passwordHash, authSalt, secretAuthSalt) {
 
     if (serverHash === passwordHash) return true;
 
-    const clientHash = legacyHash(password, authSalt || DEFAULT_SALT);
+    const clientHash = legacyHash(password, authSalt);
     serverHash = secretAuthSalt ? legacyHash(clientHash, secretAuthSalt) : clientHash;
     return serverHash === passwordHash;
 }
@@ -579,7 +579,7 @@ async function signup(request, h) {
         session = await createSession(generateToken(), res.result.id);
     }
 
-    const { activate_token, ...data } = res.result;
+    const { activateToken, ...data } = res.result;
 
     const { https, domain } = config('frontend');
 
@@ -590,7 +590,7 @@ async function signup(request, h) {
         data: {
             activation_link: `${
                 https ? 'https' : 'http'
-            }://${domain}/account/activate/${activate_token}`
+            }://${domain}/account/activate/${activateToken}`
         }
     });
 

--- a/src/routes/users.test.js
+++ b/src/routes/users.test.js
@@ -23,7 +23,7 @@ test.before(async t => {
     t.context.getTeamWithUser = getTeamWithUser;
 });
 
-test.skip('It should be possible to create a user, login and logout', async t => {
+test('It should be possible to create a user, login and logout', async t => {
     const credentials = {
         email: `test-${nanoid(5)}@ava.de`,
         password: 'strong-secure-password'

--- a/test/_config.ci.js
+++ b/test/_config.ci.js
@@ -11,7 +11,6 @@ module.exports = {
         sessionID: 'DW-SESSION',
         enableMigration: true,
         hashRounds: 15,
-        authSalt: process.env.AUTH_SALT,
         secretAuthSalt: process.env.SECRET_AUTH_SALT,
         cors: ['*']
     },

--- a/test/helpers/setup.js
+++ b/test/helpers/setup.js
@@ -9,6 +9,7 @@ const appendFile = promisify(fs.appendFile);
 
 const cleanupFile = path.join(os.tmpdir(), 'cleanup.csv');
 
+/* bcrypt hash for string "test-password" */
 const PASSWORD_HASH = '$2b$15$UdsGvrTLEk5DPRmRoHE4O..tzDpkWkAdKjBoKUjERXKoYHqTIRis6';
 
 function getCredentials() {
@@ -96,5 +97,5 @@ user;${user.id}
         return theme;
     }
 
-    return { server, models, getUser, getTeamWithUser, addToCleanup, createTheme };
+    return { server, models, getUser, getTeamWithUser, addToCleanup, createTheme, getCredentials };
 }

--- a/test/helpers/setup.js
+++ b/test/helpers/setup.js
@@ -9,7 +9,7 @@ const appendFile = promisify(fs.appendFile);
 
 const cleanupFile = path.join(os.tmpdir(), 'cleanup.csv');
 
-const passwordHash = '$2b$15$UdsGvrTLEk5DPRmRoHE4O..tzDpkWkAdKjBoKUjERXKoYHqTIRis6';
+const PASSWORD_HASH = '$2b$15$UdsGvrTLEk5DPRmRoHE4O..tzDpkWkAdKjBoKUjERXKoYHqTIRis6';
 
 function getCredentials() {
     return {
@@ -26,10 +26,10 @@ export async function setup(options) {
         await appendFile(cleanupFile, `${name};${id}\n`, { encoding: 'utf-8' });
     }
 
-    async function getUser(role = 'editor') {
+    async function getUser(role = 'editor', pwd = PASSWORD_HASH) {
         const user = await models.User.create({
             email: getCredentials().email,
-            pwd: passwordHash,
+            pwd,
             role
         });
 

--- a/test/legacy-login.test.js
+++ b/test/legacy-login.test.js
@@ -25,7 +25,7 @@ test.beforeEach(async t => {
     t.context.userEmail = user.email;
 });
 
-test.skip('Client hashed password', async t => {
+test('Client hashed password', async t => {
     const res = await t.context.server.inject({
         method: 'POST',
         url: '/v3/auth/login',
@@ -39,7 +39,7 @@ test.skip('Client hashed password', async t => {
     t.is(res.statusCode, 200);
 });
 
-test.skip('Non hashed password', async t => {
+test('Non hashed password', async t => {
     const res = await t.context.server.inject({
         method: 'POST',
         url: '/v3/auth/login',
@@ -53,7 +53,7 @@ test.skip('Non hashed password', async t => {
     t.is(res.statusCode, 200);
 });
 
-test.skip('Migrate client hashed password to new hash', async t => {
+test('Migrate client hashed password to new hash', async t => {
     let res = await t.context.server.inject({
         method: 'POST',
         url: '/v3/auth/login',
@@ -79,7 +79,7 @@ test.skip('Migrate client hashed password to new hash', async t => {
     t.is(res.statusCode, 200);
 });
 
-test.skip('Migrate password to new hash', async t => {
+test('Migrate password to new hash', async t => {
     let res = await t.context.server.inject({
         method: 'POST',
         url: '/v3/auth/login',

--- a/test/legacy-login.test.js
+++ b/test/legacy-login.test.js
@@ -3,12 +3,12 @@ import { setup } from './helpers/setup';
 
 const USER_PASSWORD = 'legacy';
 /**
- * USER_PASSWORD -> legacyHash('legacy', DEFAULT_SALT) ->
+ * USER_PASSWORD -> legacyHash(USER_PASSWORD, DEFAULT_SALT) ->
  * CLIENT_HAST
  */
 const CLIENT_HASH = '9574e9327ce73d61c8f5ffdc710e5c21cb07fcb3bef9ce4d892b88e6ad0ee107';
 /**
- * USER_PASSWORD -> legacyHash('legacy', DEFAULT_SALT) ->
+ * USER_PASSWORD -> legacyHash(USER_PASSWORD, DEFAULT_SALT) ->
  * output -> legacyHash(output, SECRET_AUTH_SALT) ->
  * LEGACY_HASH
  */


### PR DESCRIPTION
While testing, looking at logs and playing around with the API, I realized that the signup threw some errors occasionally.

This is not time critical but the fix was quite simple. I also took the time to refactor some tests that I have written a long time ago, to make them easier to understand.