### PR TITLE
Allow limiting of pending team invites per user

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -640,9 +640,9 @@
             }
         },
         "@datawrapper/orm": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/@datawrapper/orm/-/orm-3.5.1.tgz",
-            "integrity": "sha512-peocC79rGlmBh1br6d5kjGB/TcmhhxVpbbOU3RpbUrV1NKARaBFxnFH4vOFhMEdWCONo88io4XevXgPU9y/O0w==",
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/@datawrapper/orm/-/orm-3.7.0.tgz",
+            "integrity": "sha512-ravNhUXR9Lg1UY34RZBoMYKgwLZfZbeUzi2z1eIofKpsHJHUcW/mFN739ecL2P+oOae/iyfVftJnCcxW9NGSCw==",
             "requires": {
                 "assign-deep": "1.0.1",
                 "mysql2": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "url": "git+https://github.com/datawrapper/datawrapper-api.git"
     },
     "dependencies": {
-        "@datawrapper/orm": "3.5.1",
+        "@datawrapper/orm": "^3.7.0",
         "@datawrapper/schemas": "1.2.0",
         "@datawrapper/shared": "0.19.3",
         "@hapi/boom": "8.0.1",

--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -1050,7 +1050,7 @@ async function getMaxTeamInvites({ user, team, server }) {
         .filter(d => d.status === 'success')
         .map(({ data }) => data.maxInvites)
         .sort()
-        .slice(-1)[0];
+        .pop();
     return maxTeamInvites !== undefined ? maxTeamInvites : false;
 }
 

--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -883,10 +883,12 @@ async function inviteTeamMember(request, h) {
         }
     }
 
-    const maxTeamInvites = await getMaxTeamInvites({
-        server,
-        teamId: params.id
-    });
+    const maxTeamInvites = isAdmin
+        ? false
+        : await getMaxTeamInvites({
+              server,
+              teamId: params.id
+          });
 
     if (maxTeamInvites !== false) {
         const pendingInvites = await getPendingTeamInvites({ user });

--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -967,7 +967,7 @@ async function inviteTeamMember(request, h) {
 }
 
 async function addTeamMember(request, h) {
-    const { params, payload, server } = request;
+    const { auth, params, payload, server } = request;
     const isAdmin = server.methods.isAdmin(request);
 
     if (!isAdmin) return Boom.unauthorized();
@@ -999,7 +999,8 @@ async function addTeamMember(request, h) {
     const data = {
         user_id: user.id,
         organization_id: params.id,
-        team_role: payload.role
+        team_role: payload.role,
+        invited_by: auth.artifacts.id
     };
 
     await UserTeam.create(data);

--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -878,7 +878,7 @@ async function inviteTeamMember(request, h) {
     if (!isAdmin) {
         const memberRole = await getMemberRole(user.id, params.id);
 
-        if (memberRole === ROLES[2]) {
+        if (memberRole === ROLES[2] || user.role === 'pending') {
             return Boom.unauthorized();
         }
     }

--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -960,7 +960,7 @@ async function inviteTeamMember(request, h) {
         }
     });
 
-    await logAction(user, 'team/invite', { team: params.id, invited: invitee.id });
+    await logAction(user.id, 'team/invite', { team: params.id, invited: invitee.id });
 
     return h.response().code(201);
 }

--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -918,6 +918,13 @@ async function inviteTeamMember(request, h) {
         return Boom.badRequest('User is already member of team.');
     }
 
+    const maxTeamInvites = await server.app.events.emit(server.app.event.MAX_TEAM_INVITES, {
+        user,
+        team: await Team.findByPk(params.id)
+    });
+
+    console.log({maxTeamInvites});
+
     const data = {
         user_id: user.id,
         organization_id: params.id,

--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -13,6 +13,7 @@ const {
     Product,
     TeamTheme
 } = require('@datawrapper/orm/models');
+const { logAction } = require('@datawrapper/orm/utils/action');
 
 const { createResponseConfig, noContentResponse, listResponse } = require('../schemas/response.js');
 
@@ -950,6 +951,8 @@ async function inviteTeamMember(request, h) {
             }/${data.invite_token}`
         }
     });
+
+    await logAction(user, 'team/invite', { team: params.id, invited: invitee.id });
 
     return h.response().code(201);
 }

--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -885,8 +885,7 @@ async function inviteTeamMember(request, h) {
 
     const maxTeamInvites = await getMaxTeamInvites({
         server,
-        user,
-        team: await Team.findByPk(params.id)
+        teamId: params.id
     });
 
     if (maxTeamInvites !== false) {
@@ -1042,9 +1041,9 @@ function convertKeys(input, method) {
     return output;
 }
 
-async function getMaxTeamInvites({ user, team, server }) {
+async function getMaxTeamInvites({ teamId, server }) {
     const maxTeamInvitesRes = await server.app.events.emit(server.app.event.MAX_TEAM_INVITES, {
-        user
+        teamId
     });
     const maxTeamInvites = maxTeamInvitesRes
         .filter(d => d.status === 'success')

--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -890,7 +890,7 @@ async function inviteTeamMember(request, h) {
 
     if (maxTeamInvites !== false) {
         const pendingInvites = await getPendingTeamInvites({ user });
-        if (pendingInvites > maxTeamInvites) {
+        if (pendingInvites >= maxTeamInvites) {
             return Boom.notAcceptable(
                 `You already invited ${maxTeamInvites} user into teams. You can invite more users when invitations have been accepted.`
             );

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -45,7 +45,8 @@ const eventList = {
     CHART_EXPORT: 'CHART_EXPORT',
     GET_CHART_ASSET: 'GET_CHART_ASSET',
     PUT_CHART_ASSET: 'PUT_CHART_ASSET',
-    SEND_EMAIL: 'SEND_EMAIL'
+    SEND_EMAIL: 'SEND_EMAIL',
+    MAX_TEAM_INVITES: 'MAX_INVITES'
 };
 
 module.exports = { ApiEventEmitter, eventList };

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -46,7 +46,7 @@ const eventList = {
     GET_CHART_ASSET: 'GET_CHART_ASSET',
     PUT_CHART_ASSET: 'PUT_CHART_ASSET',
     SEND_EMAIL: 'SEND_EMAIL',
-    MAX_TEAM_INVITES: 'MAX_INVITES'
+    MAX_TEAM_INVITES: 'MAX_TEAM_INVITES'
 };
 
 module.exports = { ApiEventEmitter, eventList };


### PR DESCRIPTION
This PR

* stores information about _who_ invited _whom_ in the `/team/{id}/invite` handler
* adds a new Event hook `MAX_TEAM_INVITES` that allows plugins to define a maximum number of pending team invites a user can have
* updates ORM to new version (see separate [PR](https://github.com/datawrapper/orm/pull/14))
* also log team invites into the `action` table (sort of redundant now but doesn't hurt much either)

depends on https://github.com/datawrapper/orm/pull/14
