### PR TITLE
feat: send maxTeamInvites in error payload data

### DIFF
--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -891,9 +891,11 @@ async function inviteTeamMember(request, h) {
     if (maxTeamInvites !== false) {
         const pendingInvites = await getPendingTeamInvites({ user });
         if (pendingInvites >= maxTeamInvites) {
-            return Boom.notAcceptable(
+            const error = Boom.notAcceptable(
                 `You already invited ${maxTeamInvites} user into teams. You can invite more users when invitations have been accepted.`
             );
+            error.output.payload.data = { maxTeamInvites };
+            return error;
         }
     }
 


### PR DESCRIPTION
This PR adds the max number of team invites to the error response when a user attempts to invite more team members than currently allowed. This will allow us to show it in a message to the user in the front-end.