### PR TITLE
update to orm 3.8 (theme.data and theme.assets are now json fields)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -640,11 +640,12 @@
             }
         },
         "@datawrapper/orm": {
-            "version": "3.7.2",
-            "resolved": "https://registry.npmjs.org/@datawrapper/orm/-/orm-3.7.2.tgz",
-            "integrity": "sha512-BkDCfeFabgu6WLYJDgTlsPFpHXLTG+1KmKZhNMVls9Zf8NhphB85aILSuNptVCKfPCKX+Kg4D/RQ4WRrw9wUXg==",
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/@datawrapper/orm/-/orm-3.8.0.tgz",
+            "integrity": "sha512-T8m/HOU/RmfsRVF5JFftUlhZmJW0sRXIO5RZfARlDzFF7/kvXXjoPr1nEzWLNtxLd0AceZGR4+KGg/johZl5gA==",
             "requires": {
-                "assign-deep": "1.0.1",
+                "assign-deep": "^1.0.1",
+                "merge-deep": "^3.0.2",
                 "mysql2": "1.7.0",
                 "nanoid": "2.1.6",
                 "sequelize": "6.0.0",
@@ -1857,6 +1858,11 @@
             "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
             "dev": true
         },
+        "arr-union": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
         "array-find-index": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -2690,6 +2696,33 @@
             "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
             "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
             "dev": true
+        },
+        "clone-deep": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+            "integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
+            "requires": {
+                "for-own": "^0.1.3",
+                "is-plain-object": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "lazy-cache": "^1.0.3",
+                "shallow-clone": "^0.1.2"
+            },
+            "dependencies": {
+                "is-plain-object": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+                    "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+                    "requires": {
+                        "isobject": "^3.0.1"
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                }
+            }
         },
         "clone-response": {
             "version": "1.0.2",
@@ -4411,6 +4444,19 @@
             "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
             "dev": true
         },
+        "for-in": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+        },
+        "for-own": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+            "requires": {
+                "for-in": "^1.0.1"
+            }
+        },
         "forever-agent": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -5156,6 +5202,11 @@
                 "binary-extensions": "^2.0.0"
             }
         },
+        "is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+        },
         "is-callable": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
@@ -5198,6 +5249,11 @@
             "resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.2.tgz",
             "integrity": "sha512-IOQqts/aHWbiisY5DuPJQ0gcbvaLFCa7fBa9xoLfxBZvQ+ZI/Zh9xoI7Gk+G64N0FdK4AbibytHht2tWgpJWLg==",
             "dev": true
+        },
+        "is-extendable": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
         },
         "is-extglob": {
             "version": "2.1.1",
@@ -5542,6 +5598,14 @@
                 "json-buffer": "3.0.0"
             }
         },
+        "kind-of": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+            "requires": {
+                "is-buffer": "^1.1.5"
+            }
+        },
         "latest-version": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
@@ -5550,6 +5614,11 @@
             "requires": {
                 "package-json": "^6.3.0"
             }
+        },
+        "lazy-cache": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
         },
         "less": {
             "version": "3.10.3",
@@ -6306,6 +6375,16 @@
                 }
             }
         },
+        "merge-deep": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.2.tgz",
+            "integrity": "sha512-T7qC8kg4Zoti1cFd8Cr0M+qaZfOwjlPDEdZIIPPB2JZctjaPM4fX+i7HOId69tAti2fvO6X5ldfYUONDODsrkA==",
+            "requires": {
+                "arr-union": "^3.1.0",
+                "clone-deep": "^0.2.4",
+                "kind-of": "^3.0.2"
+            }
+        },
         "merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -6396,6 +6475,22 @@
                     "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
                     "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
                     "dev": true
+                }
+            }
+        },
+        "mixin-object": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
+            "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
+            "requires": {
+                "for-in": "^0.1.3",
+                "is-extendable": "^0.1.1"
+            },
+            "dependencies": {
+                "for-in": {
+                    "version": "0.1.8",
+                    "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+                    "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE="
                 }
             }
         },
@@ -8662,6 +8757,32 @@
             "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
             "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go=",
             "dev": true
+        },
+        "shallow-clone": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
+            "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
+            "requires": {
+                "is-extendable": "^0.1.1",
+                "kind-of": "^2.0.1",
+                "lazy-cache": "^0.2.3",
+                "mixin-object": "^2.0.1"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                    "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+                    "requires": {
+                        "is-buffer": "^1.0.2"
+                    }
+                },
+                "lazy-cache": {
+                    "version": "0.2.7",
+                    "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+                    "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
+                }
+            }
         },
         "shebang-command": {
             "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "url": "git+https://github.com/datawrapper/datawrapper-api.git"
     },
     "dependencies": {
-        "@datawrapper/orm": "^3.7.2",
+        "@datawrapper/orm": "^3.8.0",
         "@datawrapper/schemas": "^1.3.0",
         "@datawrapper/shared": "0.19.4",
         "@hapi/boom": "8.0.1",


### PR DESCRIPTION
with this PR I am migrating our `datawrapper_api` test database according to https://github.com/datawrapper/datawrapper/pull/281/

before this change is to be deployed the production and staging db needs to be migrated as well!