### PR TITLE
security: update Hapi and @hapi/hoek

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
     test:
         working_directory: ~/repo
         docker:
-            - image: sto3psl/dw-ci:1.3.0
+            - image: sto3psl/dw-ci:1.4.0
         steps:
             - checkout
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -669,9 +669,9 @@
             },
             "dependencies": {
                 "@hapi/hoek": {
-                    "version": "8.5.0",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-                    "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
+                    "version": "8.5.1",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+                    "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
                 },
                 "@hapi/joi": {
                     "version": "16.1.8",
@@ -720,26 +720,26 @@
             }
         },
         "@hapi/accept": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-3.2.3.tgz",
-            "integrity": "sha512-qEzsOJkCAJZxwj3iF83bSG9Lxy8Bpbrt8mRLNdvSALT6vlU2cYh6ZEHKEZPy4h/Mo31Su3j0rJgFF91+W1RWDQ==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.1.tgz",
+            "integrity": "sha512-fMr4d7zLzsAXo28PRRQPXR1o2Wmu+6z+VY1UzDp0iFo13Twj8WePakwXBiqn3E1aAlTpSNzCXdnnQXFhst8h8Q==",
             "requires": {
-                "@hapi/boom": "7.x.x",
-                "@hapi/hoek": "8.x.x"
+                "@hapi/boom": "9.x.x",
+                "@hapi/hoek": "9.x.x"
             },
             "dependencies": {
                 "@hapi/boom": {
-                    "version": "7.4.11",
-                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
-                    "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.0.0.tgz",
+                    "integrity": "sha512-D+Or4yahLq3L7D1Jf0fR1+Lgr+HPK1lej8tc6hS/fBLmK66XdpvTyKv8YUR5ls1GeQy+KGtbpKAs+ZxyzNtUyA==",
                     "requires": {
-                        "@hapi/hoek": "8.x.x"
+                        "@hapi/hoek": "9.x.x"
                     }
                 },
                 "@hapi/hoek": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.2.tgz",
-                    "integrity": "sha512-NP5SG4bzix+EtSMtcudp8TvI0lB46mXNo8uFpTDw6tqxGx4z5yx+giIunEFA0Z7oUO4DuWrOJV9xqR2tJVEdyA=="
+                    "version": "9.0.3",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.3.tgz",
+                    "integrity": "sha512-jKtjLLDiH95b002sJVc5c74PE6KKYftuyVdVmsuYId5stTaWcRFqE+5ukZI4gDUKjGn8wv2C3zPn3/nyjEI7gg=="
                 }
             }
         },
@@ -752,22 +752,23 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-3.1.0.tgz",
             "integrity": "sha512-iFQBEfm3WwWy8JdPQ8l6qXVLPtzmjITVfaxwl6dfoP8kKv6i2Uk43Ax+ShkNfOVyfEnNggqL2IyZTY3DaaRGNg==",
+            "dev": true,
             "requires": {
                 "@hapi/hoek": "6.x.x"
             }
         },
         "@hapi/b64": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-4.2.1.tgz",
-            "integrity": "sha512-zqHpQuH5CBMw6hADzKfU/IGNrxq1Q+/wTYV+OiZRQN9F3tMyk+9BUMeBvFRMamduuqL8iSp62QAnJ+7ATiYLWA==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
+            "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
             "requires": {
-                "@hapi/hoek": "8.x.x"
+                "@hapi/hoek": "9.x.x"
             },
             "dependencies": {
                 "@hapi/hoek": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.2.tgz",
-                    "integrity": "sha512-NP5SG4bzix+EtSMtcudp8TvI0lB46mXNo8uFpTDw6tqxGx4z5yx+giIunEFA0Z7oUO4DuWrOJV9xqR2tJVEdyA=="
+                    "version": "9.0.3",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.3.tgz",
+                    "integrity": "sha512-jKtjLLDiH95b002sJVc5c74PE6KKYftuyVdVmsuYId5stTaWcRFqE+5ukZI4gDUKjGn8wv2C3zPn3/nyjEI7gg=="
                 }
             }
         },
@@ -780,9 +781,9 @@
             },
             "dependencies": {
                 "@hapi/hoek": {
-                    "version": "8.5.0",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-                    "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
+                    "version": "8.5.1",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+                    "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
                 }
             }
         },
@@ -790,6 +791,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-1.3.0.tgz",
             "integrity": "sha512-gF5W/9AL10h/06HEf1bi0FP6KxZZ8LC/yHtDuoACw+1HrULvigHfnBIaSPFJXeHI3V3g0EkJpt1UOW0NKB+m+w==",
+            "dev": true,
             "requires": {
                 "@hapi/boom": "7.x.x",
                 "@hapi/hoek": "6.x.x"
@@ -799,14 +801,16 @@
                     "version": "7.4.11",
                     "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
                     "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+                    "dev": true,
                     "requires": {
                         "@hapi/hoek": "8.x.x"
                     },
                     "dependencies": {
                         "@hapi/hoek": {
-                            "version": "8.5.0",
-                            "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-                            "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
+                            "version": "8.5.1",
+                            "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+                            "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
+                            "dev": true
                         }
                     }
                 }
@@ -818,76 +822,98 @@
             "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
         },
         "@hapi/call": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/@hapi/call/-/call-5.1.1.tgz",
