### PR TITLE
feat: reloadable plugins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
     test:
         working_directory: ~/repo
         docker:
-            - image: sto3psl/dw-ci:1.3.0
+            - image: sto3psl/dw-ci:1.4.0
         steps:
             - checkout
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2591,6 +2591,11 @@
                 "readdirp": "~3.2.0"
             }
         },
+        "chownr": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+            "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
+        },
         "chroma-js": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.1.0.tgz",
@@ -4460,6 +4465,31 @@
             "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.3.tgz",
             "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU="
         },
+        "fs-extra": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "requires": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            },
+            "dependencies": {
+                "graceful-fs": {
+                    "version": "4.2.3",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+                    "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+                }
+            }
+        },
+        "fs-minipass": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+            "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+            "requires": {
+                "minipass": "^3.0.0"
+            }
+        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5511,6 +5541,14 @@
                 "minimist": "^1.2.0"
             }
         },
+        "jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "requires": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
         "jsprim": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -6422,6 +6460,37 @@
                     "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
                     "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
                     "dev": true
+                }
+            }
+        },
+        "minipass": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+            "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+            "requires": {
+                "yallist": "^4.0.0"
+            },
+            "dependencies": {
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+                }
+            }
+        },
+        "minizlib": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.0.tgz",
+            "integrity": "sha512-EzTZN/fjSvifSX0SlqUERCN39o6T40AMarPbv0MrarSFtIITCBh7bi+dU8nxGFHuqs9jdIAeoYoKuQAAASsPPA==",
+            "requires": {
+                "minipass": "^3.0.0",
+                "yallist": "^4.0.0"
+            },
+            "dependencies": {
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
                 }
             }
         },
@@ -9291,6 +9360,31 @@
                 "xtend": "~4.0.0"
             }
         },
+        "tar": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.0.1.tgz",
+            "integrity": "sha512-bKhKrrz2FJJj5s7wynxy/fyxpE0CmCjmOQ1KV4KkgXFWOgoIT/NbTMnB1n+LFNrNk0SSBVGGxcK5AGsyC+pW5Q==",
+            "requires": {
+                "chownr": "^1.1.3",
+                "fs-minipass": "^2.0.0",
+                "minipass": "^3.0.0",
+                "minizlib": "^2.1.0",
+                "mkdirp": "^1.0.3",
+                "yallist": "^4.0.0"
+            },
+            "dependencies": {
+                "mkdirp": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz",
+                    "integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g=="
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+                }
+            }
+        },
         "term-size": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
@@ -9580,6 +9674,11 @@
                 "os-tmpdir": "^1.0.1",
                 "uid2": "0.0.3"
             }
