### PR TITLE
get v3 login/signup API ready for production use 

### DIFF
--- a/src/auth/cookie-auth.js
+++ b/src/auth/cookie-auth.js
@@ -32,7 +32,10 @@ function cookieAuth(server, options) {
         ttl: cookieTTL(90),
         isSecure: process.env.NODE_ENV === 'production',
         strictHeader: false,
-        domain: api.domain,
+        domain: `.${api.domain
+            .split('.')
+            .slice(1)
+            .join('.')}`,
         isSameSite: false,
         path: '/'
     });

--- a/src/auth/cookie-auth.js
+++ b/src/auth/cookie-auth.js
@@ -1,5 +1,5 @@
 const Boom = require('@hapi/boom');
-const { cookieTTL } = require('../utils');
+const { cookieTTL, cookieDomain } = require('../utils');
 const { Session } = require('@datawrapper/orm/models');
 const getUser = require('./get-user');
 
@@ -32,10 +32,7 @@ function cookieAuth(server, options) {
         ttl: cookieTTL(90),
         isSecure: process.env.NODE_ENV === 'production',
         strictHeader: false,
-        domain: `.${api.domain
-            .split('.')
-            .slice(1)
-            .join('.')}`,
+        domain: cookieDomain(api),
         isSameSite: false,
         path: '/'
     });

--- a/src/auth/dw-auth.js
+++ b/src/auth/dw-auth.js
@@ -3,6 +3,7 @@ const get = require('lodash/get');
 const AuthBearer = require('hapi-auth-bearer-token');
 const AuthCookie = require('./cookie-auth');
 const getUser = require('./get-user');