-            "integrity": "sha512-M6fC+9+K/ZB4hIdVQ8i0kc/6J5PWlW3PEWYKAAZpw0sk+28LiRTSF8BjOWwmiIjZWWs42AnEIiFJA0YrvcDnlw==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.0.tgz",
+            "integrity": "sha512-4xHIWWqaIDQlVU88XAnomACSoC7iWUfaLfdu2T7I0y+HFFwZUrKKGfwn6ik4kwKsJRMnOliG3UXsF8V/94+Lkg==",
             "requires": {
-                "@hapi/boom": "7.x.x",
-                "@hapi/hoek": "8.x.x"
+                "@hapi/address": "4.x.x",
+                "@hapi/boom": "9.x.x",
+                "@hapi/hoek": "9.x.x"
             },
             "dependencies": {
-                "@hapi/boom": {
-                    "version": "7.4.11",
-                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
-                    "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+                "@hapi/address": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.0.0.tgz",
+                    "integrity": "sha512-GDDpkCdSUfkQCznmWUHh9dDN85BWf/V8TFKQ2JLuHdGB4Yy3YTEGBzZxoBNxfNBEvreSR/o+ZxBBSNNEVzY+lQ==",
                     "requires": {
-                        "@hapi/hoek": "8.x.x"
+                        "@hapi/hoek": "^9.0.0"
+                    }
+                },
+                "@hapi/boom": {
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.0.0.tgz",
+                    "integrity": "sha512-D+Or4yahLq3L7D1Jf0fR1+Lgr+HPK1lej8tc6hS/fBLmK66XdpvTyKv8YUR5ls1GeQy+KGtbpKAs+ZxyzNtUyA==",
+                    "requires": {
+                        "@hapi/hoek": "9.x.x"
                     }
                 },
                 "@hapi/hoek": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.2.tgz",
-                    "integrity": "sha512-NP5SG4bzix+EtSMtcudp8TvI0lB46mXNo8uFpTDw6tqxGx4z5yx+giIunEFA0Z7oUO4DuWrOJV9xqR2tJVEdyA=="
+                    "version": "9.0.3",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.3.tgz",
+                    "integrity": "sha512-jKtjLLDiH95b002sJVc5c74PE6KKYftuyVdVmsuYId5stTaWcRFqE+5ukZI4gDUKjGn8wv2C3zPn3/nyjEI7gg=="
                 }
             }
         },
         "@hapi/catbox": {
-            "version": "10.2.3",
-            "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-10.2.3.tgz",
-            "integrity": "sha512-kN9hXO4NYyOHW09CXiuj5qW1syc/0XeVOBsNNk0Tz89wWNQE5h21WF+VsfAw3uFR8swn/Wj3YEVBnWqo82m/JQ==",
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.0.1.tgz",
+            "integrity": "sha512-CsdannMSzWqLcJ7rXT55JGAzoR+BPXesKn9POOrF0A0wsumbUwHP7vxBUH/21YitcM/dLxjUfphkRAQT+XaoyQ==",
             "requires": {
-                "@hapi/boom": "7.x.x",
-                "@hapi/hoek": "8.x.x",
-                "@hapi/joi": "16.x.x",
-                "@hapi/podium": "3.x.x"
+                "@hapi/boom": "9.x.x",
+                "@hapi/hoek": "9.x.x",
+                "@hapi/joi": "17.x.x",
+                "@hapi/podium": "4.x.x"
             },
             "dependencies": {
                 "@hapi/address": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.2.tgz",
-                    "integrity": "sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q=="
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.0.0.tgz",
+                    "integrity": "sha512-GDDpkCdSUfkQCznmWUHh9dDN85BWf/V8TFKQ2JLuHdGB4Yy3YTEGBzZxoBNxfNBEvreSR/o+ZxBBSNNEVzY+lQ==",
+                    "requires": {
+                        "@hapi/hoek": "^9.0.0"
+                    }
                 },
                 "@hapi/boom": {
-                    "version": "7.4.11",
-                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
-                    "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.0.0.tgz",
+                    "integrity": "sha512-D+Or4yahLq3L7D1Jf0fR1+Lgr+HPK1lej8tc6hS/fBLmK66XdpvTyKv8YUR5ls1GeQy+KGtbpKAs+ZxyzNtUyA==",
                     "requires": {
-                        "@hapi/hoek": "8.x.x"
+                        "@hapi/hoek": "9.x.x"
                     }
+                },
+                "@hapi/formula": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
+                    "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A=="
                 },
                 "@hapi/hoek": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.2.tgz",
-                    "integrity": "sha512-NP5SG4bzix+EtSMtcudp8TvI0lB46mXNo8uFpTDw6tqxGx4z5yx+giIunEFA0Z7oUO4DuWrOJV9xqR2tJVEdyA=="
+                    "version": "9.0.3",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.3.tgz",
+                    "integrity": "sha512-jKtjLLDiH95b002sJVc5c74PE6KKYftuyVdVmsuYId5stTaWcRFqE+5ukZI4gDUKjGn8wv2C3zPn3/nyjEI7gg=="
                 },
                 "@hapi/joi": {
-                    "version": "16.1.7",
-                    "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.7.tgz",
-                    "integrity": "sha512-anaIgnZhNooG3LJLrTFzgGALTiO97zRA1UkvQHm9KxxoSiIzCozB3RCNCpDnfhTJD72QlrHA8nwGmNgpFFCIeg==",
+                    "version": "17.1.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-17.1.0.tgz",
+                    "integrity": "sha512-ob67RcPlwRWxBzLCnWvcwx5qbwf88I3ykD7gcJLWOTRfLLgosK7r6aeChz4thA3XRvuBfI0KB1tPVl2EQFlPXw==",
                     "requires": {
-                        "@hapi/address": "^2.1.2",
-                        "@hapi/formula": "^1.2.0",
-                        "@hapi/hoek": "^8.2.4",
-                        "@hapi/pinpoint": "^1.0.2",
-                        "@hapi/topo": "^3.1.3"
+                        "@hapi/address": "^4.0.0",
+                        "@hapi/formula": "^2.0.0",
+                        "@hapi/hoek": "^9.0.0",
+                        "@hapi/pinpoint": "^2.0.0",
+                        "@hapi/topo": "^5.0.0"
                     }
                 },
+                "@hapi/pinpoint": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz",
+                    "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw=="
+                },
                 "@hapi/topo": {
-                    "version": "3.1.6",
-                    "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
-                    "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+                    "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
                     "requires": {
-                        "@hapi/hoek": "^8.3.0"
+                        "@hapi/hoek": "^9.0.0"
                     }
                 }
             }
@@ -910,62 +936,62 @@
                     }
                 },
                 "@hapi/hoek": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.2.tgz",
-                    "integrity": "sha512-NP5SG4bzix+EtSMtcudp8TvI0lB46mXNo8uFpTDw6tqxGx4z5yx+giIunEFA0Z7oUO4DuWrOJV9xqR2tJVEdyA=="
+                    "version": "8.5.1",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+                    "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
                 }
             }
         },
         "@hapi/content": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@hapi/content/-/content-4.1.0.tgz",
-            "integrity": "sha512-hv2Czsl49hnWDEfRZOFow/BmYbKyfEknmk3k83gOp6moFn5ceHB4xVcna8OwsGfy8dxO81lhpPy+JgQEaU4SWw==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
+            "integrity": "sha512-mre4dl1ygd4ZyOH3tiYBrOUBzV7Pu/EOs8VLGf58vtOEECWed8Uuw6B4iR9AN/8uQt42tB04qpVaMyoMQh0oMw==",
             "requires": {
-                "@hapi/boom": "7.x.x"
+                "@hapi/boom": "9.x.x"
             },
             "dependencies": {
                 "@hapi/boom": {
-                    "version": "7.4.11",
-                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
-                    "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.0.0.tgz",
+                    "integrity": "sha512-D+Or4yahLq3L7D1Jf0fR1+Lgr+HPK1lej8tc6hS/fBLmK66XdpvTyKv8YUR5ls1GeQy+KGtbpKAs+ZxyzNtUyA==",
                     "requires": {
-                        "@hapi/hoek": "8.x.x"
+                        "@hapi/hoek": "9.x.x"
                     }
                 },
                 "@hapi/hoek": {
-                    "version": "8.5.0",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-                    "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
+                    "version": "9.0.3",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.3.tgz",
+                    "integrity": "sha512-jKtjLLDiH95b002sJVc5c74PE6KKYftuyVdVmsuYId5stTaWcRFqE+5ukZI4gDUKjGn8wv2C3zPn3/nyjEI7gg=="
                 }
             }
         },
         "@hapi/cryptiles": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-4.2.1.tgz",
