### PR TITLE
fix: properly update chart metadata

### DIFF
--- a/src/routes/charts.js
+++ b/src/routes/charts.js
@@ -665,7 +665,7 @@ async function editChart(request, h) {
     const user = auth.artifacts;
     const isAdmin = server.methods.isAdmin(request);
 
-    let chart = await Chart.findOne({
+    const chart = await Chart.findOne({
         where: {
             id: params.id,
             deleted: { [Op.not]: true }
@@ -714,7 +714,11 @@ async function editChart(request, h) {
 
     const newData = assign(prepareChart(chart), payload);
 
-    chart = await chart.update({ ...decamelizeKeys(newData), metadata: newData.metadata });
+    await Chart.update(
+        { ...decamelizeKeys(newData), metadata: newData.metadata },
+        { where: { id: chart.id }, limit: 1 }
+    );
+    await chart.reload();
 
     return {
         ...prepareChart(chart),

--- a/src/routes/charts.test.js
+++ b/src/routes/charts.test.js
@@ -170,3 +170,50 @@ test('Users cannot create chart in a team they dont have access to', async t => 
 
     t.is(chart.statusCode, 401);
 });
+
+test('Users can edit chart medatata', async t => {
+    const { session } = await t.context.getUser();
+    let chart = await t.context.server.inject({
+        method: 'POST',
+        url: '/v3/charts',
+        headers: {
+            cookie: `DW-SESSION=${session.id}`
+        },
+        payload: {
+            metadata: {
+                annotate: {
+                    notes: 'note-1'
+                }
+            }
+        }
+    });
+
+    t.is(chart.result.metadata.annotate.notes, 'note-1');
+
+    chart = await t.context.server.inject({
+        method: 'PATCH',
+        url: `/v3/charts/${chart.result.id}`,
+        headers: {
+            cookie: `DW-SESSION=${session.id}`
+        },
+        payload: {
+            metadata: {
+                annotate: {
+                    notes: 'note-2'
+                }
+            }
+        }
+    });
+
+    t.is(chart.result.metadata.annotate.notes, 'note-2');
+
+    chart = await t.context.server.inject({
+        method: 'GET',
+        url: `/v3/charts/${chart.result.id}`,
+        headers: {
+            cookie: `DW-SESSION=${session.id}`
+        }
+    });
+
+    t.is(chart.result.metadata.annotate.notes, 'note-2');
+});


### PR DESCRIPTION
Fixes: https://www.notion.so/datawrapper/changing-metadata-with-PATCH-doesn-t-work-0aa848196955412b81e6479ff7cdbc14

For some reason `Chart.prototype.update` never updated the metadata JSON in our DB even though the Sequelize model represented it correctly. Using `update` does exactly what we want.

I added a test that checks if the `PATCH` and **`GET`** request return the correct metadata object.