### PR TITLE
add tests for /v3/charts/:id/data and /v3/charts/:id/assets/:asset

### DIFF
--- a/src/routes/charts.js
+++ b/src/routes/charts.js
@@ -469,13 +469,11 @@ function register(server, options) {
                 filename
             );
             try {
-                await accessAsync(fn, fs.constants.R_OK);
+                await accessAsync(filePath, fs.constants.R_OK);
             } catch (e) {
                 throw new CodedError(404);
             }
-            return fs.createReadStream(
-                filePath
-            );
+            return fs.createReadStream(filePath);
         });
 
         events.on(event.PUT_CHART_ASSET, async function({ chart, data, filename }) {

--- a/src/routes/charts.js
+++ b/src/routes/charts.js
@@ -474,7 +474,7 @@ function register(server, options) {
                 throw new CodedError(404);
             }
             return fs.createReadStream(
-                path.join(localChartAssetRoot, getDataPath(chart.dataValues.created_at), filename)
+                filePath
             );
         });
 

--- a/src/routes/charts.js
+++ b/src/routes/charts.js
@@ -12,6 +12,7 @@ const CodedError = require('@datawrapper/shared/CodedError');
 const { promisify } = require('util');
 const mkdirAsync = promisify(fs.mkdir);
 const writeFileAsync = promisify(fs.writeFile);
+const accessAsync = promisify(fs.access);
 
 const { listResponse, createResponseConfig, noContentResponse } = require('../schemas/response');
 
@@ -462,6 +463,16 @@ function register(server, options) {
 
     if (!hasRegisteredDataPlugins) {
         events.on(event.GET_CHART_ASSET, async function({ chart, filename }) {
+            const fn = path.join(
+                localChartAssetRoot,
+                getDataPath(chart.dataValues.created_at),
+                filename
+            );
+            try {
+                await accessAsync(fn, fs.constants.R_OK);
+            } catch (e) {
+                throw new CodedError(404);
+            }
             return fs.createReadStream(
                 path.join(localChartAssetRoot, getDataPath(chart.dataValues.created_at), filename)
             );

--- a/src/routes/charts.js
+++ b/src/routes/charts.js
@@ -471,7 +471,7 @@ function register(server, options) {
             try {
                 await accessAsync(filePath, fs.constants.R_OK);
             } catch (e) {
-                throw new CodedError(404);
+                throw new CodedError('notFound');
             }
             return fs.createReadStream(filePath);
         });

--- a/src/routes/charts.js
+++ b/src/routes/charts.js
@@ -463,7 +463,7 @@ function register(server, options) {
 
     if (!hasRegisteredDataPlugins) {
         events.on(event.GET_CHART_ASSET, async function({ chart, filename }) {
-            const fn = path.join(
+            const filePath = path.join(
                 localChartAssetRoot,
                 getDataPath(chart.dataValues.created_at),
                 filename

--- a/src/routes/charts.js
+++ b/src/routes/charts.js
@@ -471,7 +471,7 @@ function register(server, options) {
             try {
                 await accessAsync(filePath, fs.constants.R_OK);
             } catch (e) {
-                throw new CodedError('notFound');
+                throw new CodedError('notFound', 'chart asset not found');
             }
             return fs.createReadStream(filePath);
         });
@@ -898,8 +898,12 @@ async function getChartAsset(request, h) {
             .header('Content-Type', contentType)
             .header('Content-Disposition', `attachment; filename=${filename}`);
     } catch (error) {
+        if (error.name === 'CodedError' && Boom[error.code]) {
+            // this seems to be an orderly error
+            return Boom[error.code](error.message);
+        }
         request.logger.error(error.message);
-        return Boom.notFound();
+        return Boom.badImplementation();
     }
 }
 


### PR DESCRIPTION
also improved error handling in case an asset doesn't exist or isn't readable. instead of the `500 internal server error` the route now returns `404 not found`.