### PR TITLE
fix: only admins can change author_id

### DIFF
--- a/src/routes/charts.js
+++ b/src/routes/charts.js
@@ -699,6 +699,10 @@ async function editChart(request, h) {
         payload.organizationId = folder.org_id ? folder.org_id : null;
     }
 
+    if ('authorId' in payload && !isAdmin) {
+        delete payload.authorId;
+    }
+
     const newData = assign(prepareChart(chart), payload);
 
     chart = await chart.update({ ...decamelizeKeys(newData), metadata: newData.metadata });

--- a/src/routes/charts.test.js
+++ b/src/routes/charts.test.js
@@ -7,6 +7,7 @@ test.before(async t => {
 
     t.context.server = server;
     t.context.data = data;
+    t.context.getUser = getUser;
     t.context.auth = {
         strategy: 'session',
         credentials: data.session,
@@ -106,4 +107,30 @@ test('Should be possible to search in multiple fields', async t => {
         t.is(chart.result.list.length, 1);
         t.is(chart.result.list[0].id, chartId);
     }
+});
+
+test('Users can not change the author ID of a chart', async t => {
+    const { user, session } = await t.context.getUser();
+    let chart = await t.context.server.inject({
+        method: 'POST',
+        url: '/v3/charts',
+        headers: {
+            cookie: `DW-SESSION=${session.id}`
+        }
+    });
+
+    t.is(chart.result.authorId, user.id);
+
+    chart = await t.context.server.inject({
+        method: 'PATCH',
+        url: `/v3/charts/${chart.result.id}`,
+        headers: {
+            cookie: `DW-SESSION=${session.id}`
+        },
+        payload: {
+            authorId: null
+        }
+    });
+
+    t.is(chart.result.authorId, user.id);
 });


### PR DESCRIPTION
Currently you can patch a chart and change author_id, which might have happened through the R library for Lisa.

This fixes it. We should check later on what other logic might be needed.