### PR TITLE
Ensure there's always only one team owner

### DIFF
--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -678,7 +678,7 @@ async function getTeamMembers(request, h) {
                 email: user.email,
                 charts: user.charts.length,
                 isAdmin: user.role === 'admin' || user.role === 'sysadmin',
-                role: user_team.team_role,
+                role: ROLES[user_team.dataValues.team_role],
                 token,
                 isNewUser: token ? user.activate_token === token : undefined,
                 url: `/v3/users/${user.id}`

--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -25,7 +25,10 @@ const teamResponse = createResponseConfig({
     }).unknown()
 });
 
-const ROLES = ['owner', 'admin', 'member'];
+const ROLE_OWNER = 'owner';
+const ROLE_ADMIN = 'admin';
+const ROLE_MEMBER = 'member';
+const ROLES = [ROLE_OWNER, ROLE_ADMIN, ROLE_MEMBER];
 
 const routes = [
     {
@@ -623,7 +626,7 @@ async function getTeamMembers(request, h) {
     if (!server.methods.isAdmin(request)) {
         const memberRole = await getMemberRole(auth.artifacts.id, params.id);
 
-        if (memberRole === ROLES[2]) {
+        if (memberRole === ROLE_MEMBER) {
             return Boom.unauthorized();
         }
     }
@@ -675,7 +678,7 @@ async function getTeamMembers(request, h) {
                 email: user.email,
                 charts: user.charts.length,
                 isAdmin: user.role === 'admin' || user.role === 'sysadmin',
-                role: ROLES[user_team.dataValues.team_role],
+                role: user_team.team_role,
                 token,
                 isNewUser: token ? user.activate_token === token : undefined,
                 url: `/v3/users/${user.id}`
@@ -691,7 +694,7 @@ async function editTeam(request, h) {
     if (!server.methods.isAdmin(request)) {
         const memberRole = await getMemberRole(auth.artifacts.id, params.id);
 
-        if (memberRole === ROLES[2]) {
+        if (memberRole === ROLE_MEMBER) {
             return Boom.unauthorized();
         }
     }
@@ -723,7 +726,7 @@ async function deleteTeam(request, h) {
     if (!server.methods.isAdmin(request)) {
         const memberRole = await getMemberRole(auth.artifacts.id, params.id);
 
-        if (memberRole !== ROLES[0]) {
+        if (memberRole !== ROLE_OWNER) {
             return Boom.unauthorized();
         }
     }
@@ -792,7 +795,7 @@ async function deleteTeamMember(request, h) {
     if (!isAdmin) {
         const memberRole = await getMemberRole(user.id, params.id);
 
-        if (memberRole === ROLES[2] && user.id !== params.userId) {
+        if (memberRole === ROLE_MEMBER && user.id !== params.userId) {
             return Boom.unauthorized();
         }
     }
@@ -806,7 +809,7 @@ async function deleteTeamMember(request, h) {
 
     const owner = await UserTeam.findOne({
         where: {
-            team_role: ROLES[0],
+            team_role: ROLE_OWNER,
             organization_id: params.id
         }
     });
@@ -925,7 +928,7 @@ async function inviteTeamMember(request, h) {
     if (!isAdmin) {
         const memberRole = await getMemberRole(user.id, params.id);
 
-        if (memberRole === ROLES[2] || user.role === 'pending') {
+        if (memberRole === ROLE_MEMBER || user.role === 'pending') {
             return Boom.unauthorized();
         }
     }
@@ -995,14 +998,14 @@ async function inviteTeamMember(request, h) {
         invited_by: user.id
     };
 
-    if (payload.role === ROLES[0]) {
+    if (payload.role === ROLE_OWNER) {
         await UserTeam.update(
             {
-                team_role: ROLES[1]
+                team_role: ROLE_ADMIN
             },
             {
                 where: {
-                    team_role: ROLES[0],
+                    team_role: ROLE_OWNER,
                     organization_id: params.id
                 }
             }
@@ -1151,14 +1154,14 @@ async function addTeamMember(request, h) {
         invited_by: auth.artifacts.id
     };
 
-    if (payload.role === ROLES[0]) {
+    if (payload.role === ROLE_OWNER) {
         await UserTeam.update(
             {
-                team_role: ROLES[1]
+                team_role: ROLE_ADMIN
             },
             {
                 where: {
-                    team_role: ROLES[0],
+                    team_role: ROLE_OWNER,
                     organization_id: params.id
                 }
             }
@@ -1177,7 +1180,7 @@ async function changeMemberStatus(request, h) {
     if (!isAdmin) {
         const memberRole = await getMemberRole(auth.artifacts.id, params.id);
 
-        if (memberRole === ROLES[2]) {
+        if (memberRole === ROLE_MEMBER) {
             return Boom.unauthorized();
         }
     }
@@ -1189,14 +1192,14 @@ async function changeMemberStatus(request, h) {
         }
     });
 
-    if (payload.role === ROLES[0]) {
+    if (payload.role === ROLE_OWNER) {
         await UserTeam.update(
             {
-                team_role: ROLES[1]
+                team_role: ROLE_ADMIN
             },
             {
                 where: {
-                    team_role: ROLES[0],
+                    team_role: ROLE_OWNER,
                     organization_id: params.id
                 }
             }

--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -532,18 +532,18 @@ module.exports = {
 };
 
 async function getMemberRole(userId, teamId) {
-    const team = await UserTeam.findOne({
+    const userTeamRow = await UserTeam.findOne({
         where: {
             user_id: userId,
             organization_id: teamId
         }
     });
 
-    if (!team) {
+    if (!userTeamRow) {
         throw Boom.unauthorized();
     }
 
-    return ROLES[team.dataValues.team_role];
+    return userTeamRow.team_role;
 }
 
 async function getAllTeams(request, h) {
@@ -679,7 +679,7 @@ async function getTeamMembers(request, h) {
                 email: user.email,
                 charts: user.charts.length,
                 isAdmin: user.role === 'admin' || user.role === 'sysadmin',
-                role: ROLES[user_team.dataValues.team_role],
+                role: user_team.team_role,
                 token,
                 isNewUser: token ? user.activate_token === token : undefined,
                 url: `/v3/users/${user.id}`
@@ -817,7 +817,7 @@ async function deleteTeamMember(request, h) {
 
     if (!row) return Boom.notFound();
 
-    if (ROLES[row.dataValues.team_role] === 'owner') {
+    if (row.team_role === ROLE_OWNER) {
         return Boom.unauthorized('Can not delete team owner.');
     }
 

--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -998,20 +998,6 @@ async function inviteTeamMember(request, h) {
         invited_by: user.id
     };
 
-    if (payload.role === ROLE_OWNER) {
-        await UserTeam.update(
-            {
-                team_role: ROLE_ADMIN
-            },
-            {
-                where: {
-                    team_role: ROLE_OWNER,
-                    organization_id: params.id
-                }
-            }
-        );
-    }
-
     await UserTeam.create(data);
     const team = await Team.findByPk(data.organization_id);
 

--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -1180,6 +1180,17 @@ async function addTeamMember(request, h) {
     return h.response().code(201);
 }
 
+function canChangeMemberStatus({ memberRole, userRole }) {
+    if (memberRole === ROLE_MEMBER) {
+        // only admins and owners may change member status
+        return false;
+    }
+    if (memberRole !== ROLE_OWNER && userRole === ROLE_OWNER) {
+        // only team owners may set a new team owner
+        return false;
+    }
+    return true;
+}
 async function changeMemberStatus(request, h) {
     const { auth, params, payload, server } = request;
 
@@ -1188,7 +1199,7 @@ async function changeMemberStatus(request, h) {
     if (!isAdmin) {
         const memberRole = await getMemberRole(auth.artifacts.id, params.id);
 
-        if (memberRole === ROLE_MEMBER) {
+        if (!canChangeMemberStatus({ memberRole, userRole: payload.role })) {
             return Boom.unauthorized();
         }
     }

--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -813,11 +813,11 @@ async function deleteTeamMember(request, h) {
 
     if (!row) return Boom.notFound();
 
-    if (ROLES[row.dataValues.team_role] === 'owner' && !isAdmin) {
+    if (ROLES[row.dataValues.team_role] === 'owner') {
         return Boom.unauthorized('Can not delete team owner.');
     }
 
-    if (!owner && !isAdmin) {
+    if (!owner) {
         const chartCount = await Chart.count({
             where: {
                 author_id: params.userId,
@@ -995,6 +995,20 @@ async function inviteTeamMember(request, h) {
         invited_by: user.id
     };
 
+    if (payload.role === ROLES[0]) {
+        await UserTeam.update(
+            {
+                team_role: ROLES[1]
+            },
+            {
+                where: {
+                    team_role: ROLES[0],
+                    organization_id: params.id
+                }
+            }
+        );
+    }
+
     await UserTeam.create(data);
     const team = await Team.findByPk(data.organization_id);
 
@@ -1137,6 +1151,20 @@ async function addTeamMember(request, h) {
         invited_by: auth.artifacts.id
     };
 
+    if (payload.role === ROLES[0]) {
+        await UserTeam.update(
+            {
+                team_role: ROLES[1]
+            },
+            {
+                where: {
+                    team_role: ROLES[0],
+                    organization_id: params.id
+                }
+            }
+        );
+    }
+
     await UserTeam.create(data);
     return h.response().code(201);
 }
@@ -1160,6 +1188,20 @@ async function changeMemberStatus(request, h) {
             organization_id: params.id
         }
     });
+
+    if (payload.role === ROLES[0]) {
+        await UserTeam.update(
+            {
+                team_role: ROLES[1]
+            },
+            {
+                where: {
+                    team_role: ROLES[0],
+                    organization_id: params.id
+                }
+            }
+        );
+    }
 
     await userTeam.update({
         team_role: payload.status

--- a/src/routes/teams.test.js
+++ b/src/routes/teams.test.js
@@ -126,6 +126,7 @@ test('owner can remove team members', async t => {
         url: `/v3/teams/${t.context.data.team.id}/members`,
         auth: t.context.auth
     });
+    t.is(member.statusCode, 200);
 
     let hasUser = !!member.result.list.find(m => m.id === user.id);
 

--- a/src/routes/teams.test.js
+++ b/src/routes/teams.test.js
@@ -178,9 +178,10 @@ test('admins can create teams', async t => {
         }
     });
 
+    t.is(team.statusCode, 201);
+
     await t.context.addToCleanup('team', team.result.id);
 
-    t.is(team.statusCode, 201);
     t.is(team.result.name, 'Test');
     t.truthy(team.result.createdAt);
 });


### PR DESCRIPTION
This PR changes behaviour of a couple of endpoints to ensure we only ever have *one single owner per team*:

- when **adding** a new member as owner, the existing owner is turned into an admin.
- when **inviting** a new member as owner, the existing owner is turned into an admin.
- when **changing** a member's role to owner, the existing owner is turned into an admin.
- admins now **can't delete team owners** from a team anymore. either choose another owner before, or delete the entire team.