### PR TITLE
Don't include deleted products

### DIFF
--- a/src/routes/products.js
+++ b/src/routes/products.js
@@ -10,7 +10,11 @@ module.exports = {
             handler: async function getAllProducts(request, h) {
                 request.server.methods.isAdmin(request, { throwError: true });
 
-                const { rows, count } = await Product.findAndCountAll();
+                const { rows, count } = await Product.findAndCountAll({
+                    where: {
+                        deleted: false
+                    }
+                });
 
                 return {
                     list: rows.map(product => {


### PR DESCRIPTION
This PR excludes products where `product.deleted = true` from the `/products` endpoint.