### PR TITLE
log chart/edit events when charts are edited or created

### DIFF
--- a/src/routes/charts.js
+++ b/src/routes/charts.js
@@ -665,6 +665,8 @@ async function createChart(request, h) {
         id
     });
 
+    await request.server.methods.logAction(user.id, `chart/edit`, chart.id);
+
     return h.response({ ...prepareChart(chart), url: `${url.pathname}/${chart.id}` }).code(201);
 }
 
@@ -727,6 +729,8 @@ async function editChart(request, h) {
         { where: { id: chart.id }, limit: 1 }
     );
     await chart.reload();
+    // log chart edit
+    await request.server.methods.logAction(user.id, `chart/edit`, chart.id);
 
     return {
         ...prepareChart(chart),

--- a/src/routes/charts.js
+++ b/src/routes/charts.js
@@ -665,6 +665,7 @@ async function createChart(request, h) {
         id
     });
 
+    // log chart/edit
     await request.server.methods.logAction(user.id, `chart/edit`, chart.id);
 
     return h.response({ ...prepareChart(chart), url: `${url.pathname}/${chart.id}` }).code(201);
@@ -729,7 +730,7 @@ async function editChart(request, h) {
         { where: { id: chart.id }, limit: 1 }
     );
     await chart.reload();
-    // log chart edit
+    // log chart/edit
     await request.server.methods.logAction(user.id, `chart/edit`, chart.id);
 
     return {

--- a/src/routes/charts.js
+++ b/src/routes/charts.js
@@ -901,8 +901,9 @@ function getAssetWhitelist(id) {
 }
 
 async function writeChartAsset(request, h) {
-    const { params } = request;
+    const { params, auth } = request;
     const { events, event } = request.server.app;
+    const user = auth.artifacts;
     const chart = await loadChart(request);
 
     const isGuestChart = chart.guest_session === request.auth.credentials.session;
@@ -929,6 +930,9 @@ async function writeChartAsset(request, h) {
         });
 
         const { code } = eventResults.find(e => e.status === 'success').data;
+
+        // log chart/edit
+        await request.server.methods.logAction(user.id, `chart/edit`, chart.id);
 
         return h.response().code(code);
     } catch (error) {


### PR DESCRIPTION
It's important to log the `chart/edit` events whenever charts are edited. This is used in several places, for instance to show recently edited charts in the user dashboard.

The PHP app is doing this on ORM level https://github.com/datawrapper/datawrapper/blob/master/lib/core/build/classes/datawrapper/Chart.php#L150-L153

but so far we decided to keep our ORM rather dumb so I added it to the API route that handles chart writes. 

The reason this event is now also logged when charts are created is that this is a use case we haven't considered before: someone creating a fully complete chart with a single `POST /v3/charts` request without further editing it with `PATCH /v3/charts/:id` requests. Using the UI this never happens, but it's possible when people are using the API.