### PR TITLE
feat: add filter option to events.emit

### DIFF
--- a/src/routes/charts.js
+++ b/src/routes/charts.js
@@ -766,27 +766,19 @@ async function exportChart(request, h) {
 
     Object.assign(payload, params);
     try {
-        const results = await events.emit(event.CHART_EXPORT, {
-            data: payload,
-            userId: user.id,
-            logger
-        });
-
-        const successfulResult = results.find(res => res.status === 'success');
-
-        if (!successfulResult) {
-            const { error } = results.find(res => res.status === 'error') || {
-                error: new CodedError(
-                    'notImplemented',
-                    `the export format "${params.format}" is not available`
-                )
-            };
-            throw error;
-        }
+        const result = await events.emit(
+            event.CHART_EXPORT,
+            {
+                data: payload,
+                userId: user.id,
+                logger
+            },
+            { filter: 'first' }
+        );
 
         await request.server.methods.logAction(user.id, `chart/export/${params.format}`, params.id);
 
-        const { stream, type } = successfulResult.data;
+        const { stream, type } = result;
 
         if (query.download) {
             return h
@@ -876,17 +868,11 @@ async function getChartAsset(request, h) {
     const filename = params.asset;
 
     try {
-        const eventResults = await events.emit(event.GET_CHART_ASSET, { chart, filename });
-        const successResult = eventResults.find(e => e.status === 'success');
-
-        if (!successResult) {
-            const errorResult = eventResults.find(e => e.status === 'error');
-            throw errorResult
-                ? errorResult.error
-                : new Error(`${event.GET_CHART_ASSET} event failed`);
-        }
-
-        const contentStream = successResult.data;
+        const contentStream = await events.emit(
+            event.GET_CHART_ASSET,
+            { chart, filename },
+            { filter: 'first' }
+        );
 
         const contentType =
             chart.type === 'locator-map' && path.extname(filename) === '.csv'
@@ -933,16 +919,18 @@ async function writeChartAsset(request, h) {
     const filename = params.asset;
 
     try {
-        const eventResults = await events.emit(event.PUT_CHART_ASSET, {
-            chart,
-            data:
-                request.headers['content-type'] === 'application/json'
-                    ? JSON.stringify(request.payload)
-                    : request.payload,
-            filename
-        });
-
-        const { code } = eventResults.find(e => e.status === 'success').data;
+        const { code } = await events.emit(
+            event.PUT_CHART_ASSET,
+            {
+                chart,
+                data:
+                    request.headers['content-type'] === 'application/json'
+                        ? JSON.stringify(request.payload)
+                        : request.payload,
+                filename
+            },
+            { filter: 'first' }
+        );
 
         // log chart/edit
         await request.server.methods.logAction(user.id, `chart/edit`, chart.id);

--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -1300,14 +1300,17 @@ function convertKeys(input, method) {
 }
 
 async function getMaxTeamInvites({ teamId, server }) {
-    const maxTeamInvitesRes = await server.app.events.emit(server.app.event.MAX_TEAM_INVITES, {
-        teamId
-    });
+    const maxTeamInvitesRes = await server.app.events.emit(
+        server.app.event.MAX_TEAM_INVITES,
+        { teamId },
+        { filter: 'success' }
+    );
+
     const maxTeamInvites = maxTeamInvitesRes
-        .filter(d => d.status === 'success')
         .map(({ data }) => data.maxInvites)
         .sort()
         .pop();
+
     return maxTeamInvites !== undefined ? maxTeamInvites : false;
 }
 

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -1,5 +1,6 @@
 const EventEmitter = require('events');
 const { noop } = require('./index');
+
 /**
  * Custom event emitter that collects results of event listeners
  *
@@ -15,12 +16,13 @@ class ApiEventEmitter extends EventEmitter {
     /**
      * Emit function that calls all listeners and returns Promise of their results
      *
+     * @private
      * @param {string} event - Name of event to emit
      * @param {any} [data] - Data to pass to event listeners
      * @return {Promise} - Promise of event results as array
      * @memberof ApiEventEmitter
      */
-    async emit(event, data) {
+    async __private__emit(event, data) {
         if (!eventList[event]) {
             throw new TypeError(`Invalid event name (${event})`);
         }
@@ -41,6 +43,62 @@ class ApiEventEmitter extends EventEmitter {
         });
 
         return Promise.all(result);
+    }
+
+    /**
+     * Filter a list of event results
+     *
+     * @param {array} eventResults - List of event results
+     * @param {function|string} filter - Result filter
+     * @returns {array|object} - List or single event result
+     * @memberof ApiEventEmitter
+     */
+    filterEventResults(eventResults, filter) {
+        if (typeof filter === 'function') {
+            return eventResults.filter(filter);
+        }
+
+        if (filter === 'first') {
+            const firstResult = eventResults.find(r => r.status === 'success') || {};
+            return firstResult.data ? [firstResult.data] : [];
+        }
+
+        if (filter === 'success') {
+            return eventResults.filter(r => r.status === 'success').map(r => r.data);
+        }
+
+        return eventResults;
+    }
+
+    /**
+     * Emit function with options
+     *
+     * @param {string} event - Name of event to emit
+     * @param {any} [data] - Data to pass to event listeners
+     * @param {object} [options] - Options object to modify returned results
+     * @param {function|string} [options.filter] - Result filter
+     * @return {Promise} - Promise of event results
+     * @memberof ApiEventEmitter
+     */
+    async emit(event, data, options = {}) {
+        const results = await this.__private__emit(event, data);
+
+        let eventResults = results;
+        if (options.filter) {
+            eventResults = this.filterEventResults(eventResults, options.filter);
+
+            if (!eventResults.length) {
+                const errorResult = results.find(r => r.status === 'error');
+
+                if (errorResult) {
+                    throw errorResult.error;
+                }
+            }
+        }
+
+        if (options.filter === 'first') return eventResults[0];
+
+        return eventResults;
     }
 }
 


### PR DESCRIPTION
_This PR is in preparation of upcoming chart hooks._

I added a convenience `filter` options to our `ApiEventEmitter`s `emit` method. This is based on our current `events.emit()` usage and what we usually did with the event results. There are **no** breaking changes and `options.filter` is entirely optional.

New method signature:
```diff
- async emit (event, data)
+ async emit (event, data, options = { filter: function|string })
```

Our main use case was to emit an event and check the successful responses or even just the first one. If none of the registered event listeners succeeded we looked for errors.

```js
/* old */
const results = await events.emit(event.CHART_EXPORT, data)

const successfulResult = results.find(res => res.status === 'success');

if (!successfulResult) {
    const { error } = results.find(res => res.status === 'error')	
    throw error;		
}

/* new */
const results = await events.emit(event.CHART_EXPORT, data, { filter: 'first'})
```

The change should make working with events in the future a little easier and more convenient.