### PR TITLE
load plugins individually and allow them to pass registration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,25 @@ module.exports = {
 }
 ```
 
+You can use the `hapijs` plugin options to prefix all routes defined in your plugin (to avoid repeating the prefix again and again):
+
+```js
+/* api.js */
+module.exports = {
+    name: 'my-plugin',
+    version: '1.0.0',
+    options: {
+        routes: {
+            prefix: '/plugins/my-plugin',
+        }
+    },
+    register: (server, options) => {
+        console.log('hello from my-plugin!')
+        console.log(`the api key is "${options.config.apiKey}"`) // the api key is "agamotto"
+    }
+}
+```
+
 ### Local plugins
 
 Plugins can be loaded from the local file system. This is very useful for plugin development. The plugin needs to be a folder inside the `plugins/` directory, with an `api.js`.

--- a/src/plugin-loader.js
+++ b/src/plugin-loader.js
@@ -26,21 +26,21 @@ module.exports = {
         }
 
         if (plugins.length) {
-            await Promise.all(
-                plugins.map(async ({ plugin, options, error, name }) => {
-                    if (error) {
-                        server.logger().error(`[Plugin] ${error}`, logError(root, name));
-                        return process.exit(1);
-                    }
+            for (const { plugin, options, error, name } of plugins) {
+                if (error) {
+                    server.logger().error(`[Plugin] ${error}`, logError(root, name));
+                    process.exit(1);
+                } else {
                     server.logger().info(
                         {
                             version: get(plugin, ['pkg', 'version'], plugin.version)
                         },
                         `[Plugin] ${get(plugin, ['pkg', 'name'], plugin.name)}`
                     );
-                    return server.register({ plugin, options }, plugin.options);
-                })
-            );
+
+                    await server.register({ plugin, options }, plugin.options);
+                }
+            }
         }
     }
 };

--- a/src/plugin-loader.js
+++ b/src/plugin-loader.js
@@ -30,16 +30,15 @@ module.exports = {
                 plugins.map(async ({ plugin, options, error, name }) => {
                     if (error) {
                         server.logger().error(`[Plugin] ${error}`, logError(root, name));
-                        process.exit(1);
-                    } else {
-                        server.logger().info(
-                            {
-                                version: get(plugin, ['pkg', 'version'], plugin.version)
-                            },
-                            `[Plugin] ${get(plugin, ['pkg', 'name'], plugin.name)}`
-                        );
-                        await server.register({ plugin, options }, plugin.options);
+                        return process.exit(1);
                     }
+                    server.logger().info(
+                        {
+                            version: get(plugin, ['pkg', 'version'], plugin.version)
+                        },
+                        `[Plugin] ${get(plugin, ['pkg', 'name'], plugin.name)}`
+                    );
+                    return server.register({ plugin, options }, plugin.options);
                 })
             );
         }


### PR DESCRIPTION
this PR allows plugins to pass registration options, like the routes prefix:

```js
module.exports = {
    name: 'copy-to-local',
    version: '1.0.0',
    options: {
        routes: {
            prefix: '/plugins/copy-to-local',
        }
    },
    register: require('./src/api/routes')
};
```

see https://hapi.dev/api/?v=19.0.5#-await-serverregisterplugins-options
