### PR TITLE
team admin include owner, hide settings for team members, fix memberCount

### DIFF
--- a/src/routes/teams-admin.js
+++ b/src/routes/teams-admin.js
@@ -60,11 +60,6 @@ function register(server, options) {
                     where: query.userId ? { id: query.userId } : undefined
                 }
             ],
-            where: {
-                deleted: {
-                    [Op.not]: true
-                }
-            },
             limit: query.limit,
             offset: query.offset,
             distinct: true

--- a/src/routes/teams-admin.js
+++ b/src/routes/teams-admin.js
@@ -138,7 +138,7 @@ function register(server, options) {
         const teamList = {
             list: rows.map(({ dataValues }) => {
                 const { users, ...data } = dataValues;
-                const owner = users.filter(user => user.user_team.team_role === 'owner').pop();
+                const owner = users.find(user => user.user_team.team_role === 'owner');
                 return camelizeKeys({
                     ...data,
                     memberCount: users.length,

--- a/src/routes/teams-admin.js
+++ b/src/routes/teams-admin.js
@@ -70,7 +70,7 @@ function register(server, options) {
                 const team = camelizeKeys({
                     ...data,
                     memberCount: users.length,
-                    teamRole: user_team.team_role,
+                    role: user_team.team_role,
                     url: `/v3/teams/${dataValues.id}`
                 });
                 if (user_team.team_role !== 'member' || isAdmin) {

--- a/src/routes/teams-admin.js
+++ b/src/routes/teams-admin.js
@@ -69,7 +69,7 @@ function register(server, options) {
         return {
             list: user.teams.map(({ dataValues }) => {
                 const { user_team, settings, users, ...data } = dataValues;
-                const owner = users.filter(user => user.user_team.team_role === 'owner').pop();
+                const owner = users.find(user => user.user_team.team_role === 'owner');
                 const team = camelizeKeys({
                     ...data,
                     memberCount: users.length,

--- a/src/routes/teams-admin.js
+++ b/src/routes/teams-admin.js
@@ -55,9 +55,6 @@ function register(server, options) {
             include: [
                 {
                     model: Team,
-                    attributes: {
-                        exclude: ['deleted']
-                    },
                     include: [
                         {
                             model: User
@@ -101,9 +98,6 @@ function register(server, options) {
 
         const options = {
             order: [[decamelize(query.orderBy), query.order]],
-            attributes: {
-                exclude: ['deleted']
-            },
             include: [
                 {
                     model: User,

--- a/src/routes/teams-admin.js
+++ b/src/routes/teams-admin.js
@@ -97,10 +97,7 @@ function register(server, options) {
             include: [
                 {
                     model: User,
-                    attributes: ['id', 'email'],
-                    through: {
-                        attributes: ['team_role']
-                    }
+                    attributes: ['id', 'email']
                 }
             ],
             limit: query.limit,

--- a/src/routes/teams-admin.js
+++ b/src/routes/teams-admin.js
@@ -168,4 +168,3 @@ function register(server, options) {
         return teamList;
     }
 }
-//

--- a/src/routes/teams-admin.js
+++ b/src/routes/teams-admin.js
@@ -55,11 +55,7 @@ function register(server, options) {
             include: [
                 {
                     model: Team,
-                    include: [
-                        {
-                            model: User
-                        }
-                    ]
+                    include: [User]
                 }
             ]
         });

--- a/src/routes/teams-admin.js
+++ b/src/routes/teams-admin.js
@@ -47,6 +47,7 @@ function register(server, options) {
 
     async function getAllTeamsByUser(request, h) {
         const { query } = request;
+        const isAdmin = server.methods.isAdmin(request);
         const user = await User.findOne({
             where: {
                 id: query.userId
@@ -75,7 +76,7 @@ function register(server, options) {
                     teamRole: user_team.team_role,
                     url: `/v3/teams/${dataValues.id}`
                 });
-                if (user_team.team_role !== 'member') {
+                if (user_team.team_role !== 'member' || isAdmin) {
                     return {
                         ...team,
                         settings,

--- a/src/routes/teams-admin.js
+++ b/src/routes/teams-admin.js
@@ -106,8 +106,10 @@ function register(server, options) {
             include: [
                 {
                     model: User,
-                    attributes: ['id'],
-                    where: query.userId ? { id: query.userId } : undefined
+                    attributes: ['id', 'email'],
+                    through: {
+                        attributes: ['team_role']
+                    }
                 }
             ],
             limit: query.limit,
@@ -135,9 +137,17 @@ function register(server, options) {
         const teamList = {
             list: rows.map(({ dataValues }) => {
                 const { users, ...data } = dataValues;
+                const owner = users.filter(user => user.user_team.team_role === 'owner').pop();
                 return camelizeKeys({
                     ...data,
                     memberCount: users.length,
+                    owner: owner
+                        ? {
+                              id: owner.id,
+                              url: `/v3/users/${owner.id}`,
+                              email: owner.email
+                          }
+                        : null,
                     url: `/v3/teams/${dataValues.id}`
                 });
             }),
@@ -157,3 +167,4 @@ function register(server, options) {
         return teamList;
     }
 }
+//

--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -589,16 +589,34 @@ async function getTeam(request, h) {
         return Boom.notFound();
     }
 
-    const { users, ...data } = team.dataValues;
+    const { users, settings, ...data } = team.dataValues;
 
-    return convertKeys(
+    const memberRole = hasTeam ? await getMemberRole(auth.artifacts.id, params.id) : undefined;
+    const owner = users.find(u => u.user_team.team_role === ROLE_OWNER);
+
+    const res = convertKeys(
         {
             ...data,
             memberCount: users.length,
+            role: memberRole,
             url: url.pathname
         },
         camelize
     );
+
+    if (isAdmin || memberRole !== ROLE_MEMBER) {
+        return {
+            ...res,
+            settings,
+            owner: owner
+                ? {
+                      id: owner.id,
+                      email: owner.email
+                  }
+                : null
+        };
+    }
+    return res;
 }
 
 async function getTeamMembers(request, h) {

--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -583,10 +583,6 @@ async function getTeam(request, h) {
         }
     };
 
-    if (!isAdmin) {
-        set(options, ['include', 0, 'where', 'id'], auth.artifacts.id);
-    }
-
     const team = await Team.findOne(options);
 
     if (!team) {

--- a/src/routes/teams.test.js
+++ b/src/routes/teams.test.js
@@ -113,7 +113,7 @@ test('[/v3/teams] check that owners and admins can see owner, but members cannot
     t.is(teams.result.list[0].owner, undefined);
 });
 
-test.only('[/v3/teams] check that owners and admins can see settings, but members cannot', async t => {
+test('[/v3/teams] check that owners and admins can see settings, but members cannot', async t => {
     const { getTeamWithUser } = t.context;
     const { addUser, user: owner, session: ownerSession } = await getTeamWithUser();
     const { user: admin, session: adminSession } = await addUser('admin');

--- a/src/routes/teams.test.js
+++ b/src/routes/teams.test.js
@@ -9,6 +9,7 @@ test.before(async t => {
 
     t.context.models = models;
     t.context.addToCleanup = addToCleanup;
+    t.context.getTeamWithUser = getTeamWithUser;
     t.context.getUser = getUser;
     t.context.server = server;
     t.context.data = data;
@@ -30,6 +31,129 @@ test('user can fetch their teams', async t => {
     t.is(teams.result.total, 1);
     t.is(teams.result.list[0].id, t.context.data.team.id);
     t.is(teams.result.list[0].name, 'Test Team');
+    t.is(teams.result.list[0].role, 'owner');
+    t.is(typeof teams.result.list[0].settings, 'object');
+});
+
+test.only('check for correct memberCount', async t => {
+    const { getTeamWithUser } = t.context;
+    const { addUser, user: owner, session: ownerSession, team } = await getTeamWithUser();
+
+    const ownerAuth = {
+        strategy: 'session',
+        credentials: ownerSession,
+        artifacts: owner
+    };
+
+    let teams = await t.context.server.inject({
+        method: 'GET',
+        url: '/v3/teams',
+        auth: ownerAuth
+    });
+
+    t.is(teams.statusCode, 200);
+    t.is(teams.result.total, 1);
+    t.is(teams.result.list[0].id, team.id);
+    t.is(teams.result.list[0].memberCount, 1);
+
+    await addUser('member');
+    await addUser('member');
+
+    teams = await t.context.server.inject({
+        method: 'GET',
+        url: '/v3/teams',
+        auth: ownerAuth
+    });
+
+    t.is(teams.result.list[0].memberCount, 3);
+});
+
+test.only('check that owners and admins can see owner, but members cannot', async t => {
+    const { getTeamWithUser } = t.context;
+    const { addUser, user: owner, session: ownerSession } = await getTeamWithUser();
+    const { user: admin, session: adminSession } = await addUser('admin');
+    const { user: member, session: memberSession } = await addUser('member');
+
+    let teams = await t.context.server.inject({
+        method: 'GET',
+        url: '/v3/teams',
+        auth: {
+            strategy: 'session',
+            credentials: ownerSession,
+            artifacts: owner
+        }
+    });
+
+    t.is(typeof teams.result.list[0].owner, 'object');
+    t.is(teams.result.list[0].owner.id, owner.id);
+
+    teams = await t.context.server.inject({
+        method: 'GET',
+        url: '/v3/teams',
+        auth: {
+            strategy: 'session',
+            credentials: adminSession,
+            artifacts: admin
+        }
+    });
+
+    t.is(typeof teams.result.list[0].owner, 'object');
+    t.is(teams.result.list[0].owner.id, owner.id);
+
+    teams = await t.context.server.inject({
+        method: 'GET',
+        url: '/v3/teams',
+        auth: {
+            strategy: 'session',
+            credentials: memberSession,
+            artifacts: member
+        }
+    });
+
+    t.is(teams.result.list[0].owner, undefined);
+});
+
+test.only('check that owners and admins can see settings, but members cannot', async t => {
+    const { getTeamWithUser } = t.context;
+    const { addUser, user: owner, session: ownerSession } = await getTeamWithUser();
+    const { user: admin, session: adminSession } = await addUser('admin');
+    const { user: member, session: memberSession } = await addUser('member');
+
+    let teams = await t.context.server.inject({
+        method: 'GET',
+        url: '/v3/teams',
+        auth: {
+            strategy: 'session',
+            credentials: ownerSession,
+            artifacts: owner
+        }
+    });
+
+    t.is(typeof teams.result.list[0].settings, 'object');
+
+    teams = await t.context.server.inject({
+        method: 'GET',
+        url: '/v3/teams',
+        auth: {
+            strategy: 'session',
+            credentials: adminSession,
+            artifacts: admin
+        }
+    });
+
+    t.is(typeof teams.result.list[0].settings, 'object');
+
+    teams = await t.context.server.inject({
+        method: 'GET',
+        url: '/v3/teams',
+        auth: {
+            strategy: 'session',
+            credentials: memberSession,
+            artifacts: member
+        }
+    });
+
+    t.is(teams.result.list[0].settings, undefined);
 });
 
 test('user can fetch individual team', async t => {

--- a/src/routes/teams.test.js
+++ b/src/routes/teams.test.js
@@ -35,7 +35,7 @@ test('user can fetch their teams', async t => {
     t.is(typeof teams.result.list[0].settings, 'object');
 });
 
-test.only('[/v3/teams] check for correct memberCount', async t => {
+test('[/v3/teams] check for correct memberCount', async t => {
     const { getTeamWithUser } = t.context;
     const { addUser, user: owner, session: ownerSession, team } = await getTeamWithUser();
 

--- a/src/routes/teams.test.js
+++ b/src/routes/teams.test.js
@@ -156,7 +156,7 @@ test.only('[/v3/teams] check that owners and admins can see settings, but member
     t.is(teams.result.list[0].settings, undefined);
 });
 
-test.only('[/v3/teams/:id] check that owners and admins can see owner, but members cannot', async t => {
+test('[/v3/teams/:id] check that owners and admins can see owner, but members cannot', async t => {
     const { getTeamWithUser } = t.context;
     const { addUser, user: owner, session: ownerSession, team } = await getTeamWithUser();
     const { user: admin, session: adminSession } = await addUser('admin');

--- a/src/routes/teams.test.js
+++ b/src/routes/teams.test.js
@@ -201,7 +201,7 @@ test.only('[/v3/teams/:id] check that owners and admins can see owner, but membe
     t.is(teams.result.owner, undefined);
 });
 
-test.only('[/v3/teams/:id] check that owners and admins can see settings, but members cannot', async t => {
+test('[/v3/teams/:id] check that owners and admins can see settings, but members cannot', async t => {
     const { getTeamWithUser } = t.context;
     const { addUser, user: owner, session: ownerSession, team } = await getTeamWithUser();
     const { user: admin, session: adminSession } = await addUser('admin');

--- a/src/routes/teams.test.js
+++ b/src/routes/teams.test.js
@@ -35,7 +35,7 @@ test('user can fetch their teams', async t => {
     t.is(typeof teams.result.list[0].settings, 'object');
 });
 
-test.only('check for correct memberCount', async t => {
+test.only('[/v3/teams] check for correct memberCount', async t => {
     const { getTeamWithUser } = t.context;
     const { addUser, user: owner, session: ownerSession, team } = await getTeamWithUser();
 
@@ -68,7 +68,7 @@ test.only('check for correct memberCount', async t => {
     t.is(teams.result.list[0].memberCount, 3);
 });
 
-test.only('check that owners and admins can see owner, but members cannot', async t => {
+test.only('[/v3/teams] check that owners and admins can see owner, but members cannot', async t => {
     const { getTeamWithUser } = t.context;
     const { addUser, user: owner, session: ownerSession } = await getTeamWithUser();
     const { user: admin, session: adminSession } = await addUser('admin');
@@ -113,7 +113,7 @@ test.only('check that owners and admins can see owner, but members cannot', asyn
     t.is(teams.result.list[0].owner, undefined);
 });
 
-test.only('check that owners and admins can see settings, but members cannot', async t => {
+test.only('[/v3/teams] check that owners and admins can see settings, but members cannot', async t => {
     const { getTeamWithUser } = t.context;
     const { addUser, user: owner, session: ownerSession } = await getTeamWithUser();
     const { user: admin, session: adminSession } = await addUser('admin');
@@ -154,6 +154,94 @@ test.only('check that owners and admins can see settings, but members cannot', a
     });
 
     t.is(teams.result.list[0].settings, undefined);
+});
+
+test.only('[/v3/teams/:id] check that owners and admins can see owner, but members cannot', async t => {
+    const { getTeamWithUser } = t.context;
+    const { addUser, user: owner, session: ownerSession, team } = await getTeamWithUser();
+    const { user: admin, session: adminSession } = await addUser('admin');
+    const { user: member, session: memberSession } = await addUser('member');
+
+    let teams = await t.context.server.inject({
+        method: 'GET',
+        url: `/v3/teams/${team.id}`,
+        auth: {
+            strategy: 'session',
+            credentials: ownerSession,
+            artifacts: owner
+        }
+    });
+
+    t.is(typeof teams.result.owner, 'object');
+    t.is(teams.result.owner.id, owner.id);
+
+    teams = await t.context.server.inject({
+        method: 'GET',
+        url: `/v3/teams/${team.id}`,
+        auth: {
+            strategy: 'session',
+            credentials: adminSession,
+            artifacts: admin
+        }
+    });
+
+    t.is(typeof teams.result.owner, 'object');
+    t.is(teams.result.owner.id, owner.id);
+
+    teams = await t.context.server.inject({
+        method: 'GET',
+        url: `/v3/teams/${team.id}`,
+        auth: {
+            strategy: 'session',
+            credentials: memberSession,
+            artifacts: member
+        }
+    });
+
+    t.is(teams.result.owner, undefined);
+});
+
+test.only('[/v3/teams/:id] check that owners and admins can see settings, but members cannot', async t => {
+    const { getTeamWithUser } = t.context;
+    const { addUser, user: owner, session: ownerSession, team } = await getTeamWithUser();
+    const { user: admin, session: adminSession } = await addUser('admin');
+    const { user: member, session: memberSession } = await addUser('member');
+
+    let teams = await t.context.server.inject({
+        method: 'GET',
+        url: `/v3/teams/${team.id}`,
+        auth: {
+            strategy: 'session',
+            credentials: ownerSession,
+            artifacts: owner
+        }
+    });
+
+    t.is(typeof teams.result.settings, 'object');
+
+    teams = await t.context.server.inject({
+        method: 'GET',
+        url: `/v3/teams/${team.id}`,
+        auth: {
+            strategy: 'session',
+            credentials: adminSession,
+            artifacts: admin
+        }
+    });
+
+    t.is(typeof teams.result.settings, 'object');
+
+    teams = await t.context.server.inject({
+        method: 'GET',
+        url: `/v3/teams/${team.id}`,
+        auth: {
+            strategy: 'session',
+            credentials: memberSession,
+            artifacts: member
+        }
+    });
+
+    t.is(teams.result.settings, undefined);
 });
 
 test('user can fetch individual team', async t => {

--- a/src/routes/teams.test.js
+++ b/src/routes/teams.test.js
@@ -68,7 +68,7 @@ test('[/v3/teams] check for correct memberCount', async t => {
     t.is(teams.result.list[0].memberCount, 3);
 });
 
-test.only('[/v3/teams] check that owners and admins can see owner, but members cannot', async t => {
+test('[/v3/teams] check that owners and admins can see owner, but members cannot', async t => {
     const { getTeamWithUser } = t.context;
     const { addUser, user: owner, session: ownerSession } = await getTeamWithUser();
     const { user: admin, session: adminSession } = await addUser('admin');


### PR DESCRIPTION
This PR fixes a couple of things:

1. Previously, the `/v3/teams` and `/v3/admin/teams?userId=..` endpoints would always return a `memberCount` of one due to the query filtering to a single user. Now the `memberCount` is correct.
2. Also the `/v3/teams` endpoint did expose the team settings to team members, while they should only be exposed to team admins and owners. This is fixed now.
3. The `/v3/teams` endpoint now includes a new property `teamRole` which reveals the authenticated users role in the team.
4. The `/v3/teams` and `/v3/admin/teams` endpoints now include information about the team owner (but only visible to team admins and team members).

As a side effect of the PR, the `/v3/teams` endpoint no longer supports pagination using `offset` and `limit`. Instead, all teams of the authenticated user will be returned. This is due to the lack of `offset` in `include` subqueries in sequelize.