### PR TITLE
refactor: make tests work with empty database

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,56 +1,31 @@
-defaults: &defaults
-    working_directory: ~/repo
-    docker:
-        - image: sto3psl/dw-ci:1.3.0
-
-cache: &cache
-    key: v3-dependency-cache-{{ checksum "package-lock.json" }}
-
-registry: &registry
-    name: Authenticate with registry
-    command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-
 version: 2
 jobs:
-    install:
-        <<: *defaults
+    test:
+        working_directory: ~/repo
+        docker:
+            - image: sto3psl/dw-ci:1.3.0
         steps:
             - checkout
+
             - restore_cache:
-                  key: v1-install-cache-{{ checksum "package-lock.json" }}
+                  keys:
+                      - v1-install-cache-{{ checksum "package-lock.json" }}
+                      - v1-install-cache
 
             - run:
-                  <<: *registry
+                  name: Authenticate with registry
+                  command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
 
             - run:
                   name: Install dependencies
+                  environment:
+                      HUSKY_SKIP_INSTALL: 1
                   command: |
-                      export DW_CONFIG_PATH=$HOME/repo/test/_config.ci.js
                       npm ci
 
-            - save_cache:
-                  <<: *cache
-                  paths:
-                      - node_modules
-                      - ~/.npm
-
-            - save_cache:
-                  key: v1-install-cache-{{ checksum "package-lock.json" }}
-                  paths:
-                      - ~/.npm
-    test:
-        <<: *defaults
-        steps:
-            - checkout
-            - restore_cache:
-                  <<: *cache
-
             - run:
-                  <<: *registry
-
-            - run:
-                name: Lint code
-                command: npm run lint
+                  name: Lint code
+                  command: npm run lint
 
             - run:
                   name: Run tests
@@ -61,6 +36,8 @@ jobs:
                       npm test -- --tap | npx tap-xunit > ~/reports/ava/results.xml
             - run:
                   name: Cleanup DB because tests failed
+                  environment:
+                      DW_CONFIG_PATH: ./test/_config.ci.js
                   command: npm run clean:db
                   when: on_fail
             - store_test_results:
@@ -68,19 +45,17 @@ jobs:
             - store_artifacts:
                   path: ~/reports
 
+            - save_cache:
+                  key: v1-install-cache-{{ checksum "package-lock.json" }}
+                  paths:
+                      - ~/.npm
+
 workflows:
     version: 2
     install, test and lint:
         jobs:
-            - install:
-                  filters:
-                      tags:
-                          only: /^v.*/
-
             - test:
                   context: Testing DB
                   filters:
                       tags:
                           only: /^v.*/
-                  requires:
-                      - install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,10 @@ jobs:
                   <<: *registry
 
             - run:
+                name: Lint code
+                command: npm run lint
+
+            - run:
                   name: Run tests
                   environment:
                       DW_CONFIG_PATH: ./test/_config.ci.js
@@ -64,15 +68,6 @@ jobs:
             - store_artifacts:
                   path: ~/reports
 
-    lint:
-        <<: *defaults
-        steps:
-            - checkout
-            - restore_cache:
-                  <<: *cache
-
-            - run: npm run lint
-
 workflows:
     version: 2
     install, test and lint:
@@ -84,13 +79,6 @@ workflows:
 
             - test:
                   context: Testing DB
-                  filters:
-                      tags:
-                          only: /^v.*/
-                  requires:
-                      - install
-
-            - lint:
                   filters:
                       tags:
                           only: /^v.*/

--- a/src/routes/auth.test.js
+++ b/src/routes/auth.test.js
@@ -20,8 +20,10 @@ test.before(async t => {
 
     t.context.server = server;
 
-    const { user } = await getUser();
+    const { user, session, token } = await getUser();
     t.context.user = user;
+    t.context.session = session.id;
+    t.context.token = token;
     t.context.models = models;
     t.context.getUser = getUser;
     t.context.getCredentials = getCredentials;
@@ -123,7 +125,7 @@ test('Logout errors with token', async t => {
         method: 'POST',
         url: '/v3/auth/logout',
         headers: {
-            authorization: `Bearer Agamotto`
+            authorization: `Bearer ${t.context.token}`
         }
     });
 
@@ -134,8 +136,8 @@ test('Logout errors with token', async t => {
 test('Tokens can be created, fetched and deleted', async t => {
     const auth = {
         strategy: 'session',
-        credentials: { session: 'Danvers' },
-        artifacts: { id: 1 }
+        credentials: { session: t.context.session },
+        artifacts: { id: t.context.user.id }
     };
 
     let res = await t.context.server.inject({

--- a/src/routes/teams.test.js
+++ b/src/routes/teams.test.js
@@ -377,7 +377,7 @@ test('owners can not get removed', async t => {
 });
 
 test('admins can create teams', async t => {
-    const admin = await t.context.models.User.findByPk(1);
+    const { user: admin } = await t.context.getUser('admin');
     const auth = { strategy: 'simple', credentials: { session: '' }, artifacts: admin };
 
     const team = await t.context.server.inject({

--- a/test/_config.ci.js
+++ b/test/_config.ci.js
@@ -10,7 +10,7 @@ module.exports = {
         domain: 'localhost',
         sessionID: 'DW-SESSION',
         enableMigration: true,
-        hashRounds: 15,
+        hashRounds: 5,
         secretAuthSalt: process.env.SECRET_AUTH_SALT,
         cors: ['*']
     },

--- a/test/helpers/teardown.js
+++ b/test/helpers/teardown.js
@@ -28,7 +28,8 @@ async function main() {
         team: [],
         session: [],
         user: [],
-        theme: []
+        theme: [],
+        token: []
     };
 
     csv.split('\n').forEach(line => {
@@ -38,10 +39,11 @@ async function main() {
         }
     });
 
-    const [actions, , , sessions, themes] = await Promise.all([
+    const [actions, , , tokens, sessions, themes] = await Promise.all([
         models.Action.destroy({ where: { id: { [Op.not]: null } } }),
         models.Chart.destroy({ where: { author_id: { [Op.in]: list.user } } }),
         models.UserTeam.destroy({ where: { organization_id: { [Op.in]: list.team } } }),
+        models.AuthToken.destroy({ where: { token: { [Op.in]: list.token } } }),
         models.Session.destroy({ where: { session_id: { [Op.in]: list.session } } }),
         models.Theme.destroy({ where: { id: { [Op.in]: list.theme } } }),
         models.UserData.destroy({ where: { user_id: { [Op.in]: list.user } } })
@@ -49,6 +51,7 @@ async function main() {
 
     log(chalk.magenta(`🧹 Cleaned ${actions} actions`));
     log(chalk.magenta(`🧹 Cleaned ${sessions} sessions`));
+    log(chalk.magenta(`🧹 Cleaned ${tokens} tokens`));
     log(chalk.magenta(`🧹 Cleaned ${themes} themes`));
 
     const teams = await models.Team.destroy({ where: { id: { [Op.in]: list.team } } });


### PR DESCRIPTION
This is a cleanup task.

Some old tests relied on certain data being available in the DB. This caused some headaches and false test failures in the past. I refactored all tests to actually create the data before they need it. This should make the tests more reliable, even more when multiple PRs are running in CircleCI.

For tests a lot of hash rounds for bcrypt aren't needed so i decreased the amount to 5 (`bcryptjs` won't go lower). This saves a lot of computation time and on my laptop reduces test times from 36s to 13s. On CircleCI you can see a similar reduction. 

Another change I made, is letting `lint` and `test` run in the same step. This should save another big chunk of time since we boot 1 less docker container.

**All in all we save around 30s per CI run.**