### PR TITLE
store user id and persistent flag in new session table fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -640,9 +640,9 @@
             }
         },
         "@datawrapper/orm": {
-            "version": "3.8.4",
-            "resolved": "https://registry.npmjs.org/@datawrapper/orm/-/orm-3.8.4.tgz",
-            "integrity": "sha512-DRSCFxP7m/ECPaA26aEdNwFGe7mJ+Oa8gVjhsIddpKC/zJv83juGmxXHzTJXUEK8+4bObD3ftpl8i7A6eOmq0Q==",
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/@datawrapper/orm/-/orm-3.9.0.tgz",
+            "integrity": "sha512-CM8NYtAndJi4FFVqqzN/OJhTbbJGIslFLELjQzIwswwSpb6VOIpn/T+kXFEXLbsEXakgLC/lD2WsJBfrC7d41A==",
             "requires": {
                 "assign-deep": "^1.0.1",
                 "merge-deep": "^3.0.2",
@@ -749,12 +749,20 @@
             "integrity": "sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q=="
         },
         "@hapi/ammo": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-3.1.0.tgz",
-            "integrity": "sha512-iFQBEfm3WwWy8JdPQ8l6qXVLPtzmjITVfaxwl6dfoP8kKv6i2Uk43Ax+ShkNfOVyfEnNggqL2IyZTY3DaaRGNg==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-3.1.2.tgz",
+            "integrity": "sha512-ej9OtFmiZv1qr45g1bxEZNGyaR4jRpyMxU6VhbxjaYThymvOwsyIsUKMZnP5Qw2tfYFuwqCJuIBHGpeIbdX9gQ==",
             "dev": true,
             "requires": {
-                "@hapi/hoek": "6.x.x"
+                "@hapi/hoek": "8.x.x"
+            },
+            "dependencies": {
+                "@hapi/hoek": {
+                    "version": "8.5.1",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+                    "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
+                    "dev": true
+                }
             }
         },
         "@hapi/b64": {
@@ -6719,9 +6727,9 @@
             "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
         },
         "moment-timezone": {
-            "version": "0.5.27",
-            "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.27.tgz",
-            "integrity": "sha512-EIKQs7h5sAsjhPCqN6ggx6cEbs94GK050254TIJySD1bzoM5JTYDwAU1IoVOeTOL6Gm27kYJ51/uuvq1kIlrbw==",
+            "version": "0.5.28",
+            "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.28.tgz",
+            "integrity": "sha512-TDJkZvAyKIVWg5EtVqRzU97w0Rb0YVbfpqyjgu6GwXCAohVRqwZjf4fOzDE6p1Ch98Sro/8hQQi65WDXW5STPw==",
             "requires": {
                 "moment": ">= 2.9.0"
             }
@@ -6758,9 +6766,9 @@
             },
             "dependencies": {
                 "iconv-lite": {
-                    "version": "0.5.0",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.0.tgz",
-                    "integrity": "sha512-NnEhI9hIEKHOzJ4f697DMz9IQEXr/MMJ5w64vN2/4Ai+wRnvV7SBrL0KLoRlwaKVghOc7LQ5YkPLuX146b6Ydw==",
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.1.tgz",
+                    "integrity": "sha512-ONHr16SQvKZNSqjQT9gy5z24Jw+uqfO02/ngBSBoqChZ+W8qXX7GPRa1RoUnzGADw8K63R1BXUMzarCVQBpY8Q==",
                     "requires": {
                         "safer-buffer": ">= 2.1.2 < 3"
                     }
@@ -8961,9 +8969,9 @@
                     "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
                 },
                 "uuid": {
-                    "version": "3.3.3",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-                    "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+                    "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "url": "git+https://github.com/datawrapper/datawrapper-api.git"
     },
     "dependencies": {
-        "@datawrapper/orm": "^3.8.4",
+        "@datawrapper/orm": "^3.9.0",
         "@datawrapper/schemas": "^1.3.0",
         "@datawrapper/shared": "0.19.4",
         "@hapi/boom": "8.0.1",

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -244,6 +244,8 @@ module.exports = {
 async function createSession(id, userId, keepSession = true) {
     return Session.create({
         id,
+        user_id: userId,
+        persistent: keepSession,
         data: {
             'dw-user-id': userId,
             persistent: keepSession,
@@ -329,7 +331,9 @@ async function login(request, h) {
                     ...session.data,
                     'dw-user-id': user.id,
                     last_action_time: Math.floor(Date.now() / 1000)
-                }
+                },
+                user_id: user.id,
+                persistent: keepSession
             }),
             associateChartsWithUser(session.id, user.id)
         ]);

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -475,6 +475,8 @@ async function signup(request, h) {
         /* associate guest session with newly created user */
         await Promise.all([
             session.update({
+                user_id: res.result.id,
+                persistent: true,
                 data: {
                     ...session.data,
                     'dw-user-id': res.result.id,
@@ -527,6 +529,8 @@ async function activateAccount(request, h) {
         // associate guest session with the activated user
         session = request.auth.credentials.data;
         await session.update({
+            user_id: user.id,
+            persistent: true,
             data: {
                 ...session.data,
                 'dw-user-id': user.id,

--- a/src/routes/auth.test.js
+++ b/src/routes/auth.test.js
@@ -357,3 +357,36 @@ test('user activation after team invite', async t => {
     t.is(res.statusCode, 200);
     t.is(res.result.email, credentials.email);
 });
+
+test('Login and logout updates session fields', async t => {
+    const { Session } = t.context.models;
+    let res = await t.context.server.inject({
+        method: 'POST',
+        url: '/v3/auth/login',
+        payload: {
+            email: t.context.user.email,
+            password: 'test-password',
+            keepSession: false
+        }
+    });
+
+    const sessionId = res.result['DW-SESSION'];
+
+    // check Session
+    const session = await Session.findByPk(sessionId);
+    t.is(session.user_id, t.context.user.id);
+    t.is(session.persistent, false);
+
+    // now logout
+    res = await t.context.server.inject({
+        method: 'POST',
+        url: '/v3/auth/logout',
+        headers: {
+            cookie: `DW-SESSION=${sessionId}`
+        }
+    });
+
+    // check that session has been destroyed
+    const session2 = await Session.findByPk(sessionId);
+    t.is(session2, null);
+});


### PR DESCRIPTION
This PR implements usage of the [new `user_id` and `persistent`](https://github.com/datawrapper/orm/pull/24) fields in the Session model.

We're keeping the existing "data" field for compatibility with the php app for now.

I will mark this PR ready once the ORM PR has been merged and a new version has been deployed to npm.