### PR TITLE
Add theme data validation for admin requests to `/v3/themes/{id}`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -658,27 +658,6 @@
                 }
             }
         },
-        "@datawrapper/schemas": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@datawrapper/schemas/-/schemas-1.2.0.tgz",
-            "integrity": "sha512-ZYPghbVc/7NP8Jy1jVk4KGYqA2LvsGb/KCWtKRwf8YteJRASbJ04ClUEiDd1FDzWJcg+ZzcZkI+n2QV1068nxw==",
-            "requires": {
-                "@hapi/joi": "^15.1.0",
-                "chalk": "^2.4.2"
-            },
-            "dependencies": {
-                "chalk": {
-                    "version": "2.4.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-                    "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    }
-                }
-            }
-        },
         "@datawrapper/shared": {
             "version": "0.19.3",
             "resolved": "https://registry.npmjs.org/@datawrapper/shared/-/shared-0.19.3.tgz",
@@ -6377,6 +6356,11 @@
                 "lolex": "^4.1.0",
                 "path-to-regexp": "^1.7.0"
             }
+        },
+        "node-fetch": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+            "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
         },
         "node-releases": {
             "version": "1.1.39",

--- a/package-lock.json
+++ b/package-lock.json
@@ -658,6 +658,52 @@
                 }
             }
         },
