### PR TITLE
fix: "lock" user creation with same email

### DIFF
--- a/src/routes/users.test.js
+++ b/src/routes/users.test.js
@@ -1,11 +1,8 @@
 import test from 'ava';
 import sortBy from 'lodash/sortBy';
 import { decamelize } from 'humps';
-import util from 'util';
 
 import { setup } from '../../test/helpers/setup';
-
-const setTimeoutPromise = util.promisify(setTimeout);
 
 test.before(async t => {
     const { server, models, getUser, getTeamWithUser, getCredentials, addToCleanup } = await setup({
@@ -600,7 +597,7 @@ test('Parallel user creation requests with the same email should not create mult
 
     const responses = await Promise.all([
         t.context.server.inject(options),
-        setTimeoutPromise(200).then(() => t.context.server.inject(options))
+        t.context.server.inject(options)
     ]);
 
     t.is(responses[0].statusCode, 201);


### PR DESCRIPTION
Still WIP but this idea should fix the issue of parallel signup requests with same email creating multiple user accounts.

I will still abstract the cache away.