+const authUtils = require('./utils.js');
 const { AuthToken } = require('@datawrapper/orm/models');
 
 async function bearerValidation(request, token, h) {
@@ -72,7 +73,12 @@ const DWAuth = {
 
             return check;
         }
+
         server.method('isAdmin', isAdmin);
+        server.method('comparePassword', authUtils.createComparePassword(server));
+
+        const { hashRounds = 15 } = server.methods.config('api');
+        server.method('hashPassword', authUtils.createHashPassword(hashRounds));
 
         server.auth.scheme('dw-auth', dwAuth);
 

--- a/src/auth/utils.js
+++ b/src/auth/utils.js
@@ -1,0 +1,129 @@
+const crypto = require('crypto');
+const bcrypt = require('bcryptjs');
+const { User } = require('@datawrapper/orm/models');
+
+const DEFAULT_SALT = 'uRPAqgUJqNuBdW62bmq3CLszRFkvq4RW';
+
+/**
+ * Generate a sha256 hash from a string. This is used in the PHP API and is needed for backwards
+ * compatibility.
+ *
+ * @param {string} pwhash - value to hash with sha256
+ * @param {string} secret - salt to hash the value with
+ * @returns {string}
+ */
+function legacyHash(pwhash, secret = DEFAULT_SALT) {
+    const hmac = crypto.createHmac('sha256', secret);
+    hmac.update(pwhash);
+    return hmac.digest('hex');
+}
+
+/**
+ * The old PHP API used sha256 to hash passwords with constant salts.
+ * The Node.js API uses bcrypt which is more secure.
+ * It is still important to support the old way for migration purposes since PHP and Node API
+ * will live side by side for some time.
+ * When the PHP Server gets turned off, we can hopefully delete this function.
+ *
+ * @deprecated
+ * @param {string} password - Password string sent from the client (Can be client side hashed or not)
+ * @param {string} passwordHash - Password hash to compare (from DB)
+ * @param {string} authSalt - defined in config.js
+ * @param {string} secretAuthSalt - defined in config.js
+ * @returns {boolean}
+ */
+function legacyLogin(password, passwordHash, authSalt, secretAuthSalt) {
+    let serverHash = secretAuthSalt ? legacyHash(password, secretAuthSalt) : password;
+
+    if (serverHash === passwordHash) return true;
+
+    const clientHash = legacyHash(password, authSalt);
+    serverHash = secretAuthSalt ? legacyHash(clientHash, secretAuthSalt) : clientHash;
+    return serverHash === passwordHash;
+}
+
+/**
+ * Migrate the old sha256 password hash to a more modern and secure bcrypt hash.
+ *
+ * @param {number} userId - ID of the user to migrate
+ * @param {string} password - User password
+ * @param {number} hashRounds - Iteration amout for bcrypt
+ */
+async function migrateHashToBcrypt(userId, password, hashRounds) {
+    const hash = await bcrypt.hash(password, hashRounds);
+
+    await User.update(
+        {
+            pwd: hash
+        },
+        { where: { id: userId } }
+    );
+}
+
+/**
+ * Hash a password with bcrypt. This function doesn't need to be directly imported since it's
+ * exposed on the Hapi server object as server method.
+ *
+ * @example
+ * const hash = await server.methods.hashPassword('hunter2')
+ *
+ * @param {number} hashRounds - Number of rounds for the brypt algorithm
+ */
+function createHashPassword(hashRounds) {
+    return async function hashPassword(password) {
+        return password === '' ? password : bcrypt.hash(password, hashRounds);
+    };
+}
+
+function createComparePassword(server) {
+    /**
+     * Check validity of a password against the saved password hash
+     *
+     * @param {string} password - Plaintext password to check
+     * @param {string} passwordHash - Password hash to compare (from DB)
+     * @param {object} options
+     * @param {number} options.userId - User ID for hash migration
+     * @returns {Boolean}
+     */
+    return async function comparePassword(password, passwordHash, { userId }) {
+        const { api } = server.methods.config();
+        let isValid = false;
+        /**
+         * Bcrypt uses a prefix for versioning. That way a bcrypt hash can be identified with "$2".
+         * https://en.wikipedia.org/wiki/Bcrypt#Description
+         */
+        if (passwordHash.startsWith('$2')) {
+            isValid = await bcrypt.compare(password, passwordHash);
+            /**
+             * Due to the migration from sha256 to bcrypt, the API must deal with sha256 passwords that
+             * got created by the PHP API and migrated from the `migrateHashToBcrypt` function.
+             * The node API get's passwords only in clear text and to compare those with a migrated
+             * password, it first has to generate the former client hashed password.
+             */
+            if (!isValid) {
+                isValid = await bcrypt.compare(legacyHash(password, api.authSalt), passwordHash);
+            }
+        } else {
+            /**
+             * The user password hash was created by the PHP API and is not a bcrypt hash. That means
+             * the API needs to use the old comparison method with double sha256 hashes.
+             */
+            isValid = legacyLogin(password, passwordHash, api.authSalt, api.secretAuthSalt);
+
+            /**
+             * When the old method works, the API migrates the old hash to a bcrypt hash for more
+             * security. This ensures a seemless migration for users.
+             */
+            if (isValid && userId && api.enableMigration) {
+                await migrateHashToBcrypt(userId, password, api.hashRounds);
+            }
+        }
+        return isValid;
+    };
+}
+
+module.exports = {
+    legacyHash,
+    createHashPassword,
+    createComparePassword
+};

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -553,7 +553,6 @@ async function signup(request, h) {
 
     if (request.auth.isAuthenticated) {
         session = await Session.findByPk(request.auth.credentials.session);
-
         if (session.data['dw-user-id']) {
             return Boom.badRequest('Impossible to sign up with active user session');
         }

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -523,12 +523,16 @@ async function resetPassword(request, h) {
     }
 
     const user = await User.findOne({
-        attributes: ['id', 'language', 'email'],
+        attributes: ['id', 'language', 'email', 'reset_password_token'],
         where: { email: request.payload.email }
     });
 
     if (!user) {
         return Boom.notFound();
+    }
+
+    if (user.reset_password_token) {
+        return Boom.badRequest('token-already-set');
     }
 
     await user.update({ reset_password_token: token });

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -587,11 +587,9 @@ async function signup(request, h) {
         session = await createSession(generateToken(), res.result.id);
     }
 
-    const { activateToken, ...data } = res.result;
-
     const api = config('api');
 
-    return h.response(camelizeKeys(data)).state(api.sessionID, session.id, {
+    return h.response(res.result).state(api.sessionID, session.id, {
         domain: `.${api.domain
             .split('.')
             .slice(1)

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -528,7 +528,7 @@ async function resetPassword(request, h) {
     });
 
     if (!user) {
-        return Boom.notFound();
+        return Boom.notFound('email-not-found');
     }
 
     if (user.reset_password_token) {

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -561,8 +561,6 @@ async function signup(request, h) {
 
     const { generateToken, config } = request.server.methods;
 
-    request.payload.activate_token = generateToken();
-
     const res = await request.server.inject({
         method: 'POST',
         url: '/v3/users',
@@ -591,18 +589,6 @@ async function signup(request, h) {
 
     const { activateToken, ...data } = res.result;
 
-    const { https, domain } = config('frontend');
-
-    await request.server.app.events.emit(request.server.app.event.SEND_EMAIL, {
-        type: 'activation',
-        to: data.email,
-        language: data.language,
-        data: {
-            activation_link: `${
-                https ? 'https' : 'http'
-            }://${domain}/account/activate/${activateToken}`
-        }
-    });
     const api = config('api');
 
     return h.response(camelizeKeys(data)).state(api.sessionID, session.id, {

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -151,7 +151,9 @@ module.exports = {
                             .description('User activation token')
                     }),
                     payload: Joi.object({
-                        password: Joi.string().min(8).description('New password of the user.')
+                        password: Joi.string()
+                            .min(8)
+                            .description('New password of the user.')
                     })
                 }
             },
@@ -209,7 +211,8 @@ module.exports = {
                 },
                 validate: {
                     payload: Joi.object({
-                        password: Joi.string().min(8)
+                        password: Joi.string()
+                            .min(8)
                             .required()
                             .example('tales-126')
                             .description(

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -209,11 +209,6 @@ module.exports = {
                 },
                 validate: {
                     payload: Joi.object({
-                        email: Joi.string()
-                            .email()
-                            .required()
-                            .example('strange@kamar-taj.com.np')
-                            .description('Email address of the user.'),
                         password: Joi.string()
                             .required()
                             .example('tales-126')
@@ -556,12 +551,12 @@ async function resetPassword(request, h) {
 
 async function changePassword(request, h) {
     const { server, payload } = request;
-    const { token, password, email } = payload;
+    const { token, password } = payload;
 
-    if (!token || !email) return Boom.badRequest();
+    if (!token || !password) return Boom.badRequest();
 
     const user = await User.findOne({
-        where: { email: email, reset_password_token: token }
+        where: { reset_password_token: token }
     });
 
     if (user) {

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -149,6 +149,9 @@ module.exports = {
                         token: Joi.string()
                             .required()
                             .description('User activation token')
+                    }),
+                    payload: Joi.object({
+                        password: Joi.string().description('New password of the user.')
                     })
                 }
             },
@@ -492,7 +495,14 @@ async function activateAccount(request, h) {
         return Boom.notFound();
     }
 
-    user = await user.update({ role: 'editor', activate_token: null });
+    const userData = { role: 'editor', activate_token: null };
+
+    const { password } = request.payload;
+    if (password) {
+        userData.pwd = await request.server.methods.hashPassword(password);
+    }
+
+    user = await user.update(userData);
 
     const response = h.response().code(204);
 

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,5 +1,3 @@
-const bcrypt = require('bcryptjs');
-const crypto = require('crypto');
 const { Op } = require('@datawrapper/orm').db;
 const { camelizeKeys } = require('humps');
 const Joi = require('@hapi/joi');
@@ -10,64 +8,6 @@ const get = require('lodash/get');
 const { cookieTTL } = require('../utils');
 const { listResponse, noContentResponse, createResponseConfig } = require('../schemas/response.js');
 const { createUserPayloadValidation } = require('./users');
-
-const DEFAULT_SALT = 'uRPAqgUJqNuBdW62bmq3CLszRFkvq4RW';
-
-/**
- * Generate a sha256 hash from a string. This is used in the PHP API and is needed for backwards
- * compatibility.
- *
- * @param {string} pwhash - value to hash with sha256
- * @param {string} secret - salt to hash the value with
- * @returns {string}
- */
-function legacyHash(pwhash, secret = DEFAULT_SALT) {
-    const hmac = crypto.createHmac('sha256', secret);
-    hmac.update(pwhash);
-    return hmac.digest('hex');
-}
-
-/**
- * The old PHP API used sha256 to hash passwords with constant salts.
- * The Node.js API uses bcrypt which is more secure.
- * It is still important to support the old way for migration purposes since PHP and Node API
- * will live side by side for some time.
- * When the PHP Server gets turned off, we can hopefully delete this function.
- *
- * @deprecated
- * @param {string} password - Password string sent from the client (Can be client side hashed or not)
- * @param {string} passwordHash - Password hash to compare (from DB)
- * @param {string} authSalt - defined in config.js
- * @param {string} secretAuthSalt - defined in config.js
- * @returns {boolean}
- */
-function legacyLogin(password, passwordHash, authSalt, secretAuthSalt) {
-    let serverHash = secretAuthSalt ? legacyHash(password, secretAuthSalt) : password;
-
-    if (serverHash === passwordHash) return true;
-
-    const clientHash = legacyHash(password, authSalt);
-    serverHash = secretAuthSalt ? legacyHash(clientHash, secretAuthSalt) : clientHash;
-    return serverHash === passwordHash;
-}
-
-/**
- * Migrate the old sha256 password hash to a more modern and secure bcrypt hash.
- *
- * @param {number} userId - ID of the user to migrate
- * @param {string} password - User password
- * @param {number} hashRounds - Iteration amout for bcrypt
- */
-async function migrateHashToBcrypt(userId, password, hashRounds) {
-    const hash = await bcrypt.hash(password, hashRounds);
-
-    await User.update(
-        {
-            pwd: hash
-        },
-        { where: { id: userId } }
-    );
-}
 
 module.exports = {
     name: 'auth-routes',
@@ -296,9 +236,7 @@ module.exports = {
             },
             handler: handleSession
         });
-    },
-    legacyLogin,
-    legacyHash
+    }
 };
 
 async function createSession(id, userId, keepSession = true) {
@@ -361,41 +299,12 @@ async function login(request, h) {
         return Boom.unauthorized('Invalid credentials');
     }
 
-    let isValid = false;
-    const { generateToken, config } = request.server.methods;
+    const { generateToken, config, comparePassword } = request.server.methods;
     const api = config('api');
 
-    /**
-     * Bcrypt uses a prefix for versioning. That way a bcrypt hash can be identified with "$2".
-     * https://en.wikipedia.org/wiki/Bcrypt#Description
-     */
-    if (user.pwd.startsWith('$2')) {
-        isValid = await bcrypt.compare(password, user.pwd);
-
-        /**
-         * Due to the migration from sha256 to bcrypt, the API must deal with sha256 passwords that
-         * got created by the PHP API and migrated from the `migrateHashToBcrypt` function.
-         * The node API get's passwords only in clear text and to compare those with a migrated
-         * password, it first has to generate the former client hashed password.
-         */
-        if (!isValid) {
-            isValid = await bcrypt.compare(legacyHash(password, api.authSalt), user.pwd);
-        }
-    } else {
-        /**
-         * The user password hash was created by the PHP API and is not a bcrypt hash. That means
-         * the API needs to use the old comparison method with double sha256 hashes.
-         */
-        isValid = legacyLogin(password, user.pwd, api.authSalt, api.secretAuthSalt);
-
-        /**
-         * When the old method works, the API migrates the old hash to a bcrypt hash for more
-         * security. This ensures a seemless migration for users.
-         */
-        if (isValid && api.enableMigration) {
-            await migrateHashToBcrypt(user.id, password, api.hashRounds);
-        }
-    }
+    let isValid = await comparePassword(password, user.pwd, {
+        userId: user.id
+    });
 
     if (!isValid && password === user.reset_password_token) {
         isValid = true;

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -297,7 +297,8 @@ module.exports = {
             handler: handleSession
         });
     },
-    legacyLogin
+    legacyLogin,
+    legacyHash
 };
 
 async function createSession(id, userId, keepSession = true) {

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -296,7 +296,8 @@ module.exports = {
             },
             handler: handleSession
         });
-    }
+    },
+    legacyLogin
 };
 
 async function createSession(id, userId, keepSession = true) {

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -151,7 +151,7 @@ module.exports = {
                             .description('User activation token')
                     }),
                     payload: Joi.object({
-                        password: Joi.string().description('New password of the user.')
+                        password: Joi.string().min(8).description('New password of the user.')
                     })
                 }
             },

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -358,6 +358,10 @@ async function handleSession(request, h) {
             [api.sessionID]: session.id
         })
         .state(api.sessionID, session.id, {
+            domain: `.${api.domain
+                .split('.')
+                .slice(1)
+                .join('.')}`,
             ttl: cookieTTL(30)
         });
 }
