### PR TITLE
Add accepting & rejecting of team invitations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -640,9 +640,9 @@
             }
         },
         "@datawrapper/orm": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@datawrapper/orm/-/orm-3.7.0.tgz",
-            "integrity": "sha512-ravNhUXR9Lg1UY34RZBoMYKgwLZfZbeUzi2z1eIofKpsHJHUcW/mFN739ecL2P+oOae/iyfVftJnCcxW9NGSCw==",
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/@datawrapper/orm/-/orm-3.7.1.tgz",
+            "integrity": "sha512-hvzcSHFZNWtmEt31D7BEZoJs9ebvz9SnwcUupHI9wcPrbrz/+5QRnKIlzhw9+FOF9DZy/sPDs6MhkjY0DPM+2Q==",
             "requires": {
                 "assign-deep": "1.0.1",
                 "mysql2": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "url": "git+https://github.com/datawrapper/datawrapper-api.git"
     },
     "dependencies": {
-        "@datawrapper/orm": "^3.7.0",
+        "@datawrapper/orm": "^3.7.1",
         "@datawrapper/schemas": "1.2.0",
         "@datawrapper/shared": "0.19.3",
         "@hapi/boom": "8.0.1",

--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -463,6 +463,7 @@ module.exports = {
             path: `/{id}/invites/{token}`,
             options: {
                 tags: ['api'],
+                auth: false,
                 description: 'Reject a team invitation',
                 validate: {
                     params: {

--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -3,6 +3,7 @@ const Boom = require('@hapi/boom');
 const { Op } = require('sequelize');
 const set = require('lodash/set');
 const nanoid = require('nanoid');
+const crypto = require('crypto');
 const { decamelize, camelize } = require('humps');
 const {
     Chart,
@@ -1092,6 +1093,12 @@ async function rejectTeamInvitation(request, h) {
     if (user) {
         // also remove user who never activated the account
         await user.destroy();
+
+        // and log a hashed version of the email for
+        // future spam detection
+        const hmac = crypto.createHash('sha256');
+        hmac.update(user.email);
+        logAction(userTeam.invited_by, 'team/invite/reject', hmac.digest('hex'));
     }
 
     return h.response().code(204);

--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -1057,6 +1057,8 @@ async function acceptTeamInvitation(request, h) {
         invite_token: ''
     });
 
+    logAction(userTeam.invited_by, 'team/invite/accept', params.id);
+
     return h.response().code(201);
 }
 

--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -1083,19 +1083,15 @@ async function rejectTeamInvitation(request, h) {
     // remove invitation
     await userTeam.destroy();
 
-    const user = await User.findOne({
-        where: {
-            id: userTeam.user_id,
-            activate_token: params.token
-        }
-    });
+    const user = await User.findByPk(userTeam.user_id);
 
     if (user) {
         // also remove user who never activated the account
-        await user.destroy();
+        if (user.activate_token === params.token) {
+            await user.destroy();
+        }
 
-        // and log a hashed version of the email for
-        // future spam detection
+        // and log email hash for future spam detection
         const hmac = crypto.createHash('sha256');
         hmac.update(user.email);
         logAction(userTeam.invited_by, 'team/invite/reject', hmac.digest('hex'));

--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -1034,7 +1034,7 @@ async function acceptTeamInvitation(request, h) {
     });
 
     if (!userTeam) {
-        return Boom.unauthorized();
+        return Boom.notFound();
     }
 
     if (userTeam.team_role === 'owner') {
@@ -1077,7 +1077,7 @@ async function rejectTeamInvitation(request, h) {
     });
 
     if (!userTeam) {
-        return Boom.unauthorized();
+        return Boom.notFound();
     }
 
     // remove invitation

--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -1032,30 +1032,30 @@ async function acceptTeamInvitation(request, h) {
         }
     });
 
-    if (userTeam) {
-        if (userTeam.team_role === 'owner') {
-            // we're invited as owner, turn former owner
-            // into team admin
-            await UserTeam.update(
-                {
-                    team_role: 'admin'
-                },
-                {
-                    where: {
-                        user_id: {
-                            [Op.not]: user.id
-                        },
-                        team_role: 'owner'
-                    }
-                }
-            );
-        }
-        await userTeam.update({
-            invite_token: ''
-        });
-    } else {
+    if (!userTeam) {
         return Boom.unauthorized();
     }
+
+    if (userTeam.team_role === 'owner') {
+        // we're invited as owner, turn former owner
+        // into team admin
+        await UserTeam.update(
+            {
+                team_role: 'admin'
+            },
+            {
+                where: {
+                    user_id: {
+                        [Op.not]: user.id
+                    },
+                    team_role: 'owner'
+                }
+            }
+        );
+    }
+    await userTeam.update({
+        invite_token: ''
+    });
 
     return h.response().code(201);
 }


### PR DESCRIPTION
As discussed [here](https://github.com/datawrapper/api/pull/70#issuecomment-560152196), I think the owner transfer should happen by the time the invitation is _accepted_ instead of when it is sent. To do so I moved the team invite logic to the API by adding two new routes:

* `POST /v3/teams/:id/invites/:token` for accepting team invitations
* `DELETE /v3/teams/:id/invites/:token` for rejecting team invitations

The handler for accepting invitations also performs the ownership transfer in case the user has been invited as owner.

This PR depends on a [bug fix in the ORM](https://github.com/datawrapper/orm/pull/16)