-            "integrity": "sha512-XoqgKsHK0l/VpqPs+tr6j6vE+VQ3+2bkF2stvttmc7xAOf1oSAwHcJ0tlp/6MxMysktt1IEY0Csy3khKaP9/uQ==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.0.0.tgz",
+            "integrity": "sha512-Yq43ti9N51Z7jbm0Q7YVCcofA+4Gh5wsBX/jZ++Z+FM8GYfBQ1WmI9ufZSL+BVX8vRxzDkdQ2fKoG6cxOQlnVQ==",
             "requires": {
-                "@hapi/boom": "7.x.x"
+                "@hapi/boom": "9.x.x"
             },
             "dependencies": {
                 "@hapi/boom": {
-                    "version": "7.4.11",
-                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
-                    "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.0.0.tgz",
+                    "integrity": "sha512-D+Or4yahLq3L7D1Jf0fR1+Lgr+HPK1lej8tc6hS/fBLmK66XdpvTyKv8YUR5ls1GeQy+KGtbpKAs+ZxyzNtUyA==",
                     "requires": {
-                        "@hapi/hoek": "8.x.x"
+                        "@hapi/hoek": "9.x.x"
                     }
                 },
                 "@hapi/hoek": {
-                    "version": "8.5.0",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-                    "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
+                    "version": "9.0.3",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.3.tgz",
+                    "integrity": "sha512-jKtjLLDiH95b002sJVc5c74PE6KKYftuyVdVmsuYId5stTaWcRFqE+5ukZI4gDUKjGn8wv2C3zPn3/nyjEI7gg=="
                 }
             }
         },
         "@hapi/file": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@hapi/file/-/file-1.0.0.tgz",
-            "integrity": "sha512-Bsfp/+1Gyf70eGtnIgmScvrH8sSypO3TcK3Zf0QdHnzn/ACnAkI6KLtGACmNRPEzzIy+W7aJX5E+1fc9GwIABQ=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
+            "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ=="
         },
         "@hapi/formula": {
             "version": "1.2.0",
@@ -973,91 +999,168 @@
             "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA=="
         },
         "@hapi/hapi": {
-            "version": "18.4.0",
-            "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-18.4.0.tgz",
-            "integrity": "sha512-uk9zqknRLcNVQKgrPURm85DqkdroWP8eDRekh/IPoKvC4VjdZSn6EH2eUriOwyud/CldeBS3HDIJ/PtRj3VxDQ==",
+            "version": "19.1.1",
+            "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-19.1.1.tgz",
+            "integrity": "sha512-rpQzSs0XsHSF7usM4qdJJ0Bcmhs9stWhUW3OiamW33bw4qL8q3uEgUKB9KH8ODmluCAkkXOQ0X0Dh9t94E5VIw==",
             "requires": {
-                "@hapi/accept": "3.x.x",
-                "@hapi/ammo": "3.x.x",
-                "@hapi/boom": "7.x.x",
-                "@hapi/bounce": "1.x.x",
-                "@hapi/call": "5.x.x",
-                "@hapi/catbox": "10.x.x",
-                "@hapi/catbox-memory": "4.x.x",
-                "@hapi/heavy": "6.x.x",
-                "@hapi/hoek": "8.x.x",
-                "@hapi/joi": "15.x.x",
-                "@hapi/mimos": "4.x.x",
-                "@hapi/podium": "3.x.x",
-                "@hapi/shot": "4.x.x",
-                "@hapi/somever": "2.x.x",
-                "@hapi/statehood": "6.x.x",
-                "@hapi/subtext": "6.x.x",
-                "@hapi/teamwork": "3.x.x",
-                "@hapi/topo": "3.x.x"
+                "@hapi/accept": "^5.0.1",
+                "@hapi/ammo": "^5.0.1",
+                "@hapi/boom": "9.x.x",
+                "@hapi/bounce": "2.x.x",
+                "@hapi/call": "8.x.x",
+                "@hapi/catbox": "11.x.x",
+                "@hapi/catbox-memory": "5.x.x",
+                "@hapi/heavy": "7.x.x",
+                "@hapi/hoek": "9.x.x",
+                "@hapi/joi": "17.x.x",
+                "@hapi/mimos": "5.x.x",
+                "@hapi/podium": "4.x.x",
+                "@hapi/shot": "5.x.x",
+                "@hapi/somever": "3.x.x",
+                "@hapi/statehood": "^7.0.2",
+                "@hapi/subtext": "^7.0.3",
+                "@hapi/teamwork": "4.x.x",
+                "@hapi/topo": "5.x.x"
             },
             "dependencies": {
-                "@hapi/boom": {
-                    "version": "7.4.11",
-                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
-                    "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+                "@hapi/address": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.0.0.tgz",
+                    "integrity": "sha512-GDDpkCdSUfkQCznmWUHh9dDN85BWf/V8TFKQ2JLuHdGB4Yy3YTEGBzZxoBNxfNBEvreSR/o+ZxBBSNNEVzY+lQ==",
                     "requires": {
-                        "@hapi/hoek": "8.x.x"
+                        "@hapi/hoek": "^9.0.0"
                     }
                 },
+                "@hapi/ammo": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
+                    "integrity": "sha512-FbCNwcTbnQP4VYYhLNGZmA76xb2aHg9AMPiy18NZyWMG310P5KdFGyA9v2rm5ujrIny77dEEIkMOwl0Xv+fSSA==",
+                    "requires": {
+                        "@hapi/hoek": "9.x.x"
+                    }
+                },
+                "@hapi/boom": {
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.0.0.tgz",
+                    "integrity": "sha512-D+Or4yahLq3L7D1Jf0fR1+Lgr+HPK1lej8tc6hS/fBLmK66XdpvTyKv8YUR5ls1GeQy+KGtbpKAs+ZxyzNtUyA==",
+                    "requires": {
+                        "@hapi/hoek": "9.x.x"
+                    }
+                },
+                "@hapi/bounce": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
+                    "integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
+                    "requires": {
+                        "@hapi/boom": "9.x.x",
+                        "@hapi/hoek": "9.x.x"
+                    }
+                },
+                "@hapi/catbox-memory": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.0.tgz",
+                    "integrity": "sha512-ByuxVJPHNaXwLzbBv4GdTr6ccpe1nG+AfYt+8ftDWEJY7EWBWzD+Klhy5oPTDGzU26pNUh1e7fcYI1ILZRxAXQ==",
+                    "requires": {
+                        "@hapi/boom": "9.x.x",
+                        "@hapi/hoek": "9.x.x"
+                    }
+                },
+                "@hapi/formula": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
+                    "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A=="
+                },
                 "@hapi/hoek": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.2.tgz",
-                    "integrity": "sha512-NP5SG4bzix+EtSMtcudp8TvI0lB46mXNo8uFpTDw6tqxGx4z5yx+giIunEFA0Z7oUO4DuWrOJV9xqR2tJVEdyA=="
+                    "version": "9.0.3",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.3.tgz",
+                    "integrity": "sha512-jKtjLLDiH95b002sJVc5c74PE6KKYftuyVdVmsuYId5stTaWcRFqE+5ukZI4gDUKjGn8wv2C3zPn3/nyjEI7gg=="
+                },
+                "@hapi/joi": {
+                    "version": "17.1.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-17.1.0.tgz",
+                    "integrity": "sha512-ob67RcPlwRWxBzLCnWvcwx5qbwf88I3ykD7gcJLWOTRfLLgosK7r6aeChz4thA3XRvuBfI0KB1tPVl2EQFlPXw==",
+                    "requires": {
+                        "@hapi/address": "^4.0.0",
+                        "@hapi/formula": "^2.0.0",
+                        "@hapi/hoek": "^9.0.0",
+                        "@hapi/pinpoint": "^2.0.0",
+                        "@hapi/topo": "^5.0.0"
+                    }
+                },
+                "@hapi/pinpoint": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz",
+                    "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw=="
+                },
+                "@hapi/topo": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+                    "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+                    "requires": {
+                        "@hapi/hoek": "^9.0.0"
+                    }
                 }
             }
         },
         "@hapi/heavy": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-6.2.2.tgz",