+        },
+        "universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
         },
         "unquote": {
             "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "bcryptjs": "2.4.3",
         "chalk": "3.0.0",
         "cssnano": "4.1.10",
+        "fs-extra": "8.1.0",
         "got": "10.0.3",
         "hapi-auth-bearer-token": "6.2.1",
         "hapi-pino": "6.3.0",
@@ -55,7 +56,8 @@
         "less": "3.10.3",
         "lodash": "4.17.15",
         "mime": "2.4.4",
-        "nanoid": "2.1.7"
+        "nanoid": "2.1.7",
+        "tar": "6.0.1"
     },
     "devDependencies": {
         "@hapi/inert": "~5.2.2",

--- a/src/plugin-loader.js
+++ b/src/plugin-loader.js
@@ -14,25 +14,28 @@ module.exports = {
         function registerPlugin(name) {
             try {
                 const pluginPath = path.join(root, name, 'api.js');
-                const plugin = require(pluginPath);
+                const { options = {}, ...plugin } = require(pluginPath);
 
-                return {
-                    plugin,
-                    options: {
-                        models,
-                        config: get(config, ['plugins', name], {}),
-                        tarball:
-                            plugin.tarball ||
-                            `https://api.github.com/repos/datawrapper/plugin-${name}/tarball`
-                    }
-                };
+                const { routes, ...opts } = options;
+                return [
+                    {
+                        plugin,
+                        options: {
+                            models,
+                            config: get(config, ['plugins', name], {}),
+                            tarball: `https://api.github.com/repos/datawrapper/plugin-${name}/tarball`,
+                            ...opts
+                        }
+                    },
+                    { routes }
+                ];
             } catch (error) {
-                return { name, error };
+                return [{ name, error }];
             }
         }
 
         if (plugins.length) {
-            for (const { plugin, options, error, name } of plugins) {
+            for (const [{ plugin, options, error, name }, pluginOptions] of plugins) {
                 if (error) {
                     server.logger().error(`[Plugin] ${error}`, logError(root, name));
                     process.exit(1);
@@ -44,7 +47,7 @@ module.exports = {
                         `[Plugin] ${get(plugin, ['pkg', 'name'], plugin.name)}`
                     );
 
-                    await server.register({ plugin, options }, plugin.options);
+                    await server.register({ plugin, options }, pluginOptions);
                 }
             }
         }

--- a/src/plugin-loader.js
+++ b/src/plugin-loader.js
@@ -13,11 +13,17 @@ module.exports = {
 
         function registerPlugin(name) {
             try {
+                const pluginPath = path.join(root, name, 'api.js');
+                const plugin = require(pluginPath);
+
                 return {
-                    plugin: require(path.join(root, name, 'api.js')),
+                    plugin,
                     options: {
                         models,
-                        config: get(config, ['plugins', name], {})
+                        config: get(config, ['plugins', name], {}),
+                        tarball:
+                            plugin.tarball ||
+                            `https://api.github.com/repos/datawrapper/plugin-${name}/tarball`
                     }
                 };
             } catch (error) {

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -55,5 +55,11 @@ module.exports = {
                 prefix: '/products'
             }
         });
+
+        server.register(require('./plugins-admin'), {
+            routes: {
+                prefix: '/admin/plugins'
+            }
+        });
     }
 };

--- a/src/routes/plugins-admin.js
+++ b/src/routes/plugins-admin.js
@@ -1,0 +1,90 @@
+const stream = require('stream');
+const fs = require('fs-extra');
+const path = require('path');
+const { promisify } = require('util');
+const Boom = require('@hapi/boom');
+const get = require('lodash/get');
+const got = require('got');
+const tar = require('tar');
+
+const pipeline = promisify(stream.pipeline);
+
+module.exports = {
+    name: 'admin-plugin-routes',
+    version: '1.0.0',
+    register
+};
+
+function register(server, options) {
+    server.route({
+        method: 'GET',
+        path: '/',
+        options: {
+            auth: 'admin'
+        },
+        handler: getAllPlugins
+    });
+
+    async function getAllPlugins(request, h) {
+        const plugins = [];
+        for (const [plugin, { version, options }] of Object.entries(request.server.registrations)) {
+            if (options && options.tarball && options.config && options.config.reload) {
+                plugins.push({
+                    plugin,
+                    version,
+                    url: `/v3/admin/plugins/${plugin}`
+                });
+            }
+        }
+
+        return { list: plugins, count: plugins.length };
+    }
+
+    server.route({
+        method: 'POST',
+        path: '/{name}',
+        options: {
+            auth: 'admin'
+        },
+        handler: updatePlugin
+    });
+
+    async function updatePlugin(request, h) {
+        const { server, params, auth } = request;
+        const registration = server.registrations[params.name];
+        const { api, general } = server.methods.config();
+
+        if (!registration) {
+            return Boom.notFound();
+        }
+
+        const tarball = get(registration, 'options.tarball');
+        if (!get(registration, 'options.config.reload') || !tarball) {
+            return Boom.notImplemented();
+        }
+
+        const destination = path.join(general.localPluginRoot, params.name);
+        const backupDestination = path.join(general.localPluginRoot, `${params.name}-backup`);
+
+        request.logger.info({ user: auth.artifacts.id }, '[Start] Backup plugin', params.name);
+        await fs.copy(destination, backupDestination, {
+            filter: src => {
+                return !src.includes('node_modules/');
+            }
+        });
+        server.logger().info('[Done] Backup plugin', params.name);
+        server.logger().info('[Start] Update plugin', params.name);
+
+        await pipeline(
+            got.stream(`${tarball}/node-publishing`, {
+                headers: {
+                    authorization: `token ${api.githubToken}`
+                }
+            }),
+            tar.extract({ C: destination, strip: 1 })
+        );
+        server.logger().info('[Done] Update plugin', params.name);
+
+        return h.response().code(204);
+    }
+}

--- a/src/routes/plugins-admin.js
+++ b/src/routes/plugins-admin.js
@@ -2,8 +2,10 @@ const stream = require('stream');
 const fs = require('fs-extra');
 const path = require('path');
 const { promisify } = require('util');
+const Joi = require('@hapi/joi');
 const Boom = require('@hapi/boom');
 const get = require('lodash/get');
+const intersection = require('lodash/intersection');
 const got = require('got');
 const tar = require('tar');
 
@@ -42,16 +44,22 @@ function register(server, options) {
 
     server.route({
         method: 'POST',
-        path: '/{name}',
+        path: '/update',
         options: {
-            auth: 'admin'
+            auth: 'admin',
+            validate: {
+                payload: {
+                    name: Joi.string().required(),
+                    branch: Joi.string().default('master')
+                }
+            }
         },
         handler: updatePlugin
     });
 
     async function updatePlugin(request, h) {
-        const { server, params, auth } = request;
-        const registration = server.registrations[params.name];
+        const { server, payload, auth } = request;
+        const registration = server.registrations[payload.name];
         const { api, general } = server.methods.config();
 
         if (!registration) {
@@ -63,27 +71,49 @@ function register(server, options) {
             return Boom.notImplemented();
         }
 
-        const destination = path.join(general.localPluginRoot, params.name);
-        const backupDestination = path.join(general.localPluginRoot, `${params.name}-backup`);
+        const pluginLocation = path.join(general.localPluginRoot, payload.name);
+        const backupFile = path.join(general.localPluginRoot, `${payload.name}-backup.tgz`);
 
-        request.logger.info({ user: auth.artifacts.id }, '[Start] Backup plugin', params.name);
-        await fs.copy(destination, backupDestination, {
-            filter: src => {
-                return !src.includes('node_modules/');
-            }
-        });
-        server.logger().info('[Done] Backup plugin', params.name);
-        server.logger().info('[Start] Update plugin', params.name);
+        const dir = await fs.readdir(pluginLocation);
 
+        /* Find directories to update */
+        const staticDirectories = intersection(dir, [
+            'less',
+            'locale',
+            'static'
+        ]); /* is this all?  */
+
+        request.logger.info({ user: auth.artifacts.id }, '[Start] Backup plugin', payload.name);
+
+        /* Create backup of current local directories */
+        await tar.create(
+            {
+                cwd: pluginLocation,
+                gzip: true,
+                file: backupFile
+            },
+            staticDirectories
+        );
+
+        server.logger().info('[Done] Backup plugin', payload.name);
+        server.logger().info('[Start] Update plugin', payload.name);
+
+        /* Download repo archive from Github and pipe it into node-tar to extract directories */
+        const staticDirectoriesRegex = new RegExp(`.*/(${staticDirectories.join('|')})/.*`);
         await pipeline(
-            got.stream(`${tarball}/node-publishing`, {
+            got.stream(`${tarball}/${payload.branch}`, {
                 headers: {
                     authorization: `token ${api.githubToken}`
                 }
             }),
-            tar.extract({ C: destination, strip: 1 })
+            tar.extract({
+                cwd: pluginLocation,
+                strip: 1,
+                filter: path => staticDirectoriesRegex.test(path)
+            })
         );
-        server.logger().info('[Done] Update plugin', params.name);
+
+        server.logger().info('[Done] Update plugin', payload.name);
 
         return h.response().code(204);
     }

--- a/src/routes/plugins-admin.js
+++ b/src/routes/plugins-admin.js
@@ -130,7 +130,7 @@ function register(server, options) {
         } catch (error) {
             if (error.name === 'HTTPError') {
                 log.error({ url }, error.message);
-                return Boom.badGateway();
+                return Boom.badGateway(`(${error.name}) ${error.message} [${url}]`);
             }
             log.error(error);
             log.info('[Failed] Update plugin', payload.name);

--- a/src/server.js
+++ b/src/server.js
@@ -133,6 +133,7 @@ async function configure(options = { usePlugins: true, useOpenAPI: true }) {
 
     server.app.event = eventList;
     server.app.events = new ApiEventEmitter({ logger: server.logger });
+    server.app.visualization = new Set();
 
     server.method('config', key => (key ? config[key] : config));
     server.method('generateToken', generateToken);


### PR DESCRIPTION
**Disclaimer:** If you try this out locally, be aware that multiple services are watching the `/plugins` directory! The implemented functionality changes files in `/plugins` which causes the API server to restart and **cancel** the update process. Make sure that you disable `/plugins` watching in `core/utils/docker/entrypoints/api-entrypoints.js` by changing this line:
```diff
- exec nodemon "$@" --watch /app --watch /plugins
+ exec nodemon "$@" --watch /app
```
> You might need to rebuild the API container (`make api`).

---

Datawrapper plugins can be updated through the applications Admin UI. This enables quick iteration and fixes of, for example, visualization plugins. With the new Node.js based chart rendering setup, API and Frontend plugins need to get updated this way too.

For a Node server to update the running code, it needs to restart. Visualization plugins mostly update static files, which are read by the API through `fs.readFile`, therefore we can update a plugins static files without having to restart the server.

With this PR the update can be accomplished with a HTTP request:

```
POST https://api.datawrapper.de/v3/admin/plugins/update
---
{
  "name": "d3-scatter-plot",
  "branch": "master" // optional
}
```

A list of plugins - **that can reload** - is available through another endpoint:
```
GET https://api.datawrapper.de/v3/admin/plugins
```

### Implementation details

* ~Plugins can mark themselves as reloadable. This is done by using the `options.reload` flag in a plugins `api.js`.~ Currently this will replace files in `less`, `locale` and `static` directories. These directories are needed for chart rendering and can be easily extended/made configurable once there is a need for it.

* An optional tarball url can be specified, to configure where to load the plugin from.  
Default: `https://api.github.com/repos/datawrapper/plugin-${name}/tarball`
```diff
const { name, version } = require('./plugin.json');

module.exports = {
    name,
    version,
+   options: {
+      "tarball": "https://assets.datawrapper.de/releases/plugin-${name}/tarball"
+   },
    register: server => {
        server.app.visualization.add('d3-scatter-plot');
    }
};
```

### Update flow

This is a simplified flow chart. For example, not all files get extracted from the Github archive (as mentioned above).

![update](https://user-images.githubusercontent.com/5798652/74723529-08a80a80-523b-11ea-88af-b7e6d83e5e56.png)
