### PR TITLE
only update users in same team on owner transfer

### DIFF
--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -1075,7 +1075,8 @@ async function acceptTeamInvitation(request, h) {
                     user_id: {
                         [Op.not]: user.id
                     },
-                    team_role: 'owner'
+                    team_role: 'owner',
+                    organization_id: params.id
                 }
             }
         );


### PR DESCRIPTION
this PR fixes the mysterious change of all team owners into admins. it was simply a missing where condition.