-            "integrity": "sha512-PY1dCCO6dsze7RlafIRhTaGeyTgVe49A/lSkxbhKGjQ7x46o/OFf7hLiRqTCDh3atcEKf6362EaB3+kTUbCsVA==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-7.0.0.tgz",
+            "integrity": "sha512-n/nheUG6zNleWkjY+3fzV3VJIAumUCaa/WoTmurjqlYY5JgC5ZKOpvP7tWi8rXmKZhbcXgjH3fHFoM55LoBT7g==",
             "requires": {
-                "@hapi/boom": "7.x.x",
-                "@hapi/hoek": "8.x.x",
-                "@hapi/joi": "16.x.x"
+                "@hapi/boom": "9.x.x",
+                "@hapi/hoek": "9.x.x",
+                "@hapi/joi": "17.x.x"
             },
             "dependencies": {
                 "@hapi/address": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.2.tgz",
-                    "integrity": "sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q=="
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.0.0.tgz",
+                    "integrity": "sha512-GDDpkCdSUfkQCznmWUHh9dDN85BWf/V8TFKQ2JLuHdGB4Yy3YTEGBzZxoBNxfNBEvreSR/o+ZxBBSNNEVzY+lQ==",
+                    "requires": {
+                        "@hapi/hoek": "^9.0.0"
+                    }
                 },
                 "@hapi/boom": {
-                    "version": "7.4.11",
-                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
-                    "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.0.0.tgz",
+                    "integrity": "sha512-D+Or4yahLq3L7D1Jf0fR1+Lgr+HPK1lej8tc6hS/fBLmK66XdpvTyKv8YUR5ls1GeQy+KGtbpKAs+ZxyzNtUyA==",
                     "requires": {
-                        "@hapi/hoek": "8.x.x"
+                        "@hapi/hoek": "9.x.x"
                     }
+                },
+                "@hapi/formula": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
+                    "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A=="
                 },
                 "@hapi/hoek": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.2.tgz",
-                    "integrity": "sha512-NP5SG4bzix+EtSMtcudp8TvI0lB46mXNo8uFpTDw6tqxGx4z5yx+giIunEFA0Z7oUO4DuWrOJV9xqR2tJVEdyA=="
+                    "version": "9.0.3",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.3.tgz",
+                    "integrity": "sha512-jKtjLLDiH95b002sJVc5c74PE6KKYftuyVdVmsuYId5stTaWcRFqE+5ukZI4gDUKjGn8wv2C3zPn3/nyjEI7gg=="
                 },
                 "@hapi/joi": {
-                    "version": "16.1.7",
-                    "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.7.tgz",
-                    "integrity": "sha512-anaIgnZhNooG3LJLrTFzgGALTiO97zRA1UkvQHm9KxxoSiIzCozB3RCNCpDnfhTJD72QlrHA8nwGmNgpFFCIeg==",
+                    "version": "17.1.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-17.1.0.tgz",
+                    "integrity": "sha512-ob67RcPlwRWxBzLCnWvcwx5qbwf88I3ykD7gcJLWOTRfLLgosK7r6aeChz4thA3XRvuBfI0KB1tPVl2EQFlPXw==",
                     "requires": {
-                        "@hapi/address": "^2.1.2",
-                        "@hapi/formula": "^1.2.0",
-                        "@hapi/hoek": "^8.2.4",
-                        "@hapi/pinpoint": "^1.0.2",
-                        "@hapi/topo": "^3.1.3"
+                        "@hapi/address": "^4.0.0",
+                        "@hapi/formula": "^2.0.0",
+                        "@hapi/hoek": "^9.0.0",
+                        "@hapi/pinpoint": "^2.0.0",
+                        "@hapi/topo": "^5.0.0"
                     }
                 },
+                "@hapi/pinpoint": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz",
+                    "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw=="
+                },
                 "@hapi/topo": {
-                    "version": "3.1.6",
-                    "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
-                    "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+                    "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
                     "requires": {
-                        "@hapi/hoek": "^8.3.0"
+                        "@hapi/hoek": "^9.0.0"
                     }
                 }
             }
@@ -1091,9 +1194,9 @@
                     }
                 },
                 "@hapi/hoek": {
-                    "version": "8.5.0",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-                    "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw==",
+                    "version": "8.5.1",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+                    "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
                     "dev": true
                 },
                 "@hapi/joi": {
@@ -1121,29 +1224,34 @@
             }
         },
         "@hapi/iron": {
-            "version": "5.1.4",
-            "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-5.1.4.tgz",
-            "integrity": "sha512-+ElC+OCiwWLjlJBmm8ZEWjlfzTMQTdgPnU/TsoU5QsktspIWmWi9IU4kU83nH+X/SSya8TP8h8P11Wr5L7dkQQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
+            "integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
             "requires": {
-                "@hapi/b64": "4.x.x",
-                "@hapi/boom": "7.x.x",
-                "@hapi/bourne": "1.x.x",
-                "@hapi/cryptiles": "4.x.x",
-                "@hapi/hoek": "8.x.x"
+                "@hapi/b64": "5.x.x",
+                "@hapi/boom": "9.x.x",
+                "@hapi/bourne": "2.x.x",
+                "@hapi/cryptiles": "5.x.x",
+                "@hapi/hoek": "9.x.x"
             },
             "dependencies": {
                 "@hapi/boom": {
-                    "version": "7.4.11",
-                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
-                    "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.0.0.tgz",
+                    "integrity": "sha512-D+Or4yahLq3L7D1Jf0fR1+Lgr+HPK1lej8tc6hS/fBLmK66XdpvTyKv8YUR5ls1GeQy+KGtbpKAs+ZxyzNtUyA==",
                     "requires": {
-                        "@hapi/hoek": "8.x.x"
+                        "@hapi/hoek": "9.x.x"
                     }
                 },
+                "@hapi/bourne": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
+                    "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
+                },
                 "@hapi/hoek": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.2.tgz",
-                    "integrity": "sha512-NP5SG4bzix+EtSMtcudp8TvI0lB46mXNo8uFpTDw6tqxGx4z5yx+giIunEFA0Z7oUO4DuWrOJV9xqR2tJVEdyA=="
+                    "version": "9.0.3",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.3.tgz",
+                    "integrity": "sha512-jKtjLLDiH95b002sJVc5c74PE6KKYftuyVdVmsuYId5stTaWcRFqE+5ukZI4gDUKjGn8wv2C3zPn3/nyjEI7gg=="
                 }
             }
         },
@@ -1159,68 +1267,68 @@
             },
             "dependencies": {
                 "@hapi/hoek": {
-                    "version": "8.5.0",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-                    "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
+                    "version": "8.5.1",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+                    "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
                 }
             }
         },
         "@hapi/mimos": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-4.1.1.tgz",
