### PR TITLE
published query param

### DIFF
--- a/src/routes/charts.js
+++ b/src/routes/charts.js
@@ -95,7 +95,8 @@ function register(server, options) {
                         .description('5 character long chart ID.')
                 }),
                 query: Joi.object({
-                    withData: Joi.boolean()
+                    withData: Joi.boolean(),
+                    published: Joi.boolean()
                 })
             },
             response: chartResponse
@@ -560,6 +561,8 @@ function prepareChart(chart) {
     const { user, in_folder, ...dataValues } = chart.dataValues;
 
     return {
+        language: 'en_US',
+        theme: 'datawrapper',
         ...camelizeKeys(dataValues),
         folderId: in_folder,
         metadata: dataValues.metadata,
@@ -773,7 +776,7 @@ async function getChart(request, h) {
         isGuestChart ||
         (await chart.isEditableBy(auth.artifacts, auth.credentials.session));
 
-    if (!isEditable) {
+    if (query.published || !isEditable) {
         if (chart.published_at) {
             chart = await ChartPublic.findOne({
                 where: {


### PR DESCRIPTION
This implements the `?published=true` query parameter for chart requests and set's some default values which are not present in the `chart_public` table but required for chart rendering.

Corresponding frontend commit https://github.com/datawrapper/frontend/commit/fabaf09cb7f0c795d897e482aa5abbb356397b11