+        "@datawrapper/schemas": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@datawrapper/schemas/-/schemas-1.3.0.tgz",
+            "integrity": "sha512-JoHj2ziCegQbC6FP5zkpSTR9rI1V/NmoDymS/TQ0A0Rjh9fxRu0KOGu9/e1QoJ329WGgNC75QEFDPmXESYlI6g==",
+            "requires": {
+                "@hapi/joi": "^16.1.7",
+                "chalk": "^2.4.2"
+            },
+            "dependencies": {
+                "@hapi/hoek": {
+                    "version": "8.5.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
+                    "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
+                },
+                "@hapi/joi": {
+                    "version": "16.1.8",
+                    "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
+                    "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
+                    "requires": {
+                        "@hapi/address": "^2.1.2",
+                        "@hapi/formula": "^1.2.0",
+                        "@hapi/hoek": "^8.2.4",
+                        "@hapi/pinpoint": "^1.0.2",
+                        "@hapi/topo": "^3.1.3"
+                    }
+                },
+                "@hapi/topo": {
+                    "version": "3.1.6",
+                    "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+                    "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+                    "requires": {
+                        "@hapi/hoek": "^8.3.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                }
+            }
+        },
         "@datawrapper/shared": {
             "version": "0.19.3",
             "resolved": "https://registry.npmjs.org/@datawrapper/shared/-/shared-0.19.3.tgz",
@@ -6356,11 +6402,6 @@
                 "lolex": "^4.1.0",
                 "path-to-regexp": "^1.7.0"
             }
-        },
-        "node-fetch": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-            "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
         },
         "node-releases": {
             "version": "1.1.39",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     },
     "dependencies": {
         "@datawrapper/orm": "^3.7.2",
+        "@datawrapper/schemas": "^1.3.0",
         "@datawrapper/shared": "0.19.3",
         "@hapi/boom": "8.0.1",
         "@hapi/catbox-memory": "4.1.1",
@@ -55,7 +56,6 @@
         "lodash": "4.17.15",
         "mime": "2.4.4",
         "nanoid": "2.1.7",
-        "node-fetch": "^2.6.0",
         "sequelize": "6.0.0"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     },
     "dependencies": {
         "@datawrapper/orm": "^3.7.2",
-        "@datawrapper/schemas": "1.2.0",
         "@datawrapper/shared": "0.19.3",
         "@hapi/boom": "8.0.1",
         "@hapi/catbox-memory": "4.1.1",
@@ -56,6 +55,7 @@
         "lodash": "4.17.15",
         "mime": "2.4.4",
         "nanoid": "2.1.7",
+        "node-fetch": "^2.6.0",
         "sequelize": "6.0.0"
     },
     "devDependencies": {

--- a/src/routes/themes.js
+++ b/src/routes/themes.js
@@ -2,6 +2,7 @@ const Joi = require('@hapi/joi');
 const Boom = require('@hapi/boom');
 const assign = require('assign-deep');
 const { Theme } = require('@datawrapper/orm/models');
+const { validateThemeData } = require('@datawrapper/schemas');
 
 module.exports = {
     name: 'themes-routes',
@@ -64,6 +65,19 @@ ${dataValues.less || ''}
 
     dataValues.extend = originalExtend;
     dataValues.url = url.pathname;
+
+    if (request.server.methods.isAdmin(request)) {
+        try {
+            await validateThemeData(dataValues.data);
+            dataValues.errors = [];
+        } catch (err) {
+            if (err.name === 'ValidationError') {
+                dataValues.errors = err.details;
+            } else {
+                throw err;
+            }
+        }
+    }
 
     const { created_at, ...theme } = dataValues;
     return { createdAt: created_at, ...theme };

--- a/src/routes/themes.js
+++ b/src/routes/themes.js
@@ -2,7 +2,6 @@ const Joi = require('@hapi/joi');
 const Boom = require('@hapi/boom');
 const assign = require('assign-deep');
 const { Theme } = require('@datawrapper/orm/models');
-const { validateThemeData } = require('@datawrapper/schemas');
 
 module.exports = {
     name: 'themes-routes',
@@ -28,7 +27,7 @@ module.exports = {
 };
 
 async function getTheme(request, h) {
-    const { params, query, url } = request;
+    const { server, params, query, url } = request;
 
     let originalExtend;
     let dataValues = { extend: params.id, data: {} };
@@ -66,9 +65,9 @@ ${dataValues.less || ''}
     dataValues.extend = originalExtend;
     dataValues.url = url.pathname;
 
-    if (request.server.methods.isAdmin(request)) {
+    if (server.methods.isAdmin(request)) {
         try {
-            await validateThemeData(dataValues.data);
+            await server.methods.validateThemeData(dataValues.data);
             dataValues.errors = [];
         } catch (err) {
             if (err.name === 'ValidationError') {

--- a/src/server.js
+++ b/src/server.js
@@ -4,6 +4,7 @@ const HapiSwagger = require('hapi-swagger');
 const get = require('lodash/get');
 const ORM = require('@datawrapper/orm');
 const { validateAPI, validateORM, validateFrontend } = require('@datawrapper/schemas/config');
+const schemas = require('@datawrapper/schemas');
 const { findConfigPath } = require('@datawrapper/shared/node/findConfig');
 
 const { generateToken } = require('./utils');
@@ -12,6 +13,8 @@ const { ApiEventEmitter, eventList } = require('./utils/events');
 const pkg = require('../package.json');
 const configPath = findConfigPath();
 const config = require(configPath);
+
+schemas.initialize(config.schemas);
 
 validateAPI(config.api);
 validateORM(config.orm);

--- a/src/server.js
+++ b/src/server.js
@@ -208,22 +208,21 @@ async function start() {
 }
 
 function loadSchemaFromUrl(baseUrl) {
-    const fetch = require('node-fetch');
+    const got = require('got');
     const cache = {};
     return async id => {
         // use cached schema if available
         if (cache[id]) return cache[id];
         // fetch schema from URL
-        return fetch(`${baseUrl}/${id}.json`)
-            .then(res => res.json())
-            .then(json => {
-                cache[id] = json;
-                // delete cache after 5 minutes
-                setTimeout(() => {
-                    delete cache[id];
-                }, 5 * 6e4);
-                return json;
-            });
+        return got(`${baseUrl}/${id}.json`, { json: true }).then(({ body }) => {
+            cache[id] = body;
+            // delete cache after 5 minutes
+            setTimeout(() => {
+                delete cache[id];
+            }, 5 * 6e4);
+
+            return body;
+        });
     };
 }
 


### PR DESCRIPTION
This PR adds schema validation for theme data objects to the `GET /v3/themes/{id}` requests. It uses a newly added `validateThemeData` method exposed by `@datawrapper/schemas` which is hot-loading the Joi schema from a JSON file rather than using the schema linked in node_modules.

Depends on https://github.com/datawrapper/schemas/pull/5