### PR TITLE
fix: use domain as is and add dot

### DIFF
--- a/src/auth/cookie-auth.js
+++ b/src/auth/cookie-auth.js
@@ -1,5 +1,5 @@
 const Boom = require('@hapi/boom');
-const { cookieTTL, cookieDomain } = require('../utils');
+const { cookieTTL } = require('../utils');
 const { Session } = require('@datawrapper/orm/models');
 const getUser = require('./get-user');
 
@@ -32,7 +32,7 @@ function cookieAuth(server, options) {
         ttl: cookieTTL(90),
         isSecure: process.env.NODE_ENV === 'production',
         strictHeader: false,
-        domain: cookieDomain(api),
+        domain: `.${api.domain}`,
         isSameSite: false,
         path: '/'
     });

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -13,25 +13,4 @@ utils.generateToken = (length = 25) => {
 
 utils.noop = () => {};
 
-/**
- * returns the domain used for session cookies
- *
- * @param {object} api - the config.api section
- * @returns {string}
- */
-utils.cookieDomain = api => {
-    // allow manual override of cookie domain
-    if (api.cookieDomain) return api.cookieDomain;
-    // try to guess the cookie domain from api domain
-    // check how many parts the domain has
-    const parts = api.domain.split('.');
-    // for domains like 'localhost' we return the full
-    // api domain, thereby making the cookie impossible to
-    // access from the frontend
-    if (parts.length < 3) return api.domain;
-    // trim off first part and prepend a dot e.g.
-    // api.datawrapper.local --> .datawrapper.local
-    return '.' + parts.slice(1).join('.');
-};
-
 module.exports = utils;


### PR DESCRIPTION
This simplifies the domain choice for the `Set-Cookie` header. 

Previously there was too much cut off, which caused developers to log themselves out of app.datawrapper.de when logging into our staging environment.