@@ -443,6 +447,10 @@ async function login(request, h) {
             [api.sessionID]: session.id
         })
         .state(api.sessionID, session.id, {
+            domain: `.${api.domain
+                .split('.')
+                .slice(1)
+                .join('.')}`,
             ttl: cookieTTL(keepSession ? 90 : 30)
         });
 }
@@ -595,8 +603,13 @@ async function signup(request, h) {
             }://${domain}/account/activate/${activateToken}`
         }
     });
+    const api = config('api');
 
-    return h.response(camelizeKeys(data)).state(config('api').sessionID, session.id, {
+    return h.response(camelizeKeys(data)).state(api.sessionID, session.id, {
+        domain: `.${api.domain
+            .split('.')
+            .slice(1)
+            .join('.')}`,
         ttl: cookieTTL(90)
     });
 }
@@ -616,10 +629,14 @@ async function activateAccount(request, h) {
     const response = h.response().code(204);
 
     if (!request.auth.credentials) {
-        const { sessionID } = request.server.methods.config('api');
+        const { domain, sessionID } = request.server.methods.config('api');
         const session = await createSession(request.server.methods.generateToken(), user.id);
 
         response.state(sessionID, session.id, {
+            domain: `.${domain
+                .split('.')
+                .slice(1)
+                .join('.')}`,
             ttl: cookieTTL(90)
         });
     }

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -7,7 +7,7 @@ const Boom = require('@hapi/boom');
 const { User, Session, AuthToken, Chart } = require('@datawrapper/orm/models');
 const set = require('lodash/set');
 const get = require('lodash/get');
-const { cookieTTL, cookieDomain } = require('../utils');
+const { cookieTTL } = require('../utils');
 const { listResponse, noContentResponse, createResponseConfig } = require('../schemas/response.js');
 const { createUserPayloadValidation } = require('./users');
 
@@ -345,7 +345,6 @@ async function handleSession(request, h) {
             [api.sessionID]: session.id
         })
         .state(api.sessionID, session.id, {
-            domain: cookieDomain(api),
             ttl: cookieTTL(30)
         });
 }
