### PR TITLE
fix: select organization_id too when querying chart

### DIFF
--- a/src/routes/charts.js
+++ b/src/routes/charts.js
@@ -858,7 +858,7 @@ async function loadChart(request) {
     const { id } = request.params;
 
     const chart = await Chart.findByPk(id, {
-        attributes: ['id', 'author_id', 'created_at', 'type', 'guest_session']
+        attributes: ['id', 'author_id', 'created_at', 'type', 'guest_session', 'organization_id']
     });
 
     if (!chart) {


### PR DESCRIPTION
Elana notified me that a user wasn't able to upload chart data with the API. After some investigation it turned out that the user was not the chart author but member of the organization.

The check if the user can upload data is done in the ORM with `User.prototype.mayEditChart` which checks the `organization_id`. Since this ID was not queried before it was `undefined` in the sequelize chart instance and the code crashed. Adding `organization_id` in the query fixes the issue.

This is not an issue when users upload data for their own charts and we couldn't reproduce it since our accounts usually have admin access and this has priority over the organization check.