### PR TITLE
hash files while copying

### DIFF
--- a/src/publish/publish.js
+++ b/src/publish/publish.js
@@ -8,7 +8,7 @@ const { Chart, ChartPublic } = require('@datawrapper/orm/models');
 const chartCore = require('@datawrapper/chart-core');
 const { getDependencies } = require('@datawrapper/chart-core/lib/get-dependencies');
 const get = require('lodash/get');
-const { stringify, hashFile } = require('../utils/index.js');
+const { stringify, readFileAndHash, copyFileHashed } = require('../utils/index.js');
 
 const { compileCSS } = require('./compile-css');
 const renderHTML = pug.compileFile(path.resolve(__dirname, './index.pug'));
@@ -65,7 +65,7 @@ async function publishChart(request, h) {
     const [css, translations, { fileName, content }] = await Promise.all([
         compileCSS({ theme, filePaths: [chartCore.less, vis.less] }),
         fs.readJSON(path.join(chartCore.path.locale, `${chart.language.replace('_', '-')}.json`)),
-        hashFile(vis.script)
+        readFileAndHash(vis.script)
     ]);
     theme.less = ''; /* reset "theme.less" to not inline it twice into the HTML */
 
@@ -91,10 +91,20 @@ async function publishChart(request, h) {
     };
     const { html, head } = chartCore.svelte.render(props);
 
-    const dependencies = getDependencies({
+    let dependencies = getDependencies({
         locale: chart.language,
         dependencies: vis.dependencies
     });
+
+    /* Create a temporary directory */
+    const outDir = await fs.mkdtemp(path.resolve(os.tmpdir(), `dw-chart-${chart.id}-`));
+
+    /* Copy dependencies into temporary directory and hash them on the way */
+    const dependencyPromises = dependencies.map(filePath => {
+        return copyFileHashed(path.join(chartCore.path.vendor, filePath), outDir);
+    });
+
+    dependencies = await Promise.all(dependencyPromises);
 
     /**
      * Render the visualizations entry: "index.html"
@@ -120,15 +130,9 @@ async function publishChart(request, h) {
         ]
     });
 
-    /**
-     * Create a temporary directory and write files to it
-     */
-    const outDir = await fs.mkdtemp(path.resolve(os.tmpdir(), `dw-chart-${chart.id}-`));
-
     /* start writing static assets adn global dependencies */
     const filePromises = [
-        ...dependencies,
-        'document-register-element.js',
+        'document-register-element.js' /* TODO: check if this can move into main.legacy.js */,
         chartCore.script['main.js'],
         chartCore.script['main.legacy.js']
     ].map(filePath =>

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -16,19 +16,46 @@ utils.stringify = obj => {
     });
 };
 
-utils.hashFile = async (filePath, hashLength = 8) => {
+function createHashedFileName(filePath, hash) {
+    const ext = path.extname(filePath);
+    const name = [path.basename(filePath, ext), hash].join('.');
+    return path.format({ name, ext });
+}
+
+utils.copyFileHashed = (filePath, destination, hashLength = 8) => {
+    let hash = crypto.createHash('sha256');
+    const outFilePath = path.join(destination, path.basename(filePath));
+    const input = fs.createReadStream(filePath);
+    const output = fs.createWriteStream(outFilePath);
+
+    input.pipe(output);
+    input.on('data', chunk => {
+        hash.update(chunk);
+    });
+
+    return new Promise((resolve, reject) => {
+        input.on('error', reject);
+        output.on('error', reject);
+
+        output.on('finish', rename);
+        async function rename() {
+            hash = hash.digest('hex').slice(0, hashLength);
+            const hashedFileName = createHashedFileName(filePath, hash);
+            await fs.move(outFilePath, path.join(destination, hashedFileName));
+            resolve(hashedFileName);
+        }
+    });
+};
+
+utils.readFileAndHash = async (filePath, hashLength = 8) => {
     const content = await fs.readFile(filePath, { encoding: 'utf-8' });
     let hash = crypto.createHash('sha256');
 
     hash.update(content);
     hash = hash.digest('hex').slice(0, hashLength);
 
-    const ext = path.extname(filePath);
     return {
-        fileName: path.format({
-            name: [path.basename(filePath, ext), hash].join('.'),
-            ext
-        }),
+        fileName: createHashedFileName(filePath, hash),
         content
     };
 };


### PR DESCRIPTION
This is part 1 of writing files into the `lib/` directory. All script files are now copied and hashed during the publish step. The output looks something like this:

```
dw-2.0.min.3c05152b.js
election-donut-chart.da634aec.js
index.html
jquery.min.0f23f82b.js
main.1624f33e.js
main.legacy.34aa38be.js
underscore.min.be3cacb1.js
```

The next step is to move decide which files stay in the publish directory and which ones are copied to some kind of `lib/` directory. Looking at the files only `index.html` really needs to be in the publish directory, is that assumption correct or am I missing something?
