### PR TITLE
fix: let all tests run and fix some errors

### DIFF
--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -297,7 +297,8 @@ module.exports = {
             handler: handleSession
         });
     },
-    legacyLogin
+    legacyLogin,
+    legacyHash
 };
 
 async function createSession(id, userId, keepSession = true) {


### PR DESCRIPTION
I removed the `.only` to make all users tests run and fixed some small logic errors.

* use `legacyHash` from `auth.js` in tests
* use `api` config object through `t.context.server.methods.config('api')`
* double `legacyHash` since the test setup has a `secretAuthSalt` configured