@@ -431,7 +430,6 @@ async function login(request, h) {
             [api.sessionID]: session.id
         })
         .state(api.sessionID, session.id, {
-            domain: cookieDomain(api),
             ttl: cookieTTL(keepSession ? 90 : 30)
         });
 }
@@ -570,7 +568,6 @@ async function signup(request, h) {
     const api = config('api');
 
     return h.response(res.result).state(api.sessionID, session.id, {
-        domain: cookieDomain(api),
         ttl: cookieTTL(90)
     });
 }
@@ -594,7 +591,6 @@ async function activateAccount(request, h) {
         const session = await createSession(request.server.methods.generateToken(), user.id);
 
         response.state(api.sessionID, session.id, {
-            domain: cookieDomain(api),
             ttl: cookieTTL(90)
         });
     }

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -209,7 +209,7 @@ module.exports = {
                 },
                 validate: {
                     payload: Joi.object({
-                        password: Joi.string()
+                        password: Joi.string().min(8)
                             .required()
                             .example('tales-126')
                             .description(

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -222,6 +222,7 @@ module.exports = {
                             ),
                         token: Joi.string()
                             .example('shamballa')
+                            .required()
                             .description('Password reset token which is send as email to the user.')
                     })
                 }

--- a/src/routes/me.js
+++ b/src/routes/me.js
@@ -51,7 +51,7 @@ module.exports = {
                         language: Joi.string()
                             .example('en_US')
                             .description('Your new language preference.'),
-                        password: Joi.string()
+                        password: Joi.string().min(8)
                             .example('13-binary-1968')
                             .description('Strong user password.'),
                         oldPassword: Joi.string().description('The previous user password.')

--- a/src/routes/me.js
+++ b/src/routes/me.js
@@ -51,7 +51,8 @@ module.exports = {
                         language: Joi.string()
                             .example('en_US')
                             .description('Your new language preference.'),
-                        password: Joi.string().min(8)
+                        password: Joi.string()
+                            .min(8)
                             .example('13-binary-1968')
                             .description('Strong user password.'),
                         oldPassword: Joi.string().description('The previous user password.')

--- a/src/routes/me.js
+++ b/src/routes/me.js
@@ -102,7 +102,10 @@ module.exports = {
                         email: Joi.string()
                             .email()
                             .example('zola@hydra.com')
-                            .description('User email address to confirm deletion.')
+                            .description('User email address to confirm deletion.'),
+                        password: Joi.string()
+                            .required()
+                            .description('User password to confirm deletion')
                     })
                 },
                 response: noContentResponse

--- a/src/routes/me.js
+++ b/src/routes/me.js
@@ -50,7 +50,11 @@ module.exports = {
                             ),
                         language: Joi.string()
                             .example('en_US')
-                            .description('Your new language preference.')
+                            .description('Your new language preference.'),
+                        password: Joi.string()
+                            .example('13-binary-1968')
+                            .description('Strong user password.'),
+                        oldPassword: Joi.string().description('The previous user password.')
                     })
                 },
                 response: meResponse

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -40,6 +40,7 @@ const createUserPayloadValidation = [
             .description('User language preference. This can be omitted.'),
         password: Joi.string()
             .example('13-binary-1968')
+            .min(8)
             .required()
             .description('Strong user password.'),
         invitation: Joi.boolean()
@@ -153,6 +154,7 @@ module.exports = {
                             ),
                         password: Joi.string()
                             .example('13-binary-1968')
+                            .min(8)
                             .description('Strong user password.'),
                         oldPassword: Joi.string().description('The previous user password.')
                     })

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -437,7 +437,7 @@ async function editUser(request, h) {
             data.pwd = await hashPassword(payload.password);
         }
     } else {
-        // non-admins need to confirm email and password changes
+        // all users need to confirm their email and password changes
         if (payload.email) {
             // check if email has changed
             const oldUser = await User.findByPk(userId);

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -264,7 +264,7 @@ async function isDeleted(id) {
 
 function hashPassword(hashRounds) {
     return async function(password) {
-        return bcrypt.hash(password, hashRounds);
+        return password === '' ? password : bcrypt.hash(password, hashRounds);
     };
 }
 
@@ -426,8 +426,9 @@ async function editUser(request, h) {
         data.email = payload.email;
         data.activateToken = payload.activateToken;
         data.role = payload.role;
-        data.pwd =
-            payload.password === '' ? payload.password : await hashPassword(payload.password);
+        if (payload.password) {
+            data.pwd = await hashPassword(payload.password);
+        }
     } else {
         // non-admins need to confirm email and password changes
         if (payload.email) {

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -497,7 +497,7 @@ async function createUser(request, h) {
         name: data.name,
         email: data.email,
         language: data.language, // session language?
-        activateToken: generateToken()
+        activate_token: generateToken()
     };
 
     if (!isInvitation) {

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -418,6 +418,14 @@ async function editUser(request, h) {
         name: payload.name
     };
 
+    if (payload.email) {
+        // see if there already is an existing user with that email address
+        const existingUser = await User.findOne({ where: { email: payload.email } });
+        if (existingUser) {
+            return Boom.conflict('email-already-exists');
+        }
+    }
+
     if (isAdmin(request)) {
         // admins can update user without confirmation
         data.email = payload.email;

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -428,8 +428,8 @@ async function editUser(request, h) {
         }
     }
 
-    if (isAdmin(request)) {
-        // admins can update user without confirmation
+    if (isAdmin(request) && userId !== auth.artifacts.id) {
+        // admins can update other users without confirmation
         data.email = payload.email;
         data.activateToken = payload.activateToken;
         data.role = payload.role;

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -451,7 +451,7 @@ async function editUser(request, h) {
     const user = await getUser(request, h);
 
     return {
-        ...user,
+        ...camelizeKeys(user.serialize()),
         updatedAt
     };
 }
@@ -521,9 +521,8 @@ async function createUser(request, h) {
         newUser.role = data.role;
     }
 
-    const { role, dataValues } = await User.create(newUser);
+    const user = await User.create(newUser);
 
-    const { pwd, ...user } = dataValues;
     const { count } = await Chart.findAndCountAll({ where: { author_id: user.id } });
 
     const { https, domain } = config('frontend');
@@ -547,8 +546,7 @@ async function createUser(request, h) {
 
     return h
         .response({
-            ...camelizeKeys(user),
-            role,
+            ...camelizeKeys(user.serialize()),
             url: `${request.url.pathname}/${user.id}`,
             chartCount: count,
             createdAt: request.server.methods.isAdmin(request) ? user.created_at : undefined

--- a/src/routes/users.test.js
+++ b/src/routes/users.test.js
@@ -10,7 +10,7 @@ test.before(async t => {
     });
     t.context.server = server;
 
-    t.context.legacyHash = require('./auth').legacyHash;
+    t.context.legacyHash = require('../auth/utils').legacyHash;
 
     t.context.user = await getUser();
     t.context.admin = await getUser('admin');

--- a/src/routes/users.test.js
+++ b/src/routes/users.test.js
@@ -510,6 +510,26 @@ test('Users can change allowed fields', async t => {
     t.is(user.language, allowedFields.language);
 });
 
+test.only('User cannot change email if it already exists', async t => {
+    const { user: user1, session } = await t.context.getUser();
+    const { user: user2 } = await t.context.getUser();
+
+    const { result, statusCode } = await t.context.server.inject({
+        method: 'PATCH',
+        url: `/v3/users/${user1.id}`,
+        headers: {
+            cookie: `DW-SESSION=${session.id}`,
+            'Content-Type': 'application/json'
+        },
+        payload: {
+            email: user2.email
+        }
+    });
+
+    t.is(statusCode, 409);
+    t.is(result.message, 'email-already-exists');
+});
+
 test('User cannot change password without old password', async t => {
     const { legacyHash, server, user: contextUser } = t.context;
     const { authSalt, secretAuthSalt } = server.methods.config('api');

--- a/src/routes/users.test.js
+++ b/src/routes/users.test.js
@@ -510,7 +510,7 @@ test('Users can change allowed fields', async t => {
     t.is(user.language, allowedFields.language);
 });
 
-test.only('User cannot change email if it already exists', async t => {
+test('User cannot change email if it already exists', async t => {
     const { user: user1, session } = await t.context.getUser();
     const { user: user2 } = await t.context.getUser();
 

--- a/src/routes/users.test.js
+++ b/src/routes/users.test.js
@@ -477,7 +477,7 @@ test('Users can change allowed fields', async t => {
 
     const allowedFields = {
         name: 'My new name',
-        email: `new-${Math.round(Math.random() * 1e6).toString(36)}@example.com`,
+        email: t.context.getCredentials().email
         language: 'de_DE'
     };
 

--- a/src/routes/users.test.js
+++ b/src/routes/users.test.js
@@ -1,22 +1,16 @@
 import test from 'ava';
 import sortBy from 'lodash/sortBy';
-import crypto from 'crypto';
-import { decamelize, decamelizeKeys } from 'humps';
+import { decamelize } from 'humps';
 
 import { setup } from '../../test/helpers/setup';
-import { api } from '../../config.js';
-
-function legacyHash(pwhash, secret) {
-    const hmac = crypto.createHmac('sha256', secret);
-    hmac.update(pwhash);
-    return hmac.digest('hex');
-}
 
 test.before(async t => {
     const { server, models, getUser, getTeamWithUser, getCredentials, addToCleanup } = await setup({
         usePlugins: false
     });
     t.context.server = server;
+
+    t.context.legacyHash = require('./auth').legacyHash;
 
     t.context.user = await getUser();
     t.context.admin = await getUser('admin');
@@ -124,23 +118,16 @@ test("New users can't set protected fields", async t => {
         customerId: 12345,
         oauthSignin: 'blub'
     };
+
     /* create user with email and some data */
-    const { result } = await t.context.server.inject({
+    const { result, statusCode } = await t.context.server.inject({
         method: 'POST',
         url: '/v3/users',
         payload: { ...credentials, ...fields }
     });
 
-    t.log('User created', result.email);
-
-    const user = await t.context.models.User.findByPk(result.id, {
-        attributes: Object.keys(decamelizeKeys(fields))
-    });
-
-    for (const f in fields) {
-        t.not(user[decamelize(f)], fields[f]);
-    }
-    await t.context.addToCleanup('user', result.id);
+    t.log(result.message);
+    t.is(statusCode, 400);
 });
 
 test('GET /users/:id - should include teams when fetched as admin', async t => {
@@ -484,18 +471,21 @@ test("Users can't change protected fields using PATCH", async t => {
 });
 
 test('Users can change allowed fields', async t => {
-    let user = await t.context.getUser();
+    let { user, session } = await t.context.getUser();
+
+    const oldEmail = user.email;
 
     const allowedFields = {
         name: 'My new name',
-        email: 'new@example.com'
+        email: 'new@example.com',
+        language: 'de_DE'
     };
 
     const res = await t.context.server.inject({
         method: 'PATCH',
-        url: `/v3/users/${user.user.id}`,
+        url: `/v3/users/${user.id}`,
         headers: {
-            cookie: `DW-SESSION=${user.session.id}`,
+            cookie: `DW-SESSION=${session.id}`,
             'Content-Type': 'application/json'
         },
         payload: allowedFields
@@ -503,17 +493,30 @@ test('Users can change allowed fields', async t => {
 
     t.is(res.statusCode, 200);
 
-    user = await user.user.reload();
-    for (const f in allowedFields) {
-        t.is(user[decamelize(f)], allowedFields[f]);
-    }
+    user = await user.reload();
+
+    const action = await t.context.models.Action.findOne({
+        where: {
+            user_id: user.id
+        }
+    });
+
+    const details = JSON.parse(action.details);
+
+    t.is(details['old-email'], oldEmail);
+    t.is(details['new-email'], allowedFields.email);
+    t.truthy(details.token);
+    t.is(user.name, allowedFields.name);
+    t.is(user.language, allowedFields.language);
 });
 
-test.only('User cannot change password without old password', async t => {
-    const { session, user } = t.context.user;
+test('User cannot change password without old password', async t => {
+    const { legacyHash, server, user: contextUser } = t.context;
+    const { authSalt, secretAuthSalt } = server.methods.config('api');
+    const { session, user } = contextUser;
 
-    const patchMe = async payload => {
-        return t.context.server.inject({
+    const patchMe = async payload =>
+        t.context.server.inject({
             method: 'PATCH',
             url: '/v3/me',
             headers: {
@@ -521,37 +524,43 @@ test.only('User cannot change password without old password', async t => {
             },
             payload
         });
-    };
 
     const oldPwdHash = user.pwd;
     // try to change without password
-    t.is((await patchMe({ password: 'new-password' })).statusCode, 401);
+    let res = await patchMe({ password: 'new-password' });
+    t.is(res.statusCode, 401);
+
     // check that password hash is still the same
     await user.reload();
     t.is(user.pwd, oldPwdHash);
+
     // try to change with false password
-    t.is((await patchMe({ password: 'new-password', oldPassword: 'I dont know' })).statusCode, 401);
+    res = await patchMe({ password: 'new-password', oldPassword: 'I dont know' });
+    t.is(res.statusCode, 401);
+
     // check that password hash is still the same
     await user.reload();
     t.is(user.pwd, oldPwdHash);
+
     // try to change with correct password
-    t.is(
-        (await patchMe({ password: 'new-password', oldPassword: 'test-password' })).statusCode,
-        200
-    );
+    res = await patchMe({ password: 'new-password', oldPassword: 'test-password' });
+    t.is(res.statusCode, 200);
+
     // check that password hash is still the same
     await user.reload();
     t.not(user.pwd, oldPwdHash);
-    // try the same with legacy login
-    await user.update({ pwd: legacyHash('legacy-password', api.authSalt) });
+
+    // try the same with legacy login (tests have secret salt configured)
+    const legacyPwd = legacyHash(legacyHash('legacy-password', authSalt), secretAuthSalt);
+    await user.update({ pwd: legacyPwd });
+
     // test is changing password also works with legacy hashes
-    t.is(
-        (await patchMe({ password: 'new-password', oldPassword: 'wrong-legacy-password' }))
-            .statusCode,
-        401
-    );
-    t.is(
-        (await patchMe({ password: 'new-password', oldPassword: 'legacy-password' })).statusCode,
-        200
-    );
+    res = await patchMe({
+        password: 'new-password',
+        oldPassword: 'wrong-legacy-password'
+    });
+    t.is(res.statusCode, 401);
+
+    res = await patchMe({ password: 'new-password', oldPassword: 'legacy-password' });
+    t.is(res.statusCode, 200);
 });

--- a/src/routes/users.test.js
+++ b/src/routes/users.test.js
@@ -477,7 +477,7 @@ test('Users can change allowed fields', async t => {
 
     const allowedFields = {
         name: 'My new name',
-        email: t.context.getCredentials().email
+        email: t.context.getCredentials().email,
         language: 'de_DE'
     };
 

--- a/src/routes/users.test.js
+++ b/src/routes/users.test.js
@@ -477,7 +477,7 @@ test('Users can change allowed fields', async t => {
 
     const allowedFields = {
         name: 'My new name',
-        email: 'new@example.com',
+        email: `new-${Math.round(Math.random() * 1e6).toString(36)}@example.com`,
         language: 'de_DE'
     };
 
@@ -571,7 +571,8 @@ test('User cannot change password without old password', async t => {
     t.not(user.pwd, oldPwdHash);
 
     // try the same with legacy login (tests have secret salt configured)
-    const legacyPwd = legacyHash(legacyHash('legacy-password', authSalt), secretAuthSalt);
+    let legacyPwd = legacyHash('legacy-password', authSalt);
+    if (secretAuthSalt) legacyPwd = legacyHash(legacyPwd, secretAuthSalt);
     await user.update({ pwd: legacyPwd });
 
     // test is changing password also works with legacy hashes

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -32,7 +32,10 @@ class ApiEventEmitter extends EventEmitter {
                 const result = await func(data);
                 return { status: 'success', data: result };
             } catch (error) {
-                this.logger().error(error, `[Event] ${event}`);
+                if (error.name !== 'CodedError') {
+                    // only log unknown errors
+                    this.logger().error(error, `[Event] ${event}`);
+                }
                 return { status: 'error', error };
             }
         });

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -13,4 +13,25 @@ utils.generateToken = (length = 25) => {
 
 utils.noop = () => {};
 
+/**
+ * returns the domain used for session cookies
+ *
+ * @param {object} api - the config.api section
+ * @returns {string}
+ */
+utils.cookieDomain = api => {
+    // allow manual override of cookie domain
+    if (api.cookieDomain) return api.cookieDomain;
+    // try to guess the cookie domain from api domain
+    // check how many parts the domain has
+    const parts = api.domain.split('.');
+    // for domains like 'localhost' we return the full
+    // api domain, thereby making the cookie impossible to
+    // access from the frontend
+    if (parts.length < 3) return api.domain;
+    // trim off first part and prepend a dot e.g.
+    // api.datawrapper.local --> .datawrapper.local
+    return '.' + parts.slice(1).join('.');
+};
+
 module.exports = utils;


### PR DESCRIPTION
Decided against doing several smaller PRs that build upon each other and will still put all changes into this PR.

Here's an overview of the changes:

### Email change confirmation emails
We're now sending  out **email change confirmation** email if non-admins attempt to change the email address of their user account (either through `PUT /v3/users/:id` or `PUT /v3/me`)

### Account invitation & account activation emails
We're now sending out proper **invitation & account activation emails** on user signup (either through `POST /v3/users` or `POST /v3/auth/signup`). The only difference between the two endpoints is that `/v3/auth/signup` will also set the session cookie (so the user is logged in right away) and that `/v3/auth/signup` rejects request from authorized users (so it can't be used by admins to create new users).

### Cross-domain session cookies
All session cookies will now work **across subdomains**. Before this PR, the API didn't explicitly set a cookie domain so `api.datawrapper.de` was used by default. This meant that cookies couldn't be used on `app.datawrapper.de` etc. The behavior of the old API was to set `.datawrapper.de` as cookie domain, and the new API does the same.
* more precisely there are two ways one can configure the cookie domain: the first is to auto-generate the cookie doman from `api.domain` config. This assumes that the frontend and api services are sharing the **same parent domain** (e.g. `app.datawrapper.de` and `api.datawrapper.de`). 
* alternatively the config settings `api.cookieDomain` can be used to manually set a custom cookie domain. this is useful in case the datawrapper services are configured run under **different parent domains** (e.g. `datawrapper.apis.e-corp.com` and `datawrapper.frontend.e-corp.com`. in this example one needs to set the `cookieDomain` to `.e-corp.com`)

### Password change requires previous password
Non-admins can no longer **change their passwords** without providing their old password with the request. This is an extra layer of security to prevent account take-overs. This affects both `PUT /v3/users/:id` and `PUT /v3/me`.

### Account deletion requires password
In `DELETE /v3/me` and non-admin `DELETE /v3/users/:id` request the **password must be provided as confirmation** on top of the email address. This is a layer of protection against deleting an account with a stolen API token (and it's how this endpoint was implemented in the legacy api).
