### PR TITLE
fix: actually use `git`

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -86,7 +86,7 @@ async function getVersionInfo() {
     try {
         const { promisify } = require('util');
         const exec = promisify(require('child_process').exec);
-        const { stdout } = await exec('gt rev-parse --short HEAD');
+        const { stdout } = await exec('git rev-parse --short HEAD');
         const commit = stdout.trim();
         return { commit, version: `${version} (${commit})` };
     } catch (error) {


### PR DESCRIPTION
Well I merged too quickly. My bad shell command (which I used to test the last option) slipped through.