### PR TITLE
expose publish status (stored temporarily in action table)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2972,9 +2972,9 @@
             }
         },
         "@datawrapper/orm": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@datawrapper/orm/-/orm-3.9.0.tgz",
-            "integrity": "sha512-CM8NYtAndJi4FFVqqzN/OJhTbbJGIslFLELjQzIwswwSpb6VOIpn/T+kXFEXLbsEXakgLC/lD2WsJBfrC7d41A==",
+            "version": "3.11.0",
+            "resolved": "https://registry.npmjs.org/@datawrapper/orm/-/orm-3.11.0.tgz",
+            "integrity": "sha512-d7CiOIRRNzM70bRvvD2MxIgyXbCiObMdbN51MwZyqO42/Trsr2+70pORvHK+6cse9HkJoObQnnqh/pg4slsS2w==",
             "requires": {
                 "assign-deep": "^1.0.1",
                 "merge-deep": "^3.0.2",
@@ -12656,11 +12656,6 @@
                     "version": "6.3.0",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                     "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-                },
-                "uuid": {
-                    "version": "3.4.0",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
                 }
             }
         },
@@ -13829,8 +13824,7 @@
         "uuid": {
             "version": "3.4.0",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-            "optional": true
+            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         },
         "v8-compile-cache": {
             "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     },
     "dependencies": {
         "@datawrapper/chart-core": "6.0.0",
-        "@datawrapper/orm": "^3.9.0",
+        "@datawrapper/orm": "^3.11.0",
         "@datawrapper/schemas": "^1.3.0",
         "@datawrapper/shared": "0.23.0",
         "@hapi/boom": "9.0.0",

--- a/src/publish/publish.js
+++ b/src/publish/publish.js
@@ -76,7 +76,7 @@ async function publishChart(request, h) {
     }
 
     // no need to await this...
-    logPublishStatus('loading-theme');
+    logPublishStatus('preparing');
 
     /**
      * Load theme information
@@ -85,9 +85,6 @@ async function publishChart(request, h) {
         url: `/v3/themes/${chart.theme}?extend=true`,
         auth
     });
-
-    // no need to await this...
-    logPublishStatus('loading-assets');
 
     /**
      * Load assets like CSS, Javascript and translations
@@ -119,22 +116,16 @@ async function publishChart(request, h) {
         theme,
         translations
     };
-    // no need to await this...
-    logPublishStatus('preparing');
-    await delay(4000);
+
+    logPublishStatus('rendering');
 
     const { html, head } = chartCore.svelte.render(props);
-
-    logPublishStatus('loading-dependencies');
-    await delay(2000);
 
     const dependencies = getDependencies({
         locale: chart.language,
         dependencies: vis.dependencies
     });
 
-    logPublishStatus('rendering');
-    await delay(4000);
     /**
      * Render the visualizations entry: "index.html"
      */
@@ -194,7 +185,6 @@ async function publishChart(request, h) {
     const newPublicVersion = chart.publicVersion + 1;
 
     logPublishStatus('uploading');
-    await delay(5000);
 
     /* move assets to publish location */
     let destination, eventError;
@@ -288,9 +278,3 @@ async function publishChartStatus(request, h) {
 }
 
 module.exports = { publishChart, publishChartStatus };
-
-async function delay(ms) {
-    return new Promise(resolve => {
-        setTimeout(() => resolve(), ms * 0.3);
-    });
-}

--- a/src/publish/publish.js
+++ b/src/publish/publish.js
@@ -4,7 +4,7 @@ const process = require('process');
 const fs = require('fs-extra');
 const os = require('os');
 const pug = require('pug');
-const { Chart, ChartPublic } = require('@datawrapper/orm/models');
+const { Chart, ChartPublic, Action } = require('@datawrapper/orm/models');
 const chartCore = require('@datawrapper/chart-core');
 const { getDependencies } = require('@datawrapper/chart-core/lib/get-dependencies');
 const get = require('lodash/get');
@@ -17,6 +17,12 @@ async function publishChart(request, h) {
     const startTiming = process.hrtime();
     const { params, auth, server } = request;
     const { events, event, visualizations } = server.app;
+
+    // @todo: check if the user is allowed to publish this chart!
+    const c = await Chart.findByPk(params.id);
+    if (!(await c.isEditableBy(auth.artifacts))) {
+        return Boom.unauthorized();
+    }
 
     /**
      * Load chart information
@@ -31,9 +37,26 @@ async function publishChart(request, h) {
         return Boom.notFound();
     }
 
+    const user = auth.artifacts;
+
+    const publishStatus = [];
+    const publishStatusAction = await request.server.methods.logAction(
+        user.id,
+        `chart/${chart.id}/publish`,
+        ''
+    );
+
+    async function logPublishStatus(action) {
+        publishStatus.push(action);
+        return publishStatusAction.update({
+            details: publishStatus.join(',')
+        });
+    }
+
     const csv = chart.data.chart;
     chart.data.chart = undefined;
     if (!csv) {
+        await logPublishStatus('error-data');
         return Boom.conflict('No chart data available.');
     }
 
@@ -42,6 +65,7 @@ async function publishChart(request, h) {
      */
     const vis = visualizations.get(chart.type);
     if (!vis) {
+        await logPublishStatus('error-vis-not-supported');
         return Boom.notImplemented(`"${chart.type}" is currently not supported.`);
     }
 
@@ -51,6 +75,9 @@ async function publishChart(request, h) {
         });
     }
 
+    // no need to await this...
+    logPublishStatus('loading-theme');
+
     /**
      * Load theme information
      */
@@ -58,6 +85,9 @@ async function publishChart(request, h) {
         url: `/v3/themes/${chart.theme}?extend=true`,
         auth
     });
+
+    // no need to await this...
+    logPublishStatus('loading-assets');
 
     /**
      * Load assets like CSS, Javascript and translations
@@ -89,13 +119,22 @@ async function publishChart(request, h) {
         theme,
         translations
     };
+    // no need to await this...
+    logPublishStatus('preparing');
+    await delay(4000);
+
     const { html, head } = chartCore.svelte.render(props);
+
+    logPublishStatus('loading-dependencies');
+    await delay(2000);
 
     const dependencies = getDependencies({
         locale: chart.language,
         dependencies: vis.dependencies
     });
 
+    logPublishStatus('rendering');
+    await delay(4000);
     /**
      * Render the visualizations entry: "index.html"
      */
@@ -125,7 +164,7 @@ async function publishChart(request, h) {
      */
     const outDir = await fs.mkdtemp(path.resolve(os.tmpdir(), `dw-chart-${chart.id}-`));
 
-    /* start writing static assets adn global dependencies */
+    /* start writing static assets and global dependencies */
     const filePromises = [
         ...dependencies,
         'document-register-element.js',
@@ -153,6 +192,9 @@ async function publishChart(request, h) {
 
     /* increment public version */
     const newPublicVersion = chart.publicVersion + 1;
+
+    logPublishStatus('uploading');
+    await delay(5000);
 
     /* move assets to publish location */
     let destination, eventError;
@@ -211,6 +253,11 @@ async function publishChart(request, h) {
 
     const endTiming = process.hrtime(startTiming);
 
+    // log action that chart has been published
+    await request.server.methods.logAction(user.id, `chart/publish`, chart.id);
+
+    await publishStatusAction.destroy();
+
     return {
         version: newPublicVersion,
         url: destination,
@@ -218,4 +265,32 @@ async function publishChart(request, h) {
     };
 }
 
-module.exports = { publishChart };
+async function publishChartStatus(request, h) {
+    const { params, auth } = request;
+
+    const chart = await Chart.findByPk(params.id);
+    if (!(await chart.isEditableBy(auth.artifacts))) {
+        return Boom.unauthorized();
+    }
+
+    const publishAction = await Action.findOne({
+        where: {
+            key: `chart/${chart.id}/publish`
+        },
+        order: [['id', 'DESC']]
+    });
+
+    if (!publishAction) return Boom.notFound();
+
+    return {
+        progress: publishAction.details.split(',')
+    };
+}
+
+module.exports = { publishChart, publishChartStatus };
+
+async function delay(ms) {
+    return new Promise(resolve => {
+        setTimeout(() => resolve(), ms * 0.3);
+    });
+}

--- a/src/publish/publish.js
+++ b/src/publish/publish.js
@@ -18,9 +18,8 @@ async function publishChart(request, h) {
     const { params, auth, server } = request;
     const { events, event, visualizations } = server.app;
 
-    // @todo: check if the user is allowed to publish this chart!
     const c = await Chart.findByPk(params.id);
-    if (!(await c.isEditableBy(auth.artifacts))) {
+    if (!(await c.isPublishableBy(auth.artifacts))) {
         return Boom.unauthorized();
     }
 

--- a/src/publish/publish.js
+++ b/src/publish/publish.js
@@ -159,11 +159,6 @@ async function publishChart(request, h) {
         ]
     });
 
-    /**
-     * Create a temporary directory and write files to it
-     */
-    const outDir = await fs.mkdtemp(path.resolve(os.tmpdir(), `dw-chart-${chart.id}-`));
-
     const filePromises = [
         'document-register-element.js' /* TODO: check if this can move into main.legacy.js */,
         chartCore.script['main.js'],

--- a/src/routes/charts.js
+++ b/src/routes/charts.js
@@ -32,7 +32,7 @@ const chartResponse = createResponseConfig({
     }).unknown()
 });
 
-const { publishChart } = require('../publish/publish');
+const { publishChart, publishChartStatus } = require('../publish/publish');
 
 module.exports = {
     name: 'chart-routes',
@@ -486,6 +486,22 @@ function register(server, options) {
             }
         },
         handler: publishChart
+    });
+
+    server.route({
+        method: 'GET',
+        path: '/{id}/publish/status',
+        options: {
+            tags: ['api'],
+            validate: {
+                params: Joi.object({
+                    id: Joi.string()
+                        .length(5)
+                        .required()
+                })
+            }
+        },
+        handler: publishChartStatus
     });
 
     async function writeChartData(request, h) {


### PR DESCRIPTION
This PR adds a new route `GET /v3/charts/:id/publish/status` for exposing progress status information while a chart is being published. The API might be super fast publishing charts now, but it might be different on production and it will certainly be different once we’re waiting for the render network to create screenshots of the published chart. 

Instead of of current progress bar we decided to show the user what they are waiting for aka what is currently happening. The idea is that this makes even a longer wait less frustrating.

The old API used the file system to store temporary progress information but in the new multi process system this isn’t an option. So instead we’re using the database to store the information. More precisely we’re creating a new `action` row.

Another thing this PR adds is a check if the user is even allowed to edit the chart. This check is performed by the Chart orm model.