-            "integrity": "sha512-CXoi/zfcTWfKYX756eEea8rXJRIb9sR4d7VwyAH9d3BkDyNgAesZxvqIdm55npQc6S9mU3FExinMAQVlIkz0eA==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-5.0.0.tgz",
+            "integrity": "sha512-EVS6wJYeE73InTlPWt+2e3Izn319iIvffDreci3qDNT+t3lA5ylJ0/SoTaID8e0TPNUkHUSsgJZXEmLHvoYzrA==",
             "requires": {
-                "@hapi/hoek": "8.x.x",
+                "@hapi/hoek": "9.x.x",
                 "mime-db": "1.x.x"
             },
             "dependencies": {
                 "@hapi/hoek": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.2.tgz",
-                    "integrity": "sha512-NP5SG4bzix+EtSMtcudp8TvI0lB46mXNo8uFpTDw6tqxGx4z5yx+giIunEFA0Z7oUO4DuWrOJV9xqR2tJVEdyA=="
+                    "version": "9.0.3",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.3.tgz",
+                    "integrity": "sha512-jKtjLLDiH95b002sJVc5c74PE6KKYftuyVdVmsuYId5stTaWcRFqE+5ukZI4gDUKjGn8wv2C3zPn3/nyjEI7gg=="
                 }
             }
         },
         "@hapi/nigel": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-3.1.1.tgz",
-            "integrity": "sha512-R9YWx4S8yu0gcCBrMUDCiEFm1SQT895dMlYoeNBp8I6YhF1BFF1iYPueKA2Kkp9BvyHdjmvrxCOns7GMmpl+Fw==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-4.0.0.tgz",
+            "integrity": "sha512-Bqs1pjcDnDQo/XGoiCCNHWTFcMzPbz3L4KU04njeFQMzzEmsojMRX7TX+PezQYCMKtHJOtMg0bHxZyMGqYtbSA==",
             "requires": {
-                "@hapi/hoek": "8.x.x",
-                "@hapi/vise": "3.x.x"
+                "@hapi/hoek": "9.x.x",
+                "@hapi/vise": "4.x.x"
             },
             "dependencies": {
                 "@hapi/hoek": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.2.tgz",
-                    "integrity": "sha512-NP5SG4bzix+EtSMtcudp8TvI0lB46mXNo8uFpTDw6tqxGx4z5yx+giIunEFA0Z7oUO4DuWrOJV9xqR2tJVEdyA=="
+                    "version": "9.0.3",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.3.tgz",
+                    "integrity": "sha512-jKtjLLDiH95b002sJVc5c74PE6KKYftuyVdVmsuYId5stTaWcRFqE+5ukZI4gDUKjGn8wv2C3zPn3/nyjEI7gg=="
                 }
             }
         },
         "@hapi/pez": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-4.1.1.tgz",
-            "integrity": "sha512-TUa2C7Xk6J69HWrm+Ad+O6dFvdVAG0BiFUYaRsmkdWjFIfwHBCaOI1dWT/juNukSb39Lj6/mDVyjN+H4nKB3xg==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-5.0.2.tgz",
+            "integrity": "sha512-jr1lAm8mE7J2IBxvDIuDI1qy2aAsoaD2jxOUd/7JRg/Vmrzco8HdKhtz4fKk6KHU6zbbsAp5m5aSWWVTUrag7g==",
             "requires": {
-                "@hapi/b64": "4.x.x",
-                "@hapi/boom": "7.x.x",
-                "@hapi/content": "4.x.x",
-                "@hapi/hoek": "8.x.x",
-                "@hapi/nigel": "3.x.x"
+                "@hapi/b64": "5.x.x",
+                "@hapi/boom": "9.x.x",
+                "@hapi/content": "^5.0.2",
+                "@hapi/hoek": "9.x.x",
+                "@hapi/nigel": "4.x.x"
             },
             "dependencies": {
                 "@hapi/boom": {
-                    "version": "7.4.11",
-                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
-                    "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.0.0.tgz",
+                    "integrity": "sha512-D+Or4yahLq3L7D1Jf0fR1+Lgr+HPK1lej8tc6hS/fBLmK66XdpvTyKv8YUR5ls1GeQy+KGtbpKAs+ZxyzNtUyA==",
                     "requires": {
-                        "@hapi/hoek": "8.x.x"
+                        "@hapi/hoek": "9.x.x"
                     }
                 },
                 "@hapi/hoek": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.2.tgz",
-                    "integrity": "sha512-NP5SG4bzix+EtSMtcudp8TvI0lB46mXNo8uFpTDw6tqxGx4z5yx+giIunEFA0Z7oUO4DuWrOJV9xqR2tJVEdyA=="
+                    "version": "9.0.3",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.3.tgz",
+                    "integrity": "sha512-jKtjLLDiH95b002sJVc5c74PE6KKYftuyVdVmsuYId5stTaWcRFqE+5ukZI4gDUKjGn8wv2C3zPn3/nyjEI7gg=="
                 }
             }
         },
@@ -1230,190 +1338,265 @@
             "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ=="
         },
         "@hapi/podium": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-3.4.2.tgz",
-            "integrity": "sha512-g9zlAkRL2uDlnEo64xzEhFLblf4fdL5Z6evAO0wJhdxEvokI/+6ryv7k6uhND481LiLzQz8qTtPYMuhH1hichw==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.0.0.tgz",
+            "integrity": "sha512-2T74rkS4OZjbsSdx4jIMbjb3cF/X6BpEE2kar71ascgL+9lf+5eczirlw3WWQ9ng2YDU469IVrADd6LYMzhEdw==",
             "requires": {
-                "@hapi/hoek": "8.x.x",
-                "@hapi/joi": "16.x.x"
+                "@hapi/hoek": "9.x.x",
+                "@hapi/joi": "17.x.x"
             },
             "dependencies": {
                 "@hapi/address": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.2.tgz",
-                    "integrity": "sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q=="
-                },
-                "@hapi/hoek": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.2.tgz",
-                    "integrity": "sha512-NP5SG4bzix+EtSMtcudp8TvI0lB46mXNo8uFpTDw6tqxGx4z5yx+giIunEFA0Z7oUO4DuWrOJV9xqR2tJVEdyA=="
-                },
-                "@hapi/joi": {
-                    "version": "16.1.7",
-                    "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.7.tgz",
-                    "integrity": "sha512-anaIgnZhNooG3LJLrTFzgGALTiO97zRA1UkvQHm9KxxoSiIzCozB3RCNCpDnfhTJD72QlrHA8nwGmNgpFFCIeg==",
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.0.0.tgz",
+                    "integrity": "sha512-GDDpkCdSUfkQCznmWUHh9dDN85BWf/V8TFKQ2JLuHdGB4Yy3YTEGBzZxoBNxfNBEvreSR/o+ZxBBSNNEVzY+lQ==",
                     "requires": {
-                        "@hapi/address": "^2.1.2",
-                        "@hapi/formula": "^1.2.0",
-                        "@hapi/hoek": "^8.2.4",
-                        "@hapi/pinpoint": "^1.0.2",
-                        "@hapi/topo": "^3.1.3"
+                        "@hapi/hoek": "^9.0.0"
                     }
                 },
-                "@hapi/topo": {
-                    "version": "3.1.6",
-                    "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
-                    "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+                "@hapi/formula": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
+                    "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A=="
+                },
+                "@hapi/hoek": {
+                    "version": "9.0.3",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.3.tgz",
+                    "integrity": "sha512-jKtjLLDiH95b002sJVc5c74PE6KKYftuyVdVmsuYId5stTaWcRFqE+5ukZI4gDUKjGn8wv2C3zPn3/nyjEI7gg=="
+                },
+                "@hapi/joi": {
+                    "version": "17.1.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-17.1.0.tgz",
+                    "integrity": "sha512-ob67RcPlwRWxBzLCnWvcwx5qbwf88I3ykD7gcJLWOTRfLLgosK7r6aeChz4thA3XRvuBfI0KB1tPVl2EQFlPXw==",
                     "requires": {
-                        "@hapi/hoek": "^8.3.0"
+                        "@hapi/address": "^4.0.0",
+                        "@hapi/formula": "^2.0.0",
+                        "@hapi/hoek": "^9.0.0",
+                        "@hapi/pinpoint": "^2.0.0",
+                        "@hapi/topo": "^5.0.0"
+                    }
+                },
+                "@hapi/pinpoint": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz",
+                    "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw=="
+                },
+                "@hapi/topo": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+                    "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+                    "requires": {
+                        "@hapi/hoek": "^9.0.0"
                     }
                 }
             }
         },
         "@hapi/shot": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-4.1.2.tgz",
-            "integrity": "sha512-6LeHLjvsq/bQ0R+fhEyr7mqExRGguNTrxFZf5DyKe3CK6pNabiGgYO4JVFaRrLZ3JyuhkS0fo8iiRE2Ql2oA/A==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.0.tgz",
+            "integrity": "sha512-JXddnJkRh3Xhv9lY1tA+TSIUaoODKbdNIPL/M8WFvFQKOttmGaDeqTW5e8Gf01LtLI7L5DraLMULHjrK1+YNFg==",
             "requires": {
-                "@hapi/hoek": "8.x.x",
-                "@hapi/joi": "16.x.x"
+                "@hapi/hoek": "9.x.x",
+                "@hapi/joi": "17.x.x"
             },
             "dependencies": {
                 "@hapi/address": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.2.tgz",
-                    "integrity": "sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q=="
-                },
-                "@hapi/hoek": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.2.tgz",
-                    "integrity": "sha512-NP5SG4bzix+EtSMtcudp8TvI0lB46mXNo8uFpTDw6tqxGx4z5yx+giIunEFA0Z7oUO4DuWrOJV9xqR2tJVEdyA=="
-                },
-                "@hapi/joi": {
-                    "version": "16.1.7",
-                    "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.7.tgz",
-                    "integrity": "sha512-anaIgnZhNooG3LJLrTFzgGALTiO97zRA1UkvQHm9KxxoSiIzCozB3RCNCpDnfhTJD72QlrHA8nwGmNgpFFCIeg==",
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.0.0.tgz",
+                    "integrity": "sha512-GDDpkCdSUfkQCznmWUHh9dDN85BWf/V8TFKQ2JLuHdGB4Yy3YTEGBzZxoBNxfNBEvreSR/o+ZxBBSNNEVzY+lQ==",
                     "requires": {
-                        "@hapi/address": "^2.1.2",
-                        "@hapi/formula": "^1.2.0",
-                        "@hapi/hoek": "^8.2.4",
-                        "@hapi/pinpoint": "^1.0.2",
-                        "@hapi/topo": "^3.1.3"
+                        "@hapi/hoek": "^9.0.0"
                     }
                 },
-                "@hapi/topo": {
-                    "version": "3.1.6",
-                    "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
-                    "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+                "@hapi/formula": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
+                    "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A=="
+                },
+                "@hapi/hoek": {
+                    "version": "9.0.3",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.3.tgz",
+                    "integrity": "sha512-jKtjLLDiH95b002sJVc5c74PE6KKYftuyVdVmsuYId5stTaWcRFqE+5ukZI4gDUKjGn8wv2C3zPn3/nyjEI7gg=="
+                },
+                "@hapi/joi": {
+                    "version": "17.1.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-17.1.0.tgz",
+                    "integrity": "sha512-ob67RcPlwRWxBzLCnWvcwx5qbwf88I3ykD7gcJLWOTRfLLgosK7r6aeChz4thA3XRvuBfI0KB1tPVl2EQFlPXw==",
                     "requires": {
-                        "@hapi/hoek": "^8.3.0"
+                        "@hapi/address": "^4.0.0",
+                        "@hapi/formula": "^2.0.0",
+                        "@hapi/hoek": "^9.0.0",
+                        "@hapi/pinpoint": "^2.0.0",
+                        "@hapi/topo": "^5.0.0"
+                    }
+                },
+                "@hapi/pinpoint": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz",
+                    "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw=="
+                },
+                "@hapi/topo": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+                    "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+                    "requires": {
+                        "@hapi/hoek": "^9.0.0"
                     }
                 }
             }
         },
         "@hapi/somever": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-2.1.1.tgz",
-            "integrity": "sha512-cic5Sto4KGd9B0oQSdKTokju+rYhCbdpzbMb0EBnrH5Oc1z048hY8PaZ1lx2vBD7I/XIfTQVQetBH57fU51XRA==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-3.0.0.tgz",
+            "integrity": "sha512-Upw/kmKotC9iEmK4y047HMYe4LDKsE5NWfjgX41XNKmFvxsQL7OiaCWVhuyyhU0ShDGBfIAnCH8jZr49z/JzZA==",
             "requires": {
-                "@hapi/bounce": "1.x.x",
-                "@hapi/hoek": "8.x.x"
+                "@hapi/bounce": "2.x.x",
+                "@hapi/hoek": "9.x.x"
             },
             "dependencies": {
+                "@hapi/boom": {
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.0.0.tgz",
+                    "integrity": "sha512-D+Or4yahLq3L7D1Jf0fR1+Lgr+HPK1lej8tc6hS/fBLmK66XdpvTyKv8YUR5ls1GeQy+KGtbpKAs+ZxyzNtUyA==",
+                    "requires": {
+                        "@hapi/hoek": "9.x.x"
+                    }
+                },
+                "@hapi/bounce": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
+                    "integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
+                    "requires": {
+                        "@hapi/boom": "9.x.x",
+                        "@hapi/hoek": "9.x.x"
+                    }
+                },
                 "@hapi/hoek": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.2.tgz",
-                    "integrity": "sha512-NP5SG4bzix+EtSMtcudp8TvI0lB46mXNo8uFpTDw6tqxGx4z5yx+giIunEFA0Z7oUO4DuWrOJV9xqR2tJVEdyA=="
+                    "version": "9.0.3",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.3.tgz",
+                    "integrity": "sha512-jKtjLLDiH95b002sJVc5c74PE6KKYftuyVdVmsuYId5stTaWcRFqE+5ukZI4gDUKjGn8wv2C3zPn3/nyjEI7gg=="
                 }
             }
         },
         "@hapi/statehood": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-6.1.2.tgz",
-            "integrity": "sha512-pYXw1x6npz/UfmtcpUhuMvdK5kuOGTKcJNfLqdNptzietK2UZH5RzNJSlv5bDHeSmordFM3kGItcuQWX2lj2nQ==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.2.tgz",
+            "integrity": "sha512-+0VNxysQu+UYzkfvAXq3X4aN65TnUwiR7gsq2cQ/4Rq26nCJjHAfrkYReEeshU2hPmJ3m5QuaBzyDqRm8WOpyg==",
             "requires": {
-                "@hapi/boom": "7.x.x",
-                "@hapi/bounce": "1.x.x",
-                "@hapi/bourne": "1.x.x",
-                "@hapi/cryptiles": "4.x.x",
-                "@hapi/hoek": "8.x.x",
-                "@hapi/iron": "5.x.x",
-                "@hapi/joi": "16.x.x"
+                "@hapi/boom": "9.x.x",
+                "@hapi/bounce": "2.x.x",
+                "@hapi/bourne": "2.x.x",
+                "@hapi/cryptiles": "5.x.x",
+                "@hapi/hoek": "9.x.x",
+                "@hapi/iron": "6.x.x",
+                "@hapi/joi": "17.x.x"
             },
             "dependencies": {
                 "@hapi/address": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.2.tgz",
-                    "integrity": "sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q=="
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.0.0.tgz",
+                    "integrity": "sha512-GDDpkCdSUfkQCznmWUHh9dDN85BWf/V8TFKQ2JLuHdGB4Yy3YTEGBzZxoBNxfNBEvreSR/o+ZxBBSNNEVzY+lQ==",
+                    "requires": {
+                        "@hapi/hoek": "^9.0.0"
+                    }
                 },
                 "@hapi/boom": {
-                    "version": "7.4.11",
-                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
-                    "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.0.0.tgz",
+                    "integrity": "sha512-D+Or4yahLq3L7D1Jf0fR1+Lgr+HPK1lej8tc6hS/fBLmK66XdpvTyKv8YUR5ls1GeQy+KGtbpKAs+ZxyzNtUyA==",
                     "requires": {
-                        "@hapi/hoek": "8.x.x"
+                        "@hapi/hoek": "9.x.x"
                     }
+                },
+                "@hapi/bounce": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
+                    "integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
+                    "requires": {
+                        "@hapi/boom": "9.x.x",
+                        "@hapi/hoek": "9.x.x"
+                    }
+                },
+                "@hapi/bourne": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
+                    "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
+                },
+                "@hapi/formula": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
+                    "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A=="
                 },
                 "@hapi/hoek": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.2.tgz",
-                    "integrity": "sha512-NP5SG4bzix+EtSMtcudp8TvI0lB46mXNo8uFpTDw6tqxGx4z5yx+giIunEFA0Z7oUO4DuWrOJV9xqR2tJVEdyA=="
+                    "version": "9.0.3",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.3.tgz",
+                    "integrity": "sha512-jKtjLLDiH95b002sJVc5c74PE6KKYftuyVdVmsuYId5stTaWcRFqE+5ukZI4gDUKjGn8wv2C3zPn3/nyjEI7gg=="
                 },
                 "@hapi/joi": {
-                    "version": "16.1.7",
-                    "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.7.tgz",
-                    "integrity": "sha512-anaIgnZhNooG3LJLrTFzgGALTiO97zRA1UkvQHm9KxxoSiIzCozB3RCNCpDnfhTJD72QlrHA8nwGmNgpFFCIeg==",
+                    "version": "17.1.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-17.1.0.tgz",
+                    "integrity": "sha512-ob67RcPlwRWxBzLCnWvcwx5qbwf88I3ykD7gcJLWOTRfLLgosK7r6aeChz4thA3XRvuBfI0KB1tPVl2EQFlPXw==",
                     "requires": {
-                        "@hapi/address": "^2.1.2",
-                        "@hapi/formula": "^1.2.0",
-                        "@hapi/hoek": "^8.2.4",
-                        "@hapi/pinpoint": "^1.0.2",
-                        "@hapi/topo": "^3.1.3"
+                        "@hapi/address": "^4.0.0",
+                        "@hapi/formula": "^2.0.0",
+                        "@hapi/hoek": "^9.0.0",
+                        "@hapi/pinpoint": "^2.0.0",
+                        "@hapi/topo": "^5.0.0"
                     }
                 },
+                "@hapi/pinpoint": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz",
+                    "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw=="
+                },
                 "@hapi/topo": {
-                    "version": "3.1.6",
-                    "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
-                    "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+                    "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
                     "requires": {
-                        "@hapi/hoek": "^8.3.0"
+                        "@hapi/hoek": "^9.0.0"
                     }
                 }
             }
         },
         "@hapi/subtext": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-6.1.2.tgz",
-            "integrity": "sha512-G1kqD1E2QdxpvpL26WieIyo3z0qCa/sAGSa2TJI/PYPWCR9rL0rqFvhWY774xPZ4uK1PV3TIaJcx8AruAvxclg==",
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-7.0.3.tgz",
+            "integrity": "sha512-CekDizZkDGERJ01C0+TzHlKtqdXZxzSWTOaH6THBrbOHnsr3GY+yiMZC+AfNCypfE17RaIakGIAbpL2Tk1z2+A==",
             "requires": {
-                "@hapi/boom": "7.x.x",
-                "@hapi/bourne": "1.x.x",
-                "@hapi/content": "4.x.x",
-                "@hapi/file": "1.x.x",
-                "@hapi/hoek": "8.x.x",
-                "@hapi/pez": "4.x.x",
-                "@hapi/wreck": "15.x.x"
+                "@hapi/boom": "9.x.x",
+                "@hapi/bourne": "2.x.x",
+                "@hapi/content": "^5.0.2",
+                "@hapi/file": "2.x.x",
+                "@hapi/hoek": "9.x.x",
+                "@hapi/pez": "^5.0.1",
+                "@hapi/wreck": "17.x.x"
             },
             "dependencies": {
                 "@hapi/boom": {
-                    "version": "7.4.11",
-                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
-                    "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.0.0.tgz",
+                    "integrity": "sha512-D+Or4yahLq3L7D1Jf0fR1+Lgr+HPK1lej8tc6hS/fBLmK66XdpvTyKv8YUR5ls1GeQy+KGtbpKAs+ZxyzNtUyA==",
                     "requires": {
-                        "@hapi/hoek": "8.x.x"
+                        "@hapi/hoek": "9.x.x"
                     }
                 },
+                "@hapi/bourne": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
+                    "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
+                },
                 "@hapi/hoek": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.2.tgz",
-                    "integrity": "sha512-NP5SG4bzix+EtSMtcudp8TvI0lB46mXNo8uFpTDw6tqxGx4z5yx+giIunEFA0Z7oUO4DuWrOJV9xqR2tJVEdyA=="
+                    "version": "9.0.3",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.3.tgz",
+                    "integrity": "sha512-jKtjLLDiH95b002sJVc5c74PE6KKYftuyVdVmsuYId5stTaWcRFqE+5ukZI4gDUKjGn8wv2C3zPn3/nyjEI7gg=="
                 }
             }
         },
         "@hapi/teamwork": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-3.3.1.tgz",
-            "integrity": "sha512-61tiqWCYvMKP7fCTXy0M4VE6uNIwA0qvgFoiDubgfj7uqJ0fdHJFQNnVPGrxhLWlwz0uBPWrQlBH7r8y9vFITQ=="
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-4.0.0.tgz",
+            "integrity": "sha512-V6xYOrr5aFv/IJqNPneaYCu8vuGTKisamqHVRS3JJnbZr18TrpXdsJOYk9pjPhFti+M2YETPebQLUr820N5NoQ=="
         },
         "@hapi/topo": {
             "version": "3.1.0",
@@ -1424,17 +1607,17 @@
             }
         },
         "@hapi/vise": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-3.1.1.tgz",
-            "integrity": "sha512-OXarbiCSadvtg+bSdVPqu31Z1JoBL+FwNYz3cYoBKQ5xq1/Cr4A3IkGpAZbAuxU5y4NL5pZFZG3d2a3ZGm/dOQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-4.0.0.tgz",
+            "integrity": "sha512-eYyLkuUiFZTer59h+SGy7hUm+qE9p+UemePTHLlIWppEd+wExn3Df5jO04bFQTm7nleF5V8CtuYQYb+VFpZ6Sg==",
             "requires": {
-                "@hapi/hoek": "8.x.x"
+                "@hapi/hoek": "9.x.x"
             },
             "dependencies": {
                 "@hapi/hoek": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.2.tgz",
-                    "integrity": "sha512-NP5SG4bzix+EtSMtcudp8TvI0lB46mXNo8uFpTDw6tqxGx4z5yx+giIunEFA0Z7oUO4DuWrOJV9xqR2tJVEdyA=="
+                    "version": "9.0.3",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.3.tgz",
+                    "integrity": "sha512-jKtjLLDiH95b002sJVc5c74PE6KKYftuyVdVmsuYId5stTaWcRFqE+5ukZI4gDUKjGn8wv2C3zPn3/nyjEI7gg=="
                 }
             }
         },
@@ -1460,9 +1643,9 @@
                     }
                 },
                 "@hapi/hoek": {
-                    "version": "8.5.0",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-                    "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw==",
+                    "version": "8.5.1",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+                    "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
                     "dev": true
                 },
                 "@hapi/joi": {
@@ -1490,27 +1673,32 @@
             }
         },
         "@hapi/wreck": {
-            "version": "15.1.0",
-            "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-15.1.0.tgz",
-            "integrity": "sha512-tQczYRTTeYBmvhsek/D49En/5khcShaBEmzrAaDjMrFXKJRuF8xA8+tlq1ETLBFwGd6Do6g2OC74rt11kzawzg==",
+            "version": "17.0.0",
+            "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.0.0.tgz",
+            "integrity": "sha512-d8lqCinbKyDByn7GzJDRDbitddhIEydNm44UcAMejfhEH3o4IYvKYq6K8cAqXbilXPuvZc0ErlUOg9SDdgRtMw==",
             "requires": {
-                "@hapi/boom": "7.x.x",
-                "@hapi/bourne": "1.x.x",
-                "@hapi/hoek": "8.x.x"
+                "@hapi/boom": "9.x.x",
+                "@hapi/bourne": "2.x.x",
+                "@hapi/hoek": "9.x.x"
             },
             "dependencies": {
                 "@hapi/boom": {
-                    "version": "7.4.11",
-                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
-                    "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.0.0.tgz",
+                    "integrity": "sha512-D+Or4yahLq3L7D1Jf0fR1+Lgr+HPK1lej8tc6hS/fBLmK66XdpvTyKv8YUR5ls1GeQy+KGtbpKAs+ZxyzNtUyA==",
                     "requires": {
-                        "@hapi/hoek": "8.x.x"
+                        "@hapi/hoek": "9.x.x"
                     }
                 },
+                "@hapi/bourne": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
+                    "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
+                },
                 "@hapi/hoek": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.2.tgz",
-                    "integrity": "sha512-NP5SG4bzix+EtSMtcudp8TvI0lB46mXNo8uFpTDw6tqxGx4z5yx+giIunEFA0Z7oUO4DuWrOJV9xqR2tJVEdyA=="
+                    "version": "9.0.3",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.3.tgz",
+                    "integrity": "sha512-jKtjLLDiH95b002sJVc5c74PE6KKYftuyVdVmsuYId5stTaWcRFqE+5ukZI4gDUKjGn8wv2C3zPn3/nyjEI7gg=="
                 }
             }
         },
@@ -4671,9 +4859,9 @@
                     },
                     "dependencies": {
                         "@hapi/hoek": {
-                            "version": "8.5.0",
-                            "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-                            "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
+                            "version": "8.5.1",
+                            "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+                            "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
                         }
                     }
                 }
@@ -4691,9 +4879,9 @@
             },
             "dependencies": {
                 "@hapi/hoek": {
-                    "version": "8.5.0",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-                    "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
+                    "version": "8.5.1",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+                    "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
                 }
             }
         },
@@ -4721,9 +4909,9 @@
                     },
                     "dependencies": {
                         "@hapi/hoek": {
-                            "version": "8.5.0",
-                            "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-                            "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
+                            "version": "8.5.1",
+                            "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+                            "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
                         }
                     }
                 }
@@ -6360,9 +6548,9 @@
             "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
         },
         "mime-db": {
-            "version": "1.42.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
-            "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ=="
+            "version": "1.43.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+            "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
         },
         "mime-types": {
             "version": "2.1.24",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@datawrapper/shared": "0.19.4",
         "@hapi/boom": "8.0.1",
         "@hapi/catbox-memory": "4.1.1",
-        "@hapi/hapi": "18.4.0",
+        "@hapi/hapi": "19.1.1",
         "@hapi/joi": "15.1.1",
         "arg": "4.1.2",
         "assign-deep": "1.0.1",

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,6 @@
 const Hapi = require('@hapi/hapi');
 const Boom = require('@hapi/boom');
+const Joi = require('@hapi/joi');
 const HapiSwagger = require('hapi-swagger');
 const get = require('lodash/get');
 const ORM = require('@datawrapper/orm');
@@ -130,6 +131,8 @@ async function configure(options = { usePlugins: true, useOpenAPI: true }) {
         'datawrapper-api',
         Object.keys(config.plugins)
     );
+
+    server.validator(Joi);
 
     server.app.event = eventList;
     server.app.events = new ApiEventEmitter({ logger: server.logger });


### PR DESCRIPTION
This PR fixes a low severity vulnerability in one of Hapi's dependencies (`@hapi/hoek`).

> Versions of @hapi/hoek prior to 8.5.1 and 9.0.3 are vulnerable to Prototype Pollution. The clone function fails to prevent the modification of the Object prototype when passed specially-crafted input. Attackers may use this to change existing properties that exist in all objects, which may lead to Denial of Service or Remote Code Execution in specific circumstances.
This issue does not affect hapi applications since the framework protects against such malicious inputs. Applications that use @hapi/hoek outside of the hapi ecosystem may be vulnerable.
> https://www.npmjs.com/advisories/1468

**Our API was never vulnerable because Hapi itself guards against these inputs.**

> This issue does not affect hapi applications since the framework protects against such malicious inputs.

I took the liberty to update `@hapi/hapi` to the current version too since the only breaking change is the use of private class fields internally (requires node 12) and the `server.validator()` change.

> https://hapi.dev/resources/changelog/