### PR TITLE
publish assets to lib folder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,34 +42,35 @@
             }
         },
         "@babel/compat-data": {
-            "version": "7.8.6",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.8.6.tgz",
-            "integrity": "sha512-CurCIKPTkS25Mb8mz267vU95vy+TyUpnctEX2lV33xWNmHAfjruztgiPBbXZRh3xZZy1CYvGx6XfxyTVS+sk7Q==",
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.9.0.tgz",
+            "integrity": "sha512-zeFQrr+284Ekvd9e7KAX954LkapWiOmQtsfHirhxqfdlX6MEC32iRE+pqUGlYIBchdevaCwvzxWGSy/YBNI85g==",
             "requires": {
-                "browserslist": "^4.8.5",
+                "browserslist": "^4.9.1",
                 "invariant": "^2.2.4",
                 "semver": "^5.5.0"
             },
             "dependencies": {
                 "browserslist": {
-                    "version": "4.9.1",
-                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.9.1.tgz",
-                    "integrity": "sha512-Q0DnKq20End3raFulq6Vfp1ecB9fh8yUNV55s8sekaDDeqBaCtWlRHCUdaWyUeSSBJM7IbM6HcsyaeYqgeDhnw==",
+                    "version": "4.11.0",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.0.tgz",
+                    "integrity": "sha512-WqEC7Yr5wUH5sg6ruR++v2SGOQYpyUdYYd4tZoAq1F7y+QXoLoYGXVbxhtaIqWmAJjtNTRjVD3HuJc1OXTel2A==",
                     "requires": {
-                        "caniuse-lite": "^1.0.30001030",
-                        "electron-to-chromium": "^1.3.363",
-                        "node-releases": "^1.1.50"
+                        "caniuse-lite": "^1.0.30001035",
+                        "electron-to-chromium": "^1.3.380",
+                        "node-releases": "^1.1.52",
+                        "pkg-up": "^3.1.0"
                     }
                 },
                 "caniuse-lite": {
-                    "version": "1.0.30001035",
-                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001035.tgz",
-                    "integrity": "sha512-C1ZxgkuA4/bUEdMbU5WrGY4+UhMFFiXrgNAfxiMIqWgFTWfv/xsZCS2xEHT2LMq7xAZfuAnu6mcqyDl0ZR6wLQ=="
+                    "version": "1.0.30001036",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001036.tgz",
+                    "integrity": "sha512-jU8CIFIj2oR7r4W+5AKcsvWNVIb6Q6OZE3UsrXrZBHFtreT4YgTeOJtTucp+zSedEpTi3L5wASSP0LYIE3if6w=="
                 },
                 "electron-to-chromium": {
-                    "version": "1.3.378",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.378.tgz",
-                    "integrity": "sha512-nBp/AfhaVIOnfwgL1CZxt80IcqWcyYXiX6v5gflAksxy+SzBVz7A7UWR1Nos92c9ofXW74V9PoapzRb0jJfYXw=="
+                    "version": "1.3.382",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.382.tgz",
+                    "integrity": "sha512-gJfxOcgnBlXhfnUUObsq3n3ReU8CT6S8je97HndYRkKsNZMJJ38zO/pI5aqO7L3Myfq+E3pqPyKK/ynyLEQfBA=="
                 },
                 "node-releases": {
                     "version": "1.1.52",
@@ -257,139 +258,13 @@
             },
             "dependencies": {
                 "@babel/types": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
-                    "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+                    "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
                     "requires": {
-                        "esutils": "^2.0.2",
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
-                    }
-                }
-            }
-        },
-        "@babel/helper-call-delegate": {
-            "version": "7.8.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.8.7.tgz",
-            "integrity": "sha512-doAA5LAKhsFCR0LAFIf+r2RSMmC+m8f/oQ+URnUET/rWeEzC0yTRmAGyWkD4sSu3xwbS7MYQ2u+xlt1V5R56KQ==",
-            "requires": {
-                "@babel/helper-hoist-variables": "^7.8.3",
-                "@babel/traverse": "^7.8.3",
-                "@babel/types": "^7.8.7"
-            },
-            "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-                    "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-                    "requires": {
-                        "@babel/highlight": "^7.8.3"
-                    }
-                },
-                "@babel/generator": {
-                    "version": "7.8.8",
-                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.8.tgz",
-                    "integrity": "sha512-HKyUVu69cZoclptr8t8U5b6sx6zoWjh8jiUhnuj3MpZuKT2dJ8zPTuiy31luq32swhI0SpwItCIlU8XW7BZeJg==",
-                    "requires": {
-                        "@babel/types": "^7.8.7",
-                        "jsesc": "^2.5.1",
-                        "lodash": "^4.17.13",
-                        "source-map": "^0.5.0"
-                    }
-                },
-                "@babel/helper-function-name": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-                    "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-                    "requires": {
-                        "@babel/helper-get-function-arity": "^7.8.3",
-                        "@babel/template": "^7.8.3",
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/helper-get-function-arity": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-                    "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-                    "requires": {
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/helper-split-export-declaration": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-                    "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-                    "requires": {
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/highlight": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-                    "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-                    "requires": {
-                        "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
-                        "js-tokens": "^4.0.0"
-                    }
-                },
-                "@babel/parser": {
-                    "version": "7.8.8",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
-                    "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
-                },
-                "@babel/template": {
-                    "version": "7.8.6",
-                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
-                    "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-                    "requires": {
-                        "@babel/code-frame": "^7.8.3",
-                        "@babel/parser": "^7.8.6",
-                        "@babel/types": "^7.8.6"
-                    }
-                },
-                "@babel/traverse": {
-                    "version": "7.8.6",
-                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
-                    "integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
-                    "requires": {
-                        "@babel/code-frame": "^7.8.3",
-                        "@babel/generator": "^7.8.6",
-                        "@babel/helper-function-name": "^7.8.3",
-                        "@babel/helper-split-export-declaration": "^7.8.3",
-                        "@babel/parser": "^7.8.6",
-                        "@babel/types": "^7.8.6",
-                        "debug": "^4.1.0",
-                        "globals": "^11.1.0",
-                        "lodash": "^4.17.13"
-                    }
-                },
-                "@babel/types": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
-                    "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
-                    "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.13",
-                        "to-fast-properties": "^2.0.0"
-                    }
-                },
-                "chalk": {
-                    "version": "2.4.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-                    "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    }
-                },
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-                    "requires": {
-                        "ms": "^2.1.1"
                     }
                 }
             }
@@ -407,24 +282,25 @@
             },
             "dependencies": {
                 "browserslist": {
-                    "version": "4.9.1",
-                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.9.1.tgz",
-                    "integrity": "sha512-Q0DnKq20End3raFulq6Vfp1ecB9fh8yUNV55s8sekaDDeqBaCtWlRHCUdaWyUeSSBJM7IbM6HcsyaeYqgeDhnw==",
+                    "version": "4.11.0",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.0.tgz",
+                    "integrity": "sha512-WqEC7Yr5wUH5sg6ruR++v2SGOQYpyUdYYd4tZoAq1F7y+QXoLoYGXVbxhtaIqWmAJjtNTRjVD3HuJc1OXTel2A==",
                     "requires": {
-                        "caniuse-lite": "^1.0.30001030",
-                        "electron-to-chromium": "^1.3.363",
-                        "node-releases": "^1.1.50"
+                        "caniuse-lite": "^1.0.30001035",
+                        "electron-to-chromium": "^1.3.380",
+                        "node-releases": "^1.1.52",
+                        "pkg-up": "^3.1.0"
                     }
                 },
                 "caniuse-lite": {
-                    "version": "1.0.30001035",
-                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001035.tgz",
-                    "integrity": "sha512-C1ZxgkuA4/bUEdMbU5WrGY4+UhMFFiXrgNAfxiMIqWgFTWfv/xsZCS2xEHT2LMq7xAZfuAnu6mcqyDl0ZR6wLQ=="
+                    "version": "1.0.30001036",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001036.tgz",
+                    "integrity": "sha512-jU8CIFIj2oR7r4W+5AKcsvWNVIb6Q6OZE3UsrXrZBHFtreT4YgTeOJtTucp+zSedEpTi3L5wASSP0LYIE3if6w=="
                 },
                 "electron-to-chromium": {
-                    "version": "1.3.378",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.378.tgz",
-                    "integrity": "sha512-nBp/AfhaVIOnfwgL1CZxt80IcqWcyYXiX6v5gflAksxy+SzBVz7A7UWR1Nos92c9ofXW74V9PoapzRb0jJfYXw=="
+                    "version": "1.3.382",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.382.tgz",
+                    "integrity": "sha512-gJfxOcgnBlXhfnUUObsq3n3ReU8CT6S8je97HndYRkKsNZMJJ38zO/pI5aqO7L3Myfq+E3pqPyKK/ynyLEQfBA=="
                 },
                 "node-releases": {
                     "version": "1.1.52",
@@ -470,11 +346,11 @@
                     }
                 },
                 "@babel/types": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
-                    "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+                    "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
                     "requires": {
-                        "esutils": "^2.0.2",
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
                     }
@@ -562,19 +438,19 @@
                     }
                 },
                 "@babel/highlight": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-                    "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+                    "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
                     "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
                         "js-tokens": "^4.0.0"
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.8.8",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
-                    "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
+                    "version": "7.9.4",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+                    "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
                 },
                 "@babel/template": {
                     "version": "7.8.6",
@@ -587,11 +463,11 @@
                     }
                 },
                 "@babel/types": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
-                    "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+                    "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
                     "requires": {
-                        "esutils": "^2.0.2",
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
                     }
@@ -626,11 +502,11 @@
                     }
                 },
                 "@babel/generator": {
-                    "version": "7.8.8",
-                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.8.tgz",
-                    "integrity": "sha512-HKyUVu69cZoclptr8t8U5b6sx6zoWjh8jiUhnuj3MpZuKT2dJ8zPTuiy31luq32swhI0SpwItCIlU8XW7BZeJg==",
+                    "version": "7.9.4",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.4.tgz",
+                    "integrity": "sha512-rjP8ahaDy/ouhrvCoU1E5mqaitWrxwuNGU+dy1EpaoK48jZay4MdkskKGIMHLZNewg8sAsqpGSREJwP0zH3YQA==",
                     "requires": {
-                        "@babel/types": "^7.8.7",
+                        "@babel/types": "^7.9.0",
                         "jsesc": "^2.5.1",
                         "lodash": "^4.17.13",
                         "source-map": "^0.5.0"
@@ -663,19 +539,19 @@
                     }
                 },
                 "@babel/highlight": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-                    "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+                    "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
                     "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
                         "js-tokens": "^4.0.0"
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.8.8",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
-                    "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
+                    "version": "7.9.4",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+                    "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
                 },
                 "@babel/template": {
                     "version": "7.8.6",
@@ -688,27 +564,27 @@
                     }
                 },
                 "@babel/traverse": {
-                    "version": "7.8.6",
-                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
-                    "integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.0.tgz",
+                    "integrity": "sha512-jAZQj0+kn4WTHO5dUZkZKhbFrqZE7K5LAQ5JysMnmvGij+wOdr+8lWqPeW0BcF4wFwrEXXtdGO7wcV6YPJcf3w==",
                     "requires": {
                         "@babel/code-frame": "^7.8.3",
-                        "@babel/generator": "^7.8.6",
+                        "@babel/generator": "^7.9.0",
                         "@babel/helper-function-name": "^7.8.3",
                         "@babel/helper-split-export-declaration": "^7.8.3",
-                        "@babel/parser": "^7.8.6",
-                        "@babel/types": "^7.8.6",
+                        "@babel/parser": "^7.9.0",
+                        "@babel/types": "^7.9.0",
                         "debug": "^4.1.0",
                         "globals": "^11.1.0",
                         "lodash": "^4.17.13"
                     }
                 },
                 "@babel/types": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
-                    "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+                    "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
                     "requires": {
-                        "esutils": "^2.0.2",
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
                     }
@@ -762,11 +638,11 @@
             },
             "dependencies": {
                 "@babel/types": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
-                    "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+                    "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
                     "requires": {
-                        "esutils": "^2.0.2",
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
                     }
@@ -782,11 +658,11 @@
             },
             "dependencies": {
                 "@babel/types": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
-                    "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+                    "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
                     "requires": {
-                        "esutils": "^2.0.2",
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
                     }
@@ -802,11 +678,11 @@
             },
             "dependencies": {
                 "@babel/types": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
-                    "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+                    "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
                     "requires": {
-                        "esutils": "^2.0.2",
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
                     }
@@ -814,16 +690,16 @@
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.8.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.8.6.tgz",
-            "integrity": "sha512-RDnGJSR5EFBJjG3deY0NiL0K9TO8SXxS9n/MPsbPK/s9LbQymuLNtlzvDiNS7IpecuL45cMeLVkA+HfmlrnkRg==",
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
+            "integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
             "requires": {
                 "@babel/helper-module-imports": "^7.8.3",
                 "@babel/helper-replace-supers": "^7.8.6",
                 "@babel/helper-simple-access": "^7.8.3",
                 "@babel/helper-split-export-declaration": "^7.8.3",
                 "@babel/template": "^7.8.6",
-                "@babel/types": "^7.8.6",
+                "@babel/types": "^7.9.0",
                 "lodash": "^4.17.13"
             },
             "dependencies": {
@@ -844,19 +720,19 @@
                     }
                 },
                 "@babel/highlight": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-                    "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+                    "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
                     "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
                         "js-tokens": "^4.0.0"
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.8.8",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
-                    "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
+                    "version": "7.9.4",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+                    "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
                 },
                 "@babel/template": {
                     "version": "7.8.6",
@@ -869,11 +745,11 @@
                     }
                 },
                 "@babel/types": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
-                    "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+                    "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
                     "requires": {
-                        "esutils": "^2.0.2",
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
                     }
@@ -899,11 +775,11 @@
             },
             "dependencies": {
                 "@babel/types": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
-                    "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+                    "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
                     "requires": {
-                        "esutils": "^2.0.2",
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
                     }
@@ -913,14 +789,12 @@
         "@babel/helper-plugin-utils": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-            "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
-            "dev": true
+            "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
         },
         "@babel/helper-regex": {
             "version": "7.4.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.4.tgz",
             "integrity": "sha512-Y5nuB/kESmR3tKjU8Nkn1wMGEx1tjJX076HBMeL3XLQCu6vA/YRzuTW0bbb+qRnXvQGn+d6Rx953yffl8vEy7Q==",
-            "dev": true,
             "requires": {
                 "lodash": "^4.17.11"
             }
@@ -958,11 +832,11 @@
                     }
                 },
                 "@babel/generator": {
-                    "version": "7.8.8",
-                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.8.tgz",
-                    "integrity": "sha512-HKyUVu69cZoclptr8t8U5b6sx6zoWjh8jiUhnuj3MpZuKT2dJ8zPTuiy31luq32swhI0SpwItCIlU8XW7BZeJg==",
+                    "version": "7.9.4",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.4.tgz",
+                    "integrity": "sha512-rjP8ahaDy/ouhrvCoU1E5mqaitWrxwuNGU+dy1EpaoK48jZay4MdkskKGIMHLZNewg8sAsqpGSREJwP0zH3YQA==",
                     "requires": {
-                        "@babel/types": "^7.8.7",
+                        "@babel/types": "^7.9.0",
                         "jsesc": "^2.5.1",
                         "lodash": "^4.17.13",
                         "source-map": "^0.5.0"
@@ -995,19 +869,19 @@
                     }
                 },
                 "@babel/highlight": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-                    "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+                    "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
                     "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
                         "js-tokens": "^4.0.0"
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.8.8",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
-                    "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
+                    "version": "7.9.4",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+                    "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
                 },
                 "@babel/template": {
                     "version": "7.8.6",
@@ -1020,27 +894,27 @@
                     }
                 },
                 "@babel/traverse": {
-                    "version": "7.8.6",
-                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
-                    "integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.0.tgz",
+                    "integrity": "sha512-jAZQj0+kn4WTHO5dUZkZKhbFrqZE7K5LAQ5JysMnmvGij+wOdr+8lWqPeW0BcF4wFwrEXXtdGO7wcV6YPJcf3w==",
                     "requires": {
                         "@babel/code-frame": "^7.8.3",
-                        "@babel/generator": "^7.8.6",
+                        "@babel/generator": "^7.9.0",
                         "@babel/helper-function-name": "^7.8.3",
                         "@babel/helper-split-export-declaration": "^7.8.3",
-                        "@babel/parser": "^7.8.6",
-                        "@babel/types": "^7.8.6",
+                        "@babel/parser": "^7.9.0",
+                        "@babel/types": "^7.9.0",
                         "debug": "^4.1.0",
                         "globals": "^11.1.0",
                         "lodash": "^4.17.13"
                     }
                 },
                 "@babel/types": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
-                    "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+                    "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
                     "requires": {
-                        "esutils": "^2.0.2",
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
                     }
@@ -1083,19 +957,19 @@
                     }
                 },
                 "@babel/highlight": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-                    "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+                    "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
                     "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
                         "js-tokens": "^4.0.0"
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.8.8",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
-                    "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
+                    "version": "7.9.4",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+                    "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
                 },
                 "@babel/template": {
                     "version": "7.8.6",
@@ -1108,11 +982,11 @@
                     }
                 },
                 "@babel/types": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
-                    "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+                    "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
                     "requires": {
-                        "esutils": "^2.0.2",
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
                     }
@@ -1137,6 +1011,11 @@
             "requires": {
                 "@babel/types": "^7.0.0"
             }
+        },
+        "@babel/helper-validator-identifier": {
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz",
+            "integrity": "sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw=="
         },
         "@babel/helper-wrap-function": {
             "version": "7.2.0",
@@ -1350,10 +1229,26 @@
                 }
             }
         },
-        "@babel/plugin-proposal-object-rest-spread": {
+        "@babel/plugin-proposal-numeric-separator": {
             "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.8.3.tgz",
-            "integrity": "sha512-8qvuPwU/xxUCt78HocNlv0mXXo0wdh9VT1R04WU8HGOfaOob26pF+9P5/lYjN/q7DHOX1bvX60hnhOvuQUJdbA==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.8.3.tgz",
+            "integrity": "sha512-jWioO1s6R/R+wEHizfaScNsAx+xKgwTLNXSh7tTC4Usj3ItsPEhYkEpU4h+lpnBwq7NBVOJXfO6cRFYcX69JUQ==",
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/plugin-syntax-numeric-separator": "^7.8.3"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.8.3",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+                    "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
+                }
+            }
+        },
+        "@babel/plugin-proposal-object-rest-spread": {
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.0.tgz",
+            "integrity": "sha512-UgqBv6bjq4fDb8uku9f+wcm1J7YxJ5nT7WO/jBr0cl0PLKb7t1O6RNR1kZbjgx2LQtsDI9hwoQVmn0yhXeQyow==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.8.3",
                 "@babel/plugin-syntax-object-rest-spread": "^7.8.0"
@@ -1377,9 +1272,9 @@
             }
         },
         "@babel/plugin-proposal-optional-chaining": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.8.3.tgz",
-            "integrity": "sha512-QIoIR9abkVn+seDE3OjA08jWcs3eZ9+wJCKSRgo3WdEU2csFYgdScb+8qHB3+WXsGJD55u+5hWCISI7ejXS+kg==",
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.9.0.tgz",
+            "integrity": "sha512-NDn5tu3tcv4W30jNhmc2hyD5c56G6cXx4TesJubhxrJeCvuuMpttxr0OnNCqbZGhFjLrg+NIhxxC+BK5F6yS3w==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.8.3",
                 "@babel/plugin-syntax-optional-chaining": "^7.8.0"
@@ -1447,6 +1342,21 @@
             "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.8.3",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+                    "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
+                }
+            }
+        },
+        "@babel/plugin-syntax-numeric-separator": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.8.3.tgz",
+            "integrity": "sha512-H7dCMAdN83PcCmqmkHB5dtp+Xa9a6LKSvA2hiFBC/5alSHxM5VgWZXFqDi0YFe8XNGT6iCa+z4V4zSt/PdZ7Dw==",
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3"
             },
             "dependencies": {
                 "@babel/helper-plugin-utils": {
@@ -1544,11 +1454,11 @@
                     }
                 },
                 "@babel/generator": {
-                    "version": "7.8.8",
-                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.8.tgz",
-                    "integrity": "sha512-HKyUVu69cZoclptr8t8U5b6sx6zoWjh8jiUhnuj3MpZuKT2dJ8zPTuiy31luq32swhI0SpwItCIlU8XW7BZeJg==",
+                    "version": "7.9.4",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.4.tgz",
+                    "integrity": "sha512-rjP8ahaDy/ouhrvCoU1E5mqaitWrxwuNGU+dy1EpaoK48jZay4MdkskKGIMHLZNewg8sAsqpGSREJwP0zH3YQA==",
                     "requires": {
-                        "@babel/types": "^7.8.7",
+                        "@babel/types": "^7.9.0",
                         "jsesc": "^2.5.1",
                         "lodash": "^4.17.13",
                         "source-map": "^0.5.0"
@@ -1617,19 +1527,19 @@
                     }
                 },
                 "@babel/highlight": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-                    "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+                    "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
                     "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
                         "js-tokens": "^4.0.0"
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.8.8",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
-                    "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
+                    "version": "7.9.4",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+                    "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
                 },
                 "@babel/template": {
                     "version": "7.8.6",
@@ -1642,27 +1552,27 @@
                     }
                 },
                 "@babel/traverse": {
-                    "version": "7.8.6",
-                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
-                    "integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.0.tgz",
+                    "integrity": "sha512-jAZQj0+kn4WTHO5dUZkZKhbFrqZE7K5LAQ5JysMnmvGij+wOdr+8lWqPeW0BcF4wFwrEXXtdGO7wcV6YPJcf3w==",
                     "requires": {
                         "@babel/code-frame": "^7.8.3",
-                        "@babel/generator": "^7.8.6",
+                        "@babel/generator": "^7.9.0",
                         "@babel/helper-function-name": "^7.8.3",
                         "@babel/helper-split-export-declaration": "^7.8.3",
-                        "@babel/parser": "^7.8.6",
-                        "@babel/types": "^7.8.6",
+                        "@babel/parser": "^7.9.0",
+                        "@babel/types": "^7.9.0",
                         "debug": "^4.1.0",
                         "globals": "^11.1.0",
                         "lodash": "^4.17.13"
                     }
                 },
                 "@babel/types": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
-                    "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+                    "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
                     "requires": {
-                        "esutils": "^2.0.2",
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
                     }
@@ -1719,9 +1629,9 @@
             }
         },
         "@babel/plugin-transform-classes": {
-            "version": "7.8.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.8.6.tgz",
-            "integrity": "sha512-k9r8qRay/R6v5aWZkrEclEhKO6mc1CCQr2dLsVHBmOQiMpN6I2bpjX3vgnldUWeEI1GHVNByULVxZ4BdP4Hmdg==",
+            "version": "7.9.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.9.2.tgz",
+            "integrity": "sha512-TC2p3bPzsfvSsqBZo0kJnuelnoK9O3welkUpqSqBQuBF6R5MN2rysopri8kNvtlGIb2jmUO7i15IooAZJjZuMQ==",
             "requires": {
                 "@babel/helper-annotate-as-pure": "^7.8.3",
                 "@babel/helper-define-map": "^7.8.3",
@@ -1781,19 +1691,19 @@
                     }
                 },
                 "@babel/highlight": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-                    "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+                    "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
                     "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
                         "js-tokens": "^4.0.0"
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.8.8",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
-                    "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
+                    "version": "7.9.4",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+                    "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
                 },
                 "@babel/template": {
                     "version": "7.8.6",
@@ -1806,11 +1716,11 @@
                     }
                 },
                 "@babel/types": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
-                    "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+                    "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
                     "requires": {
-                        "esutils": "^2.0.2",
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
                     }
@@ -1861,7 +1771,6 @@
             "version": "7.4.4",
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
             "integrity": "sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==",
-            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0",
                 "@babel/helper-regex": "^7.4.4",
@@ -1900,9 +1809,9 @@
             }
         },
         "@babel/plugin-transform-for-of": {
-            "version": "7.8.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.6.tgz",
-            "integrity": "sha512-M0pw4/1/KI5WAxPsdcUL/w2LJ7o89YHN3yLkzNjg7Yl15GlVGgzHyCU+FMeAxevHGsLVmUqbirlUIKTafPmzdw==",
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.9.0.tgz",
+            "integrity": "sha512-lTAnWOpMwOXpyDx06N+ywmF3jNbafZEqZ96CGYabxHrxNX8l5ny7dt4bK/rGwAh9utyP2b2Hv7PlZh1AAS54FQ==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.8.3"
             },
@@ -1955,19 +1864,19 @@
                     "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
                 },
                 "@babel/highlight": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-                    "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+                    "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
                     "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
                         "js-tokens": "^4.0.0"
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.8.8",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
-                    "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
+                    "version": "7.9.4",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+                    "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
                 },
                 "@babel/template": {
                     "version": "7.8.6",
@@ -1980,11 +1889,11 @@
                     }
                 },
                 "@babel/types": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
-                    "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+                    "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
                     "requires": {
-                        "esutils": "^2.0.2",
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
                     }
@@ -2032,11 +1941,11 @@
             }
         },
         "@babel/plugin-transform-modules-amd": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.8.3.tgz",
-            "integrity": "sha512-MadJiU3rLKclzT5kBH4yxdry96odTUwuqrZM+GllFI/VhxfPz+k9MshJM+MwhfkCdxxclSbSBbUGciBngR+kEQ==",
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.9.0.tgz",
+            "integrity": "sha512-vZgDDF003B14O8zJy0XXLnPH4sg+9X5hFBBGN1V+B2rgrB+J2xIypSN6Rk9imB2hSTHQi5OHLrFWsZab1GMk+Q==",
             "requires": {
-                "@babel/helper-module-transforms": "^7.8.3",
+                "@babel/helper-module-transforms": "^7.9.0",
                 "@babel/helper-plugin-utils": "^7.8.3",
                 "babel-plugin-dynamic-import-node": "^2.3.0"
             },
@@ -2133,12 +2042,12 @@
             }
         },
         "@babel/plugin-transform-modules-systemjs": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.8.3.tgz",
-            "integrity": "sha512-8cESMCJjmArMYqa9AO5YuMEkE4ds28tMpZcGZB/jl3n0ZzlsxOAi3mC+SKypTfT8gjMupCnd3YiXCkMjj2jfOg==",
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.9.0.tgz",
+            "integrity": "sha512-FsiAv/nao/ud2ZWy4wFacoLOm5uxl0ExSQ7ErvP7jpoihLR6Cq90ilOFyX9UXct3rbtKsAiZ9kFt5XGfPe/5SQ==",
             "requires": {
                 "@babel/helper-hoist-variables": "^7.8.3",
-                "@babel/helper-module-transforms": "^7.8.3",
+                "@babel/helper-module-transforms": "^7.9.0",
                 "@babel/helper-plugin-utils": "^7.8.3",
                 "babel-plugin-dynamic-import-node": "^2.3.0"
             },
@@ -2151,11 +2060,11 @@
             }
         },
         "@babel/plugin-transform-modules-umd": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.8.3.tgz",
-            "integrity": "sha512-evhTyWhbwbI3/U6dZAnx/ePoV7H6OUG+OjiJFHmhr9FPn0VShjwC2kdxqIuQ/+1P50TMrneGzMeyMTFOjKSnAw==",
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.9.0.tgz",
+            "integrity": "sha512-uTWkXkIVtg/JGRSIABdBoMsoIeoHQHPTL0Y2E7xf5Oj7sLqwVsNXOkNk0VJc7vF0IMBsPeikHxFjGe+qmwPtTQ==",
             "requires": {
-                "@babel/helper-module-transforms": "^7.8.3",
+                "@babel/helper-module-transforms": "^7.9.0",
                 "@babel/helper-plugin-utils": "^7.8.3"
             },
             "dependencies": {
@@ -2206,11 +2115,10 @@
             }
         },
         "@babel/plugin-transform-parameters": {
-            "version": "7.8.8",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.8.tgz",
-            "integrity": "sha512-hC4Ld/Ulpf1psQciWWwdnUspQoQco2bMzSrwU6TmzRlvoYQe4rQFy9vnCZDTlVeCQj0JPfL+1RX0V8hCJvkgBA==",
+            "version": "7.9.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.9.3.tgz",
+            "integrity": "sha512-fzrQFQhp7mIhOzmOtPiKffvCYQSK10NR8t6BBz2yPbeUHb9OLW8RZGtgDRBn8z2hGcwvKDL3vC7ojPTLNxmqEg==",
             "requires": {
-                "@babel/helper-call-delegate": "^7.8.7",
                 "@babel/helper-get-function-arity": "^7.8.3",
                 "@babel/helper-plugin-utils": "^7.8.3"
             },
@@ -2229,11 +2137,11 @@
                     "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
                 },
                 "@babel/types": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
-                    "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+                    "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
                     "requires": {
-                        "esutils": "^2.0.2",
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
                     }
@@ -2279,9 +2187,9 @@
             }
         },
         "@babel/plugin-transform-runtime": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.8.3.tgz",
-            "integrity": "sha512-/vqUt5Yh+cgPZXXjmaG9NT8aVfThKk7G4OqkVhrXqwsC5soMn/qTCxs36rZ2QFhpfTJcjw4SNDIZ4RUb8OL4jQ==",
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.9.0.tgz",
+            "integrity": "sha512-pUu9VSf3kI1OqbWINQ7MaugnitRss1z533436waNXp+0N3ur3zfut37sXiQMxkuCF4VUjwZucen/quskCh7NHw==",
             "requires": {
                 "@babel/helper-module-imports": "^7.8.3",
                 "@babel/helper-plugin-utils": "^7.8.3",
@@ -2373,11 +2281,11 @@
                     "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
                 },
                 "@babel/types": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
-                    "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+                    "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
                     "requires": {
-                        "esutils": "^2.0.2",
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
                     }
@@ -2416,11 +2324,11 @@
             }
         },
         "@babel/preset-env": {
-            "version": "7.8.7",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.8.7.tgz",
-            "integrity": "sha512-BYftCVOdAYJk5ASsznKAUl53EMhfBbr8CJ1X+AJLfGPscQkwJFiaV/Wn9DPH/7fzm2v6iRYJKYHSqyynTGw0nw==",
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.9.0.tgz",
+            "integrity": "sha512-712DeRXT6dyKAM/FMbQTV/FvRCms2hPCx+3weRjZ8iQVQWZejWWk1wwG6ViWMyqb/ouBbGOl5b6aCk0+j1NmsQ==",
             "requires": {
-                "@babel/compat-data": "^7.8.6",
+                "@babel/compat-data": "^7.9.0",
                 "@babel/helper-compilation-targets": "^7.8.7",
                 "@babel/helper-module-imports": "^7.8.3",
                 "@babel/helper-plugin-utils": "^7.8.3",
@@ -2428,14 +2336,16 @@
                 "@babel/plugin-proposal-dynamic-import": "^7.8.3",
                 "@babel/plugin-proposal-json-strings": "^7.8.3",
                 "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
-                "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
+                "@babel/plugin-proposal-numeric-separator": "^7.8.3",
+                "@babel/plugin-proposal-object-rest-spread": "^7.9.0",
                 "@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
-                "@babel/plugin-proposal-optional-chaining": "^7.8.3",
+                "@babel/plugin-proposal-optional-chaining": "^7.9.0",
                 "@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
                 "@babel/plugin-syntax-async-generators": "^7.8.0",
                 "@babel/plugin-syntax-dynamic-import": "^7.8.0",
                 "@babel/plugin-syntax-json-strings": "^7.8.0",
                 "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+                "@babel/plugin-syntax-numeric-separator": "^7.8.0",
                 "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
                 "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
                 "@babel/plugin-syntax-optional-chaining": "^7.8.0",
@@ -2444,20 +2354,20 @@
                 "@babel/plugin-transform-async-to-generator": "^7.8.3",
                 "@babel/plugin-transform-block-scoped-functions": "^7.8.3",
                 "@babel/plugin-transform-block-scoping": "^7.8.3",
-                "@babel/plugin-transform-classes": "^7.8.6",
+                "@babel/plugin-transform-classes": "^7.9.0",
                 "@babel/plugin-transform-computed-properties": "^7.8.3",
                 "@babel/plugin-transform-destructuring": "^7.8.3",
                 "@babel/plugin-transform-dotall-regex": "^7.8.3",
                 "@babel/plugin-transform-duplicate-keys": "^7.8.3",
                 "@babel/plugin-transform-exponentiation-operator": "^7.8.3",
-                "@babel/plugin-transform-for-of": "^7.8.6",
+                "@babel/plugin-transform-for-of": "^7.9.0",
                 "@babel/plugin-transform-function-name": "^7.8.3",
                 "@babel/plugin-transform-literals": "^7.8.3",
                 "@babel/plugin-transform-member-expression-literals": "^7.8.3",
-                "@babel/plugin-transform-modules-amd": "^7.8.3",
-                "@babel/plugin-transform-modules-commonjs": "^7.8.3",
-                "@babel/plugin-transform-modules-systemjs": "^7.8.3",
-                "@babel/plugin-transform-modules-umd": "^7.8.3",
+                "@babel/plugin-transform-modules-amd": "^7.9.0",
+                "@babel/plugin-transform-modules-commonjs": "^7.9.0",
+                "@babel/plugin-transform-modules-systemjs": "^7.9.0",
+                "@babel/plugin-transform-modules-umd": "^7.9.0",
                 "@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
                 "@babel/plugin-transform-new-target": "^7.8.3",
                 "@babel/plugin-transform-object-super": "^7.8.3",
@@ -2471,8 +2381,9 @@
                 "@babel/plugin-transform-template-literals": "^7.8.3",
                 "@babel/plugin-transform-typeof-symbol": "^7.8.4",
                 "@babel/plugin-transform-unicode-regex": "^7.8.3",
-                "@babel/types": "^7.8.7",
-                "browserslist": "^4.8.5",
+                "@babel/preset-modules": "^0.1.3",
+                "@babel/types": "^7.9.0",
+                "browserslist": "^4.9.1",
                 "core-js-compat": "^3.6.2",
                 "invariant": "^2.2.2",
                 "levenary": "^1.1.1",
@@ -2488,11 +2399,11 @@
                     }
                 },
                 "@babel/generator": {
-                    "version": "7.8.8",
-                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.8.tgz",
-                    "integrity": "sha512-HKyUVu69cZoclptr8t8U5b6sx6zoWjh8jiUhnuj3MpZuKT2dJ8zPTuiy31luq32swhI0SpwItCIlU8XW7BZeJg==",
+                    "version": "7.9.4",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.4.tgz",
+                    "integrity": "sha512-rjP8ahaDy/ouhrvCoU1E5mqaitWrxwuNGU+dy1EpaoK48jZay4MdkskKGIMHLZNewg8sAsqpGSREJwP0zH3YQA==",
                     "requires": {
-                        "@babel/types": "^7.8.7",
+                        "@babel/types": "^7.9.0",
                         "jsesc": "^2.5.1",
                         "lodash": "^4.17.13",
                         "source-map": "^0.5.0"
@@ -2561,19 +2472,19 @@
                     }
                 },
                 "@babel/highlight": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-                    "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+                    "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
                     "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
                         "js-tokens": "^4.0.0"
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.8.8",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
-                    "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
+                    "version": "7.9.4",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+                    "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
                 },
                 "@babel/plugin-proposal-async-generator-functions": {
                     "version": "7.8.3",
@@ -2637,11 +2548,11 @@
                     }
                 },
                 "@babel/plugin-transform-modules-commonjs": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.8.3.tgz",
-                    "integrity": "sha512-JpdMEfA15HZ/1gNuB9XEDlZM1h/gF/YOH7zaZzQu2xCFRfwc01NXBMHHSTT6hRjlXJJs5x/bfODM3LiCk94Sxg==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.9.0.tgz",
+                    "integrity": "sha512-qzlCrLnKqio4SlgJ6FMMLBe4bySNis8DFn1VkGmOcxG9gqEyPIOzeQrA//u0HAKrWpJlpZbZMPB1n/OPa4+n8g==",
                     "requires": {
-                        "@babel/helper-module-transforms": "^7.8.3",
+                        "@babel/helper-module-transforms": "^7.9.0",
                         "@babel/helper-plugin-utils": "^7.8.3",
                         "@babel/helper-simple-access": "^7.8.3",
                         "babel-plugin-dynamic-import-node": "^2.3.0"
@@ -2658,45 +2569,46 @@
                     }
                 },
                 "@babel/traverse": {
-                    "version": "7.8.6",
-                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
-                    "integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.0.tgz",
+                    "integrity": "sha512-jAZQj0+kn4WTHO5dUZkZKhbFrqZE7K5LAQ5JysMnmvGij+wOdr+8lWqPeW0BcF4wFwrEXXtdGO7wcV6YPJcf3w==",
                     "requires": {
                         "@babel/code-frame": "^7.8.3",
-                        "@babel/generator": "^7.8.6",
+                        "@babel/generator": "^7.9.0",
                         "@babel/helper-function-name": "^7.8.3",
                         "@babel/helper-split-export-declaration": "^7.8.3",
-                        "@babel/parser": "^7.8.6",
-                        "@babel/types": "^7.8.6",
+                        "@babel/parser": "^7.9.0",
+                        "@babel/types": "^7.9.0",
                         "debug": "^4.1.0",
                         "globals": "^11.1.0",
                         "lodash": "^4.17.13"
                     }
                 },
                 "@babel/types": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
-                    "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+                    "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
                     "requires": {
-                        "esutils": "^2.0.2",
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
                     }
                 },
                 "browserslist": {
-                    "version": "4.9.1",
-                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.9.1.tgz",
-                    "integrity": "sha512-Q0DnKq20End3raFulq6Vfp1ecB9fh8yUNV55s8sekaDDeqBaCtWlRHCUdaWyUeSSBJM7IbM6HcsyaeYqgeDhnw==",
+                    "version": "4.11.0",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.0.tgz",
+                    "integrity": "sha512-WqEC7Yr5wUH5sg6ruR++v2SGOQYpyUdYYd4tZoAq1F7y+QXoLoYGXVbxhtaIqWmAJjtNTRjVD3HuJc1OXTel2A==",
                     "requires": {
-                        "caniuse-lite": "^1.0.30001030",
-                        "electron-to-chromium": "^1.3.363",
-                        "node-releases": "^1.1.50"
+                        "caniuse-lite": "^1.0.30001035",
+                        "electron-to-chromium": "^1.3.380",
+                        "node-releases": "^1.1.52",
+                        "pkg-up": "^3.1.0"
                     }
                 },
                 "caniuse-lite": {
-                    "version": "1.0.30001035",
-                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001035.tgz",
-                    "integrity": "sha512-C1ZxgkuA4/bUEdMbU5WrGY4+UhMFFiXrgNAfxiMIqWgFTWfv/xsZCS2xEHT2LMq7xAZfuAnu6mcqyDl0ZR6wLQ=="
+                    "version": "1.0.30001036",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001036.tgz",
+                    "integrity": "sha512-jU8CIFIj2oR7r4W+5AKcsvWNVIb6Q6OZE3UsrXrZBHFtreT4YgTeOJtTucp+zSedEpTi3L5wASSP0LYIE3if6w=="
                 },
                 "chalk": {
                     "version": "2.4.2",
@@ -2717,9 +2629,9 @@
                     }
                 },
                 "electron-to-chromium": {
-                    "version": "1.3.378",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.378.tgz",
-                    "integrity": "sha512-nBp/AfhaVIOnfwgL1CZxt80IcqWcyYXiX6v5gflAksxy+SzBVz7A7UWR1Nos92c9ofXW74V9PoapzRb0jJfYXw=="
+                    "version": "1.3.382",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.382.tgz",
+                    "integrity": "sha512-gJfxOcgnBlXhfnUUObsq3n3ReU8CT6S8je97HndYRkKsNZMJJ38zO/pI5aqO7L3Myfq+E3pqPyKK/ynyLEQfBA=="
                 },
                 "node-releases": {
                     "version": "1.1.52",
@@ -2734,6 +2646,30 @@
                             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                             "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
                         }
+                    }
+                }
+            }
+        },
+        "@babel/preset-modules": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.3.tgz",
+            "integrity": "sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==",
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+                "@babel/plugin-transform-dotall-regex": "^7.4.4",
+                "@babel/types": "^7.4.4",
+                "esutils": "^2.0.2"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+                    "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.0",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
                     }
                 }
             }
@@ -2814,26 +2750,26 @@
             }
         },
         "@datawrapper/chart-core": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-7.0.0.tgz",
-            "integrity": "sha512-zFP+43RSL47oUyFoO3ItKmTZQC4pjnH6IopcCAdOxEuMUT0zOhjTJRE+ACshuiN62UtwYl4mkUKNb3PZOCwGMA==",
+            "version": "8.0.0-1",
+            "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-8.0.0-1.tgz",
+            "integrity": "sha512-ZyIjaqey9z/7A3rIao/W+sQ/BWzsUhxvUnMo9nMLbvLs809XNSJhqYi8gYgoV6iXq3D6YFBKp8e9d9twj5gKBg==",
             "requires": {
-                "@babel/core": "7.8.7",
-                "@babel/plugin-transform-runtime": "7.8.3",
-                "@babel/preset-env": "7.8.7",
-                "@babel/runtime": "7.8.7",
-                "@datawrapper/shared": "0.23.0",
+                "@babel/core": "7.9.0",
+                "@babel/plugin-transform-runtime": "7.9.0",
+                "@babel/preset-env": "7.9.0",
+                "@babel/runtime": "7.9.2",
+                "@datawrapper/polyfills": "2.0.0-0",
+                "@datawrapper/shared": "0.23.1",
                 "@rollup/plugin-commonjs": "11.0.2",
                 "@rollup/plugin-node-resolve": "7.1.1",
                 "babel-eslint": "10.1.0",
                 "core-js": "3.6.4",
                 "fontfaceobserver": "2.1.0",
-                "rollup": "1.32.0",
-                "rollup-plugin-babel": "4.3.3",
-                "rollup-plugin-output-manifest": "1.0.2",
+                "rollup": "2.1.0",
+                "rollup-plugin-babel": "4.4.0",
                 "rollup-plugin-svelte": "5.1.1",
-                "rollup-plugin-terser": "5.2.0",
-                "svelte": "3.19.2"
+                "rollup-plugin-terser": "5.3.0",
+                "svelte": "3.20.1"
             },
             "dependencies": {
                 "@babel/code-frame": {
@@ -2845,21 +2781,22 @@
                     }
                 },
                 "@babel/core": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.7.tgz",
-                    "integrity": "sha512-rBlqF3Yko9cynC5CCFy6+K/w2N+Sq/ff2BPy+Krp7rHlABIr5epbA7OxVeKoMHB39LZOp1UY5SuLjy6uWi35yA==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
+                    "integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
                     "requires": {
                         "@babel/code-frame": "^7.8.3",
-                        "@babel/generator": "^7.8.7",
-                        "@babel/helpers": "^7.8.4",
-                        "@babel/parser": "^7.8.7",
+                        "@babel/generator": "^7.9.0",
+                        "@babel/helper-module-transforms": "^7.9.0",
+                        "@babel/helpers": "^7.9.0",
+                        "@babel/parser": "^7.9.0",
                         "@babel/template": "^7.8.6",
-                        "@babel/traverse": "^7.8.6",
-                        "@babel/types": "^7.8.7",
+                        "@babel/traverse": "^7.9.0",
+                        "@babel/types": "^7.9.0",
                         "convert-source-map": "^1.7.0",
                         "debug": "^4.1.0",
                         "gensync": "^1.0.0-beta.1",
-                        "json5": "^2.1.0",
+                        "json5": "^2.1.2",
                         "lodash": "^4.17.13",
                         "resolve": "^1.3.2",
                         "semver": "^5.4.1",
@@ -2867,11 +2804,11 @@
                     }
                 },
                 "@babel/generator": {
-                    "version": "7.8.8",
-                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.8.tgz",
-                    "integrity": "sha512-HKyUVu69cZoclptr8t8U5b6sx6zoWjh8jiUhnuj3MpZuKT2dJ8zPTuiy31luq32swhI0SpwItCIlU8XW7BZeJg==",
+                    "version": "7.9.4",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.4.tgz",
+                    "integrity": "sha512-rjP8ahaDy/ouhrvCoU1E5mqaitWrxwuNGU+dy1EpaoK48jZay4MdkskKGIMHLZNewg8sAsqpGSREJwP0zH3YQA==",
                     "requires": {
-                        "@babel/types": "^7.8.7",
+                        "@babel/types": "^7.9.0",
                         "jsesc": "^2.5.1",
                         "lodash": "^4.17.13",
                         "source-map": "^0.5.0"
@@ -2904,29 +2841,37 @@
                     }
                 },
                 "@babel/helpers": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.4.tgz",
-                    "integrity": "sha512-VPbe7wcQ4chu4TDQjimHv/5tj73qz88o12EPkO2ValS2QiQS/1F2SsjyIGNnAD0vF/nZS6Cf9i+vW6HIlnaR8w==",
+                    "version": "7.9.2",
+                    "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
+                    "integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
                     "requires": {
                         "@babel/template": "^7.8.3",
-                        "@babel/traverse": "^7.8.4",
-                        "@babel/types": "^7.8.3"
+                        "@babel/traverse": "^7.9.0",
+                        "@babel/types": "^7.9.0"
                     }
                 },
                 "@babel/highlight": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-                    "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+                    "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
                     "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
                         "js-tokens": "^4.0.0"
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.8.8",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
-                    "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
+                    "version": "7.9.4",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+                    "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
+                },
+                "@babel/runtime": {
+                    "version": "7.9.2",
+                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+                    "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+                    "requires": {
+                        "regenerator-runtime": "^0.13.4"
+                    }
                 },
                 "@babel/template": {
                     "version": "7.8.6",
@@ -2939,29 +2884,50 @@
                     }
                 },
                 "@babel/traverse": {
-                    "version": "7.8.6",
-                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
-                    "integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.0.tgz",
+                    "integrity": "sha512-jAZQj0+kn4WTHO5dUZkZKhbFrqZE7K5LAQ5JysMnmvGij+wOdr+8lWqPeW0BcF4wFwrEXXtdGO7wcV6YPJcf3w==",
                     "requires": {
                         "@babel/code-frame": "^7.8.3",
-                        "@babel/generator": "^7.8.6",
+                        "@babel/generator": "^7.9.0",
                         "@babel/helper-function-name": "^7.8.3",
                         "@babel/helper-split-export-declaration": "^7.8.3",
-                        "@babel/parser": "^7.8.6",
-                        "@babel/types": "^7.8.6",
+                        "@babel/parser": "^7.9.0",
+                        "@babel/types": "^7.9.0",
                         "debug": "^4.1.0",
                         "globals": "^11.1.0",
                         "lodash": "^4.17.13"
                     }
                 },
                 "@babel/types": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
-                    "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+                    "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
                     "requires": {
-                        "esutils": "^2.0.2",
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "@datawrapper/shared": {
+                    "version": "0.23.1",
+                    "resolved": "https://registry.npmjs.org/@datawrapper/shared/-/shared-0.23.1.tgz",
+                    "integrity": "sha512-Kr+Cy5c9IAUZbAvAkpGoURl+BSDVYs994IVZoxeo68olKh6cnM36ljqWkyb7FS8Hno5Af1YHuoUo7yxyPer1Zw==",
+                    "requires": {
+                        "chroma-js": "^2.0.3",
+                        "d3-array": "^1.2.4",
+                        "lodash-es": "^4.17.15",
+                        "sinon": "^7.3.2",
+                        "svelte": "^2.16.1",
+                        "svelte-extras": "^2.0.2",
+                        "underscore": "^1.9.1"
+                    },
+                    "dependencies": {
+                        "svelte": {
+                            "version": "2.16.1",
+                            "resolved": "https://registry.npmjs.org/svelte/-/svelte-2.16.1.tgz",
+                            "integrity": "sha512-TpXdfukSkmWkMnH6PPVm7FRW8SSFcTyqBiP+6VN8rtZJ7Lp1Xbf/e3oz73eQBxF0UPZw1aAn1b91lX2XTeD3zg=="
+                        }
                     }
                 },
                 "chalk": {
@@ -2995,10 +2961,23 @@
                         "ms": "^2.1.1"
                     }
                 },
+                "json5": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.2.tgz",
+                    "integrity": "sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==",
+                    "requires": {
+                        "minimist": "^1.2.5"
+                    }
+                },
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+                },
                 "svelte": {
-                    "version": "3.19.2",
-                    "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.19.2.tgz",
-                    "integrity": "sha512-Jswg065u8R9QYcN0rdpTQSFIr0hFq7YUzcPpEY6ZpFSAWkJKZG9AJvHE1d8+NJDTfr7SzKrO6EYssYYkUmszpA=="
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.20.1.tgz",
+                    "integrity": "sha512-m/dw52BZf+p6KYnyKLErIcGalu4pwJrQbUM7VZriRw6ZlJj1qMAZsLcIWzEB3I0hhdJwkKb7LrrvUIeqmbO92Q=="
                 }
             }
         },
@@ -3021,6 +3000,11 @@
                     "integrity": "sha512-2NDzpiuEy3+H0AVtdt8LoFi7PnqkOnIzYmJQp7xsEU6VexLluHQwKREuiz57XaQC5006seIadPrIZJhyS2n7aw=="
                 }
             }
+        },
+        "@datawrapper/polyfills": {
+            "version": "2.0.0-0",
+            "resolved": "https://registry.npmjs.org/@datawrapper/polyfills/-/polyfills-2.0.0-0.tgz",
+            "integrity": "sha512-xpgrArFGQMxyxDW2A1pYpG8UW7T+V+D4ZTsZXMOqDed4KsPUnUtPsVlglTqE5HWWv2ZIfP8dJ0hKh9r1PoLMkg=="
         },
         "@datawrapper/schemas": {
             "version": "1.3.0",
@@ -4348,7 +4332,8 @@
         "acorn": {
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-            "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
+            "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+            "dev": true
         },
         "acorn-globals": {
             "version": "3.1.0",
@@ -6056,24 +6041,25 @@
             },
             "dependencies": {
                 "browserslist": {
-                    "version": "4.9.1",
-                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.9.1.tgz",
-                    "integrity": "sha512-Q0DnKq20End3raFulq6Vfp1ecB9fh8yUNV55s8sekaDDeqBaCtWlRHCUdaWyUeSSBJM7IbM6HcsyaeYqgeDhnw==",
+                    "version": "4.11.0",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.0.tgz",
+                    "integrity": "sha512-WqEC7Yr5wUH5sg6ruR++v2SGOQYpyUdYYd4tZoAq1F7y+QXoLoYGXVbxhtaIqWmAJjtNTRjVD3HuJc1OXTel2A==",
                     "requires": {
-                        "caniuse-lite": "^1.0.30001030",
-                        "electron-to-chromium": "^1.3.363",
-                        "node-releases": "^1.1.50"
+                        "caniuse-lite": "^1.0.30001035",
+                        "electron-to-chromium": "^1.3.380",
+                        "node-releases": "^1.1.52",
+                        "pkg-up": "^3.1.0"
                     }
                 },
                 "caniuse-lite": {
-                    "version": "1.0.30001035",
-                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001035.tgz",
-                    "integrity": "sha512-C1ZxgkuA4/bUEdMbU5WrGY4+UhMFFiXrgNAfxiMIqWgFTWfv/xsZCS2xEHT2LMq7xAZfuAnu6mcqyDl0ZR6wLQ=="
+                    "version": "1.0.30001036",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001036.tgz",
+                    "integrity": "sha512-jU8CIFIj2oR7r4W+5AKcsvWNVIb6Q6OZE3UsrXrZBHFtreT4YgTeOJtTucp+zSedEpTi3L5wASSP0LYIE3if6w=="
                 },
                 "electron-to-chromium": {
-                    "version": "1.3.378",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.378.tgz",
-                    "integrity": "sha512-nBp/AfhaVIOnfwgL1CZxt80IcqWcyYXiX6v5gflAksxy+SzBVz7A7UWR1Nos92c9ofXW74V9PoapzRb0jJfYXw=="
+                    "version": "1.3.382",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.382.tgz",
+                    "integrity": "sha512-gJfxOcgnBlXhfnUUObsq3n3ReU8CT6S8je97HndYRkKsNZMJJ38zO/pI5aqO7L3Myfq+E3pqPyKK/ynyLEQfBA=="
                 },
                 "node-releases": {
                     "version": "1.1.52",
@@ -8965,6 +8951,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
             "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+            "dev": true,
             "requires": {
                 "minimist": "^1.2.0"
             }
@@ -9909,7 +9896,8 @@
         "minimist": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+            "dev": true
         },
         "minimist-options": {
             "version": "3.0.2",
@@ -10822,7 +10810,6 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
             "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
-            "dev": true,
             "requires": {
                 "p-try": "^2.0.0"
             }
@@ -10853,8 +10840,7 @@
         "p-try": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-            "dev": true
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
         },
         "package-hash": {
             "version": "4.0.0",
@@ -11256,6 +11242,46 @@
             "dev": true,
             "requires": {
                 "find-up": "^4.0.0"
+            }
+        },
+        "pkg-up": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+            "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+            "requires": {
+                "find-up": "^3.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+                }
             }
         },
         "please-upgrade-node": {
@@ -12269,7 +12295,6 @@
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
             "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
-            "dev": true,
             "requires": {
                 "regenerate": "^1.4.0"
             }
@@ -12280,9 +12305,9 @@
             "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g=="
         },
         "regenerator-transform": {
-            "version": "0.14.3",
-            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.3.tgz",
-            "integrity": "sha512-zXHNKJspmONxBViAb3ZUmFoFPnTBs3zFhCEZJiwp/gkNzxVbTqNJVjYKx6Qk1tQ1P4XLf4TbH9+KBB7wGoAaUw==",
+            "version": "0.14.4",
+            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.4.tgz",
+            "integrity": "sha512-EaJaKPBI9GvKpvUz2mz4fhx7WPgvwRLY9v3hlNHWmAuJHI13T4nwKnNvm5RWJzEdnI5g5UwtOww+S8IdoUC2bw==",
             "requires": {
                 "@babel/runtime": "^7.8.4",
                 "private": "^0.1.8"
@@ -12307,7 +12332,6 @@
             "version": "4.5.4",
             "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
             "integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
-            "dev": true,
             "requires": {
                 "regenerate": "^1.4.0",
                 "regenerate-unicode-properties": "^8.0.2",
@@ -12339,14 +12363,12 @@
         "regjsgen": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
-            "integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
-            "dev": true
+            "integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA=="
         },
         "regjsparser": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
             "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
-            "dev": true,
             "requires": {
                 "jsesc": "~0.5.0"
             },
@@ -12354,8 +12376,7 @@
                 "jsesc": {
                     "version": "0.5.0",
                     "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-                    "dev": true
+                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
                 }
             }
         },
@@ -12495,30 +12516,28 @@
             }
         },
         "rollup": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.0.tgz",
-            "integrity": "sha512-ab2tF5pdDqm2zuI8j02ceyrJSScl9V2C24FgWQ1v1kTFTu1UrG5H0hpP++mDZlEFyZX4k0chtGEHU2i+pAzBgA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.1.0.tgz",
+            "integrity": "sha512-gfE1455AEazVVTJoeQtcOq/U6GSxwoj4XPSWVsuWmgIxj7sBQNLDOSA82PbdMe+cP8ql8fR1jogPFe8Wg8g4SQ==",
             "requires": {
-                "@types/estree": "*",
-                "@types/node": "*",
-                "acorn": "^7.1.0"
+                "fsevents": "~2.1.2"
+            },
+            "dependencies": {
+                "fsevents": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+                    "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+                    "optional": true
+                }
             }
         },
         "rollup-plugin-babel": {
-            "version": "4.3.3",
-            "resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.3.3.tgz",
-            "integrity": "sha512-tKzWOCmIJD/6aKNz0H1GMM+lW1q9KyFubbWzGiOG540zxPPifnEAHTZwjo0g991Y+DyOZcLqBgqOdqazYE5fkw==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.4.0.tgz",
+            "integrity": "sha512-Lek/TYp1+7g7I+uMfJnnSJ7YWoD58ajo6Oarhlex7lvUce+RCKRuGRSgztDO3/MF/PuGKmUL5iTHKf208UNszw==",
             "requires": {
                 "@babel/helper-module-imports": "^7.0.0",
                 "rollup-pluginutils": "^2.8.1"
-            }
-        },
-        "rollup-plugin-output-manifest": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/rollup-plugin-output-manifest/-/rollup-plugin-output-manifest-1.0.2.tgz",
-            "integrity": "sha512-vRZamZW60hJnnFFSF3ycFwPnsiGlTiUHg9dWfGFBXOA9tstKTyG7ZheD4pHA1NFgK/uHG099cmSzZ9LgG8lOiQ==",
-            "requires": {
-                "tslib": "^1.10.0"
             }
         },
         "rollup-plugin-svelte": {
@@ -12532,9 +12551,9 @@
             }
         },
         "rollup-plugin-terser": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.2.0.tgz",
-            "integrity": "sha512-jQI+nYhtDBc9HFRBz8iGttQg7li9klmzR62RG2W2nN6hJ/FI2K2ItYQ7kJ7/zn+vs+BP1AEccmVRjRN989I+Nw==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.3.0.tgz",
+            "integrity": "sha512-XGMJihTIO3eIBsVGq7jiNYOdDMb3pVxuzY0uhOE/FM4x/u9nQgr3+McsjzqBn3QfHIpNSZmFnpoKAwHBEcsT7g==",
             "requires": {
                 "@babel/code-frame": "^7.5.5",
                 "jest-worker": "^24.9.0",
@@ -12552,12 +12571,12 @@
                     }
                 },
                 "@babel/highlight": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-                    "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+                    "version": "7.9.0",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+                    "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
                     "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.0",
                         "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
                         "js-tokens": "^4.0.0"
                     }
                 },
@@ -13739,8 +13758,7 @@
         "unicode-match-property-value-ecmascript": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
-            "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
-            "dev": true
+            "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g=="
         },
         "unicode-property-aliases-ecmascript": {
             "version": "1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,19 +62,19 @@
                     }
                 },
                 "caniuse-lite": {
-                    "version": "1.0.30001033",
-                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001033.tgz",
-                    "integrity": "sha512-8Ibzxee6ibc5q88cM1usPsMpJOG5CTq0s/dKOmlekPbDGKt+UrnOOTPSjQz3kVo6yL7N4SB5xd+FGLHQmbzh6A=="
+                    "version": "1.0.30001035",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001035.tgz",
+                    "integrity": "sha512-C1ZxgkuA4/bUEdMbU5WrGY4+UhMFFiXrgNAfxiMIqWgFTWfv/xsZCS2xEHT2LMq7xAZfuAnu6mcqyDl0ZR6wLQ=="
                 },
                 "electron-to-chromium": {
-                    "version": "1.3.372",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.372.tgz",
-                    "integrity": "sha512-77a4jYC52OdisHM+Tne7dgWEvQT1FoNu/jYl279pP88ZtG4ZRIPyhQwAKxj6C2rzsyC1OwsOds9JlZtNncSz6g=="
+                    "version": "1.3.378",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.378.tgz",
+                    "integrity": "sha512-nBp/AfhaVIOnfwgL1CZxt80IcqWcyYXiX6v5gflAksxy+SzBVz7A7UWR1Nos92c9ofXW74V9PoapzRb0jJfYXw=="
                 },
                 "node-releases": {
-                    "version": "1.1.51",
-                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.51.tgz",
-                    "integrity": "sha512-1eQEs6HFYY1kMXQPOLzCf7HdjReErmvn85tZESMczdCNVWP3Y7URYLBAyYynuI7yef1zj4HN5q+oB2x67QU0lw==",
+                    "version": "1.1.52",
+                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.52.tgz",
+                    "integrity": "sha512-snSiT1UypkgGt2wxPqS6ImEUICbNCMb31yaxWrOLXjhlt2z2/IBpaOxzONExqSm4y5oLnAqjjRWu+wsDzK5yNQ==",
                     "requires": {
                         "semver": "^6.3.0"
                     },
@@ -287,9 +287,9 @@
                     }
                 },
                 "@babel/generator": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.7.tgz",
-                    "integrity": "sha512-DQwjiKJqH4C3qGiyQCAExJHoZssn49JTMJgZ8SANGgVFdkupcUhLOdkAeoC6kmHZCPfoDG5M0b6cFlSN5wW7Ew==",
+                    "version": "7.8.8",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.8.tgz",
+                    "integrity": "sha512-HKyUVu69cZoclptr8t8U5b6sx6zoWjh8jiUhnuj3MpZuKT2dJ8zPTuiy31luq32swhI0SpwItCIlU8XW7BZeJg==",
                     "requires": {
                         "@babel/types": "^7.8.7",
                         "jsesc": "^2.5.1",
@@ -334,9 +334,9 @@
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
-                    "integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
+                    "version": "7.8.8",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
+                    "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
                 },
                 "@babel/template": {
                     "version": "7.8.6",
@@ -417,19 +417,19 @@
                     }
                 },
                 "caniuse-lite": {
-                    "version": "1.0.30001033",
-                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001033.tgz",
-                    "integrity": "sha512-8Ibzxee6ibc5q88cM1usPsMpJOG5CTq0s/dKOmlekPbDGKt+UrnOOTPSjQz3kVo6yL7N4SB5xd+FGLHQmbzh6A=="
+                    "version": "1.0.30001035",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001035.tgz",
+                    "integrity": "sha512-C1ZxgkuA4/bUEdMbU5WrGY4+UhMFFiXrgNAfxiMIqWgFTWfv/xsZCS2xEHT2LMq7xAZfuAnu6mcqyDl0ZR6wLQ=="
                 },
                 "electron-to-chromium": {
-                    "version": "1.3.372",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.372.tgz",
-                    "integrity": "sha512-77a4jYC52OdisHM+Tne7dgWEvQT1FoNu/jYl279pP88ZtG4ZRIPyhQwAKxj6C2rzsyC1OwsOds9JlZtNncSz6g=="
+                    "version": "1.3.378",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.378.tgz",
+                    "integrity": "sha512-nBp/AfhaVIOnfwgL1CZxt80IcqWcyYXiX6v5gflAksxy+SzBVz7A7UWR1Nos92c9ofXW74V9PoapzRb0jJfYXw=="
                 },
                 "node-releases": {
-                    "version": "1.1.51",
-                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.51.tgz",
-                    "integrity": "sha512-1eQEs6HFYY1kMXQPOLzCf7HdjReErmvn85tZESMczdCNVWP3Y7URYLBAyYynuI7yef1zj4HN5q+oB2x67QU0lw==",
+                    "version": "1.1.52",
+                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.52.tgz",
+                    "integrity": "sha512-snSiT1UypkgGt2wxPqS6ImEUICbNCMb31yaxWrOLXjhlt2z2/IBpaOxzONExqSm4y5oLnAqjjRWu+wsDzK5yNQ==",
                     "requires": {
                         "semver": "^6.3.0"
                     },
@@ -444,13 +444,13 @@
             }
         },
         "@babel/helper-create-regexp-features-plugin": {
-            "version": "7.8.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.6.tgz",
-            "integrity": "sha512-bPyujWfsHhV/ztUkwGHz/RPV1T1TDEsSZDsN42JPehndA+p1KKTh3npvTadux0ZhCrytx9tvjpWNowKby3tM6A==",
+            "version": "7.8.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.8.tgz",
+            "integrity": "sha512-LYVPdwkrQEiX9+1R29Ld/wTrmQu1SSKYnuOk3g0CkcZMA1p0gsNxJFj/3gBdaJ7Cg0Fnek5z0DsMULePP7Lrqg==",
             "requires": {
                 "@babel/helper-annotate-as-pure": "^7.8.3",
                 "@babel/helper-regex": "^7.8.3",
-                "regexpu-core": "^4.6.0"
+                "regexpu-core": "^4.7.0"
             },
             "dependencies": {
                 "@babel/helper-annotate-as-pure": {
@@ -479,18 +479,49 @@
                         "to-fast-properties": "^2.0.0"
                     }
                 },
+                "jsesc": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+                },
+                "regenerate-unicode-properties": {
+                    "version": "8.2.0",
+                    "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
+                    "integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
+                    "requires": {
+                        "regenerate": "^1.4.0"
+                    }
+                },
                 "regexpu-core": {
-                    "version": "4.6.0",
-                    "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
-                    "integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
+                    "version": "4.7.0",
+                    "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.0.tgz",
+                    "integrity": "sha512-TQ4KXRnIn6tz6tjnrXEkD/sshygKH/j5KzK86X8MkeHyZ8qst/LZ89j3X4/8HEIfHANTFIP/AbXakeRhWIl5YQ==",
                     "requires": {
                         "regenerate": "^1.4.0",
-                        "regenerate-unicode-properties": "^8.1.0",
-                        "regjsgen": "^0.5.0",
-                        "regjsparser": "^0.6.0",
+                        "regenerate-unicode-properties": "^8.2.0",
+                        "regjsgen": "^0.5.1",
+                        "regjsparser": "^0.6.4",
                         "unicode-match-property-ecmascript": "^1.0.4",
-                        "unicode-match-property-value-ecmascript": "^1.1.0"
+                        "unicode-match-property-value-ecmascript": "^1.2.0"
                     }
+                },
+                "regjsgen": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
+                    "integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg=="
+                },
+                "regjsparser": {
+                    "version": "0.6.4",
+                    "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.4.tgz",
+                    "integrity": "sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==",
+                    "requires": {
+                        "jsesc": "~0.5.0"
+                    }
+                },
+                "unicode-match-property-value-ecmascript": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
+                    "integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ=="
                 }
             }
         },
@@ -541,9 +572,9 @@
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
-                    "integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
+                    "version": "7.8.8",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
+                    "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
                 },
                 "@babel/template": {
                     "version": "7.8.6",
@@ -595,9 +626,9 @@
                     }
                 },
                 "@babel/generator": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.7.tgz",
-                    "integrity": "sha512-DQwjiKJqH4C3qGiyQCAExJHoZssn49JTMJgZ8SANGgVFdkupcUhLOdkAeoC6kmHZCPfoDG5M0b6cFlSN5wW7Ew==",
+                    "version": "7.8.8",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.8.tgz",
+                    "integrity": "sha512-HKyUVu69cZoclptr8t8U5b6sx6zoWjh8jiUhnuj3MpZuKT2dJ8zPTuiy31luq32swhI0SpwItCIlU8XW7BZeJg==",
                     "requires": {
                         "@babel/types": "^7.8.7",
                         "jsesc": "^2.5.1",
@@ -642,9 +673,9 @@
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
-                    "integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
+                    "version": "7.8.8",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
+                    "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
                 },
                 "@babel/template": {
                     "version": "7.8.6",
@@ -823,9 +854,9 @@
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
-                    "integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
+                    "version": "7.8.8",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
+                    "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
                 },
                 "@babel/template": {
                     "version": "7.8.6",
@@ -927,9 +958,9 @@
                     }
                 },
                 "@babel/generator": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.7.tgz",
-                    "integrity": "sha512-DQwjiKJqH4C3qGiyQCAExJHoZssn49JTMJgZ8SANGgVFdkupcUhLOdkAeoC6kmHZCPfoDG5M0b6cFlSN5wW7Ew==",
+                    "version": "7.8.8",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.8.tgz",
+                    "integrity": "sha512-HKyUVu69cZoclptr8t8U5b6sx6zoWjh8jiUhnuj3MpZuKT2dJ8zPTuiy31luq32swhI0SpwItCIlU8XW7BZeJg==",
                     "requires": {
                         "@babel/types": "^7.8.7",
                         "jsesc": "^2.5.1",
@@ -974,9 +1005,9 @@
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
-                    "integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
+                    "version": "7.8.8",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
+                    "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
                 },
                 "@babel/template": {
                     "version": "7.8.6",
@@ -1062,9 +1093,9 @@
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
-                    "integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
+                    "version": "7.8.8",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
+                    "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
                 },
                 "@babel/template": {
                     "version": "7.8.6",
@@ -1362,11 +1393,11 @@
             }
         },
         "@babel/plugin-proposal-unicode-property-regex": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.8.3.tgz",
-            "integrity": "sha512-1/1/rEZv2XGweRwwSkLpY+s60za9OZ1hJs4YDqFHCw0kYWYwL5IFljVY1MYBL+weT1l9pokDO2uhSTLVxzoHkQ==",
+            "version": "7.8.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.8.8.tgz",
+            "integrity": "sha512-EVhjVsMpbhLw9ZfHWSx2iy13Q8Z/eg8e8ccVWt23sWQK5l1UdkoLJPN5w69UA4uITGBnEZD2JOe4QOHycYKv8A==",
             "requires": {
-                "@babel/helper-create-regexp-features-plugin": "^7.8.3",
+                "@babel/helper-create-regexp-features-plugin": "^7.8.8",
                 "@babel/helper-plugin-utils": "^7.8.3"
             },
             "dependencies": {
@@ -1513,9 +1544,9 @@
                     }
                 },
                 "@babel/generator": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.7.tgz",
-                    "integrity": "sha512-DQwjiKJqH4C3qGiyQCAExJHoZssn49JTMJgZ8SANGgVFdkupcUhLOdkAeoC6kmHZCPfoDG5M0b6cFlSN5wW7Ew==",
+                    "version": "7.8.8",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.8.tgz",
+                    "integrity": "sha512-HKyUVu69cZoclptr8t8U5b6sx6zoWjh8jiUhnuj3MpZuKT2dJ8zPTuiy31luq32swhI0SpwItCIlU8XW7BZeJg==",
                     "requires": {
                         "@babel/types": "^7.8.7",
                         "jsesc": "^2.5.1",
@@ -1596,9 +1627,9 @@
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
-                    "integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
+                    "version": "7.8.8",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
+                    "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
                 },
                 "@babel/template": {
                     "version": "7.8.6",
@@ -1760,9 +1791,9 @@
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
-                    "integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
+                    "version": "7.8.8",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
+                    "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
                 },
                 "@babel/template": {
                     "version": "7.8.6",
@@ -1812,9 +1843,9 @@
             }
         },
         "@babel/plugin-transform-destructuring": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.8.3.tgz",
-            "integrity": "sha512-H4X646nCkiEcHZUZaRkhE2XVsoz0J/1x3VVujnn96pSoGCtKPA99ZZA+va+gK+92Zycd6OBKCD8tDb/731bhgQ==",
+            "version": "7.8.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.8.8.tgz",
+            "integrity": "sha512-eRJu4Vs2rmttFCdhPUM3bV0Yo/xPSdPw6ML9KHs/bjB4bLA5HXlbvYXPOD5yASodGod+krjYx21xm1QmL8dCJQ==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.8.3"
             },
@@ -1934,9 +1965,9 @@
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
-                    "integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
+                    "version": "7.8.8",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
+                    "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
                 },
                 "@babel/template": {
                     "version": "7.8.6",
@@ -2175,9 +2206,9 @@
             }
         },
         "@babel/plugin-transform-parameters": {
-            "version": "7.8.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.7.tgz",
-            "integrity": "sha512-brYWaEPTRimOctz2NDA3jnBbDi7SVN2T4wYuu0aqSzxC3nozFZngGaw29CJ9ZPweB7k+iFmZuoG3IVPIcXmD2g==",
+            "version": "7.8.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.8.tgz",
+            "integrity": "sha512-hC4Ld/Ulpf1psQciWWwdnUspQoQco2bMzSrwU6TmzRlvoYQe4rQFy9vnCZDTlVeCQj0JPfL+1RX0V8hCJvkgBA==",
             "requires": {
                 "@babel/helper-call-delegate": "^7.8.7",
                 "@babel/helper-get-function-arity": "^7.8.3",
@@ -2457,9 +2488,9 @@
                     }
                 },
                 "@babel/generator": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.7.tgz",
-                    "integrity": "sha512-DQwjiKJqH4C3qGiyQCAExJHoZssn49JTMJgZ8SANGgVFdkupcUhLOdkAeoC6kmHZCPfoDG5M0b6cFlSN5wW7Ew==",
+                    "version": "7.8.8",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.8.tgz",
+                    "integrity": "sha512-HKyUVu69cZoclptr8t8U5b6sx6zoWjh8jiUhnuj3MpZuKT2dJ8zPTuiy31luq32swhI0SpwItCIlU8XW7BZeJg==",
                     "requires": {
                         "@babel/types": "^7.8.7",
                         "jsesc": "^2.5.1",
@@ -2540,9 +2571,9 @@
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
-                    "integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
+                    "version": "7.8.8",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
+                    "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
                 },
                 "@babel/plugin-proposal-async-generator-functions": {
                     "version": "7.8.3",
@@ -2663,9 +2694,9 @@
                     }
                 },
                 "caniuse-lite": {
-                    "version": "1.0.30001033",
-                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001033.tgz",
-                    "integrity": "sha512-8Ibzxee6ibc5q88cM1usPsMpJOG5CTq0s/dKOmlekPbDGKt+UrnOOTPSjQz3kVo6yL7N4SB5xd+FGLHQmbzh6A=="
+                    "version": "1.0.30001035",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001035.tgz",
+                    "integrity": "sha512-C1ZxgkuA4/bUEdMbU5WrGY4+UhMFFiXrgNAfxiMIqWgFTWfv/xsZCS2xEHT2LMq7xAZfuAnu6mcqyDl0ZR6wLQ=="
                 },
                 "chalk": {
                     "version": "2.4.2",
@@ -2686,14 +2717,14 @@
                     }
                 },
                 "electron-to-chromium": {
-                    "version": "1.3.372",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.372.tgz",
-                    "integrity": "sha512-77a4jYC52OdisHM+Tne7dgWEvQT1FoNu/jYl279pP88ZtG4ZRIPyhQwAKxj6C2rzsyC1OwsOds9JlZtNncSz6g=="
+                    "version": "1.3.378",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.378.tgz",
+                    "integrity": "sha512-nBp/AfhaVIOnfwgL1CZxt80IcqWcyYXiX6v5gflAksxy+SzBVz7A7UWR1Nos92c9ofXW74V9PoapzRb0jJfYXw=="
                 },
                 "node-releases": {
-                    "version": "1.1.51",
-                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.51.tgz",
-                    "integrity": "sha512-1eQEs6HFYY1kMXQPOLzCf7HdjReErmvn85tZESMczdCNVWP3Y7URYLBAyYynuI7yef1zj4HN5q+oB2x67QU0lw==",
+                    "version": "1.1.52",
+                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.52.tgz",
+                    "integrity": "sha512-snSiT1UypkgGt2wxPqS6ImEUICbNCMb31yaxWrOLXjhlt2z2/IBpaOxzONExqSm4y5oLnAqjjRWu+wsDzK5yNQ==",
                     "requires": {
                         "semver": "^6.3.0"
                     },
@@ -2783,9 +2814,9 @@
             }
         },
         "@datawrapper/chart-core": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-6.0.0.tgz",
-            "integrity": "sha512-y0Fb5ERMdM7pWmh+0+RPsm1a6o0Kr6iRpocb6y0asnRtj0H2/vYgIQFfwtdkKGPm8ycRWG2v+K+yoeaD2odYsA==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-7.0.0.tgz",
+            "integrity": "sha512-zFP+43RSL47oUyFoO3ItKmTZQC4pjnH6IopcCAdOxEuMUT0zOhjTJRE+ACshuiN62UtwYl4mkUKNb3PZOCwGMA==",
             "requires": {
                 "@babel/core": "7.8.7",
                 "@babel/plugin-transform-runtime": "7.8.3",
@@ -2836,9 +2867,9 @@
                     }
                 },
                 "@babel/generator": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.7.tgz",
-                    "integrity": "sha512-DQwjiKJqH4C3qGiyQCAExJHoZssn49JTMJgZ8SANGgVFdkupcUhLOdkAeoC6kmHZCPfoDG5M0b6cFlSN5wW7Ew==",
+                    "version": "7.8.8",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.8.tgz",
+                    "integrity": "sha512-HKyUVu69cZoclptr8t8U5b6sx6zoWjh8jiUhnuj3MpZuKT2dJ8zPTuiy31luq32swhI0SpwItCIlU8XW7BZeJg==",
                     "requires": {
                         "@babel/types": "^7.8.7",
                         "jsesc": "^2.5.1",
@@ -2893,9 +2924,9 @@
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.8.7",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
-                    "integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
+                    "version": "7.8.8",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
+                    "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
                 },
                 "@babel/template": {
                     "version": "7.8.6",
@@ -2972,9 +3003,9 @@
             }
         },
         "@datawrapper/orm": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/@datawrapper/orm/-/orm-3.9.0.tgz",
-            "integrity": "sha512-CM8NYtAndJi4FFVqqzN/OJhTbbJGIslFLELjQzIwswwSpb6VOIpn/T+kXFEXLbsEXakgLC/lD2WsJBfrC7d41A==",
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@datawrapper/orm/-/orm-3.10.1.tgz",
+            "integrity": "sha512-N6LTx9OSHpYO5YCOuYl8TJu5U0R6Au75wkruzAUsfbdzLzcFBPuLISM/801XCjfc5QoGIQN7Icj2IKXvOSVZjw==",
             "requires": {
                 "assign-deep": "^1.0.1",
                 "merge-deep": "^3.0.2",
@@ -6035,19 +6066,19 @@
                     }
                 },
                 "caniuse-lite": {
-                    "version": "1.0.30001033",
-                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001033.tgz",
-                    "integrity": "sha512-8Ibzxee6ibc5q88cM1usPsMpJOG5CTq0s/dKOmlekPbDGKt+UrnOOTPSjQz3kVo6yL7N4SB5xd+FGLHQmbzh6A=="
+                    "version": "1.0.30001035",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001035.tgz",
+                    "integrity": "sha512-C1ZxgkuA4/bUEdMbU5WrGY4+UhMFFiXrgNAfxiMIqWgFTWfv/xsZCS2xEHT2LMq7xAZfuAnu6mcqyDl0ZR6wLQ=="
                 },
                 "electron-to-chromium": {
-                    "version": "1.3.372",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.372.tgz",
-                    "integrity": "sha512-77a4jYC52OdisHM+Tne7dgWEvQT1FoNu/jYl279pP88ZtG4ZRIPyhQwAKxj6C2rzsyC1OwsOds9JlZtNncSz6g=="
+                    "version": "1.3.378",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.378.tgz",
+                    "integrity": "sha512-nBp/AfhaVIOnfwgL1CZxt80IcqWcyYXiX6v5gflAksxy+SzBVz7A7UWR1Nos92c9ofXW74V9PoapzRb0jJfYXw=="
                 },
                 "node-releases": {
-                    "version": "1.1.51",
-                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.51.tgz",
-                    "integrity": "sha512-1eQEs6HFYY1kMXQPOLzCf7HdjReErmvn85tZESMczdCNVWP3Y7URYLBAyYynuI7yef1zj4HN5q+oB2x67QU0lw==",
+                    "version": "1.1.52",
+                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.52.tgz",
+                    "integrity": "sha512-snSiT1UypkgGt2wxPqS6ImEUICbNCMb31yaxWrOLXjhlt2z2/IBpaOxzONExqSm4y5oLnAqjjRWu+wsDzK5yNQ==",
                     "requires": {
                         "semver": "^6.3.0"
                     },
@@ -12238,6 +12269,7 @@
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
             "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
+            "dev": true,
             "requires": {
                 "regenerate": "^1.4.0"
             }
@@ -12248,9 +12280,9 @@
             "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g=="
         },
         "regenerator-transform": {
-            "version": "0.14.2",
-            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.2.tgz",
-            "integrity": "sha512-V4+lGplCM/ikqi5/mkkpJ06e9Bujq1NFmNLvsCs56zg3ZbzrnUzAtizZ24TXxtRX/W2jcdScwQCnbL0CICTFkQ==",
+            "version": "0.14.3",
+            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.3.tgz",
+            "integrity": "sha512-zXHNKJspmONxBViAb3ZUmFoFPnTBs3zFhCEZJiwp/gkNzxVbTqNJVjYKx6Qk1tQ1P4XLf4TbH9+KBB7wGoAaUw==",
             "requires": {
                 "@babel/runtime": "^7.8.4",
                 "private": "^0.1.8"
@@ -12307,12 +12339,14 @@
         "regjsgen": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
-            "integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA=="
+            "integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
+            "dev": true
         },
         "regjsparser": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
             "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+            "dev": true,
             "requires": {
                 "jsesc": "~0.5.0"
             },
@@ -12320,7 +12354,8 @@
                 "jsesc": {
                     "version": "0.5.0",
                     "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+                    "dev": true
                 }
             }
         },
@@ -12656,11 +12691,6 @@
                     "version": "6.3.0",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                     "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-                },
-                "uuid": {
-                    "version": "3.4.0",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
                 }
             }
         },
@@ -13452,9 +13482,9 @@
             }
         },
         "terser": {
-            "version": "4.6.6",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.6.tgz",
-            "integrity": "sha512-4lYPyeNmstjIIESr/ysHg2vUPRGf2tzF9z2yYwnowXVuVzLEamPN1Gfrz7f8I9uEPuHcbFlW4PLIAsJoxXyJ1g==",
+            "version": "4.6.7",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.7.tgz",
+            "integrity": "sha512-fmr7M1f7DBly5cX2+rFDvmGBAaaZyPrHYK4mMdHEDAdNTqXSZgSOfqsfGq2HqPGT/1V0foZZuCZFx8CHKgAk3g==",
             "requires": {
                 "commander": "^2.20.0",
                 "source-map": "~0.6.1",
@@ -13709,7 +13739,8 @@
         "unicode-match-property-value-ecmascript": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
-            "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g=="
+            "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
+            "dev": true
         },
         "unicode-property-aliases-ecmascript": {
             "version": "1.0.5",
@@ -13829,8 +13860,7 @@
         "uuid": {
             "version": "3.4.0",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-            "optional": true
+            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         },
         "v8-compile-cache": {
             "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "url": "git+https://github.com/datawrapper/datawrapper-api.git"
     },
     "dependencies": {
-        "@datawrapper/chart-core": "7.0.0",
+        "@datawrapper/chart-core": "8.0.0-1",
         "@datawrapper/orm": "3.10.1",
         "@datawrapper/schemas": "^1.3.0",
         "@datawrapper/shared": "0.23.0",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
         "url": "git+https://github.com/datawrapper/datawrapper-api.git"
     },
     "dependencies": {
-        "@datawrapper/chart-core": "6.0.0",
-        "@datawrapper/orm": "^3.9.0",
+        "@datawrapper/chart-core": "7.0.0",
+        "@datawrapper/orm": "3.10.1",
         "@datawrapper/schemas": "^1.3.0",
         "@datawrapper/shared": "0.23.0",
         "@hapi/boom": "9.0.0",

--- a/src/publish/index.pug
+++ b/src/publish/index.pug
@@ -17,17 +17,5 @@ html(lang="en")
 
     script.
       window.parent.postMessage('datawrapper:vis:reload', '*');
-      /* Modified version of https://jasonformat.com/modern-script-loading/ */
-      $loadjs(JSON.parse(!{CORE_SCRIPT}))
-      function $loadjs(js,s,p) {
-        s = document.createElement('script')
-        if ('noModule' in s) s.type = 'module', s.src = js['main.js']
-        else {
-          s.src = js['main.legacy.js']
-          p = document.createElement('script')
-          /* polyfill needed for svelte 3 code in IE11 */
-          p.src = "document-register-element.js"
-          document.head.appendChild(p)
-        }
-        document.head.appendChild(s)
-      }
+
+    script(src=CORE_SCRIPT)

--- a/src/publish/publish.js
+++ b/src/publish/publish.js
@@ -84,7 +84,8 @@ async function publishChart(request, h) {
             themeId: theme.id,
             fontsJSON: theme.fonts,
             typographyJSON: theme.data.typography,
-            templateJS: false
+            templateJS: false,
+            polyfillUri: `../../lib/vendor`
         },
         theme,
         translations
@@ -94,17 +95,24 @@ async function publishChart(request, h) {
     let dependencies = getDependencies({
         locale: chart.language,
         dependencies: vis.dependencies
-    });
+    }).map(file => path.join(chartCore.path.vendor, file));
 
     /* Create a temporary directory */
     const outDir = await fs.mkdtemp(path.resolve(os.tmpdir(), `dw-chart-${chart.id}-`));
 
     /* Copy dependencies into temporary directory and hash them on the way */
-    const dependencyPromises = dependencies.map(filePath => {
-        return copyFileHashed(path.join(chartCore.path.vendor, filePath), outDir);
-    });
+    const dependencyPromises = [dependencies, vis.libraries.map(lib => lib.file)]
+        .flat()
+        .map(filePath => copyFileHashed(filePath, outDir));
 
-    dependencies = await Promise.all(dependencyPromises);
+    dependencies = (await Promise.all(dependencyPromises)).map(file => [file, 'lib/vendor/']);
+
+    const [coreScript] = await Promise.all([
+        copyFileHashed(path.join(chartCore.path.vendor, 'main.js'), path.join(outDir)),
+        fs.writeFile(path.join(outDir, fileName), content)
+    ]);
+
+    dependencies.push([fileName, 'lib/vis/']);
 
     /**
      * Render the visualizations entry: "index.html"
@@ -113,16 +121,9 @@ async function publishChart(request, h) {
         __DW_SVELTE_PROPS__: stringify(props),
         CHART_HTML: html,
         CHART_HEAD: head,
-        CORE_SCRIPT: stringify(chartCore.script),
+        CORE_SCRIPT: `../../lib/${coreScript}`,
         CSS: css,
-        SCRIPTS: [
-            dependencies.map(d => d.split('/').pop()),
-            vis.libraries.map(lib =>
-                /* TODO: local <> cdn switch */
-                lib.cdn.replace('%asset_domain%', 'datawrapper-stg.dwcdn.net')
-            ),
-            fileName
-        ].flat(),
+        SCRIPTS: dependencies.map(([file, prefix]) => `../../${prefix}${file}`),
         CHART_CLASS: [
             `vis-height-${get(vis, 'height', 'fit')}`,
             `theme-${get(theme, 'id')}`,
@@ -130,24 +131,18 @@ async function publishChart(request, h) {
         ]
     });
 
-    /* start writing static assets adn global dependencies */
-    const filePromises = [
-        'document-register-element.js' /* TODO: check if this can move into main.legacy.js */,
-        chartCore.script['main.js'],
-        chartCore.script['main.legacy.js']
-    ].map(filePath =>
-        fs.copyFile(
-            path.join(chartCore.path.vendor, filePath),
-            path.join(outDir, path.basename(filePath))
-        )
-    );
+    /* Copy polyfills to destination */
+    const polyfillPromises = chartCore.polyfills.map(async filePath => {
+        const file = path.basename(filePath);
+        await fs.copyFile(filePath, path.join(outDir, file));
+        return [file, 'lib/vendor/'];
+    });
+
+    const polyfillFiles = await Promise.all(polyfillPromises);
 
     /* write "index.html", visualization Javascript and other assets */
-    await Promise.all([
-        fs.writeFile(path.join(outDir, 'index.html'), indexHTML, { encoding: 'utf-8' }),
-        fs.writeFile(path.join(outDir, fileName), content),
-        ...filePromises
-    ]);
+    await fs.writeFile(path.join(outDir, 'index.html'), indexHTML, { encoding: 'utf-8' });
+    const fileMap = [...dependencies, ...polyfillFiles, [coreScript, 'lib/'], ['index.html']];
 
     /**
      * The hard work is done!
@@ -160,15 +155,17 @@ async function publishChart(request, h) {
 
     /* move assets to publish location */
     let destination, eventError;
+
     try {
+        /* NOTE: temp fix until we change the bulkData implementation */
+        const dbChart = await Chart.findByPk(chart.id);
         destination = await events.emit(
             event.PUBLISH_CHART,
             {
                 outDir,
-                chart: {
-                    id: chart.id,
-                    public_version: newPublicVersion
-                }
+                fileMap,
+                publicVersion: newPublicVersion,
+                chart: dbChart
             },
             { filter: 'first' }
         );

--- a/src/server.js
+++ b/src/server.js
@@ -4,13 +4,13 @@ const Joi = require('@hapi/joi');
 const HapiSwagger = require('hapi-swagger');
 const get = require('lodash/get');
 const ORM = require('@datawrapper/orm');
-const fs = require('fs');
-const { promisify } = require('util');
+const fs = require('fs-extra');
+const path = require('path');
 const { validateAPI, validateORM, validateFrontend } = require('@datawrapper/schemas/config');
 const schemas = require('@datawrapper/schemas');
 const { findConfigPath } = require('@datawrapper/shared/node/findConfig');
 
-const readFile = promisify(fs.readFile);
+const CodedError = require('@datawrapper/shared/CodedError');
 
 const { generateToken } = require('./utils');
 const { ApiEventEmitter, eventList } = require('./utils/events');
@@ -149,7 +149,6 @@ async function configure(options = { usePlugins: true, useOpenAPI: true }) {
     server.method('config', key => (key ? config[key] : config));
     server.method('generateToken', generateToken);
     server.method('logAction', require('@datawrapper/orm/utils/action').logAction);
-    server.method('readJSON', (path, options) => readFile(path, options).then(JSON.parse));
 
     const { validateThemeData } = schemas.initialize({
         getSchema: config.api.schemaBaseUrl
@@ -176,6 +175,68 @@ async function configure(options = { usePlugins: true, useOpenAPI: true }) {
 
     if (options.usePlugins) {
         await server.register([require('./plugin-loader')], routeOptions);
+    }
+
+    const { events, event } = server.app;
+    const { general, frontend } = server.methods.config();
+    const { localChartAssetRoot } = general;
+    const registeredEvents = events.eventNames();
+    const hasRegisteredDataPlugins =
+        registeredEvents.includes(event.GET_CHART_ASSET) &&
+        registeredEvents.includes(event.PUT_CHART_ASSET);
+
+    if (localChartAssetRoot === undefined && !hasRegisteredDataPlugins) {
+        server
+            .logger()
+            .error(
+                '[Config] You need to configure `general.localChartAssetRoot` or install a plugin that implements chart asset storage.'
+            );
+        process.exit(1);
+    }
+
+    if (!hasRegisteredDataPlugins) {
+        events.on(event.GET_CHART_ASSET, async function({ chart, filename }) {
+            const filePath = path.join(
+                localChartAssetRoot,
+                getDataPath(chart.dataValues.created_at),
+                filename
+            );
+            try {
+                await fs.access(filePath, fs.constants.R_OK);
+            } catch (e) {
+                throw new CodedError('notFound', 'chart asset not found');
+            }
+            return fs.createReadStream(filePath);
+        });
+
+        events.on(event.PUT_CHART_ASSET, async function({ chart, data, filename }) {
+            const outPath = path.join(
+                localChartAssetRoot,
+                getDataPath(chart.dataValues.created_at)
+            );
+
+            await fs.mkdir(outPath, { recursive: true });
+            await fs.writeFile(path.join(outPath, filename), data);
+            return { code: 200 };
+        });
+    }
+
+    const hasRegisteredPublishPlugin = registeredEvents.includes(event.PUBLISH_CHART);
+
+    if (!hasRegisteredPublishPlugin) {
+        const protocol = frontend.https ? 'https' : 'http';
+        events.on(event.PUBLISH_CHART, async ({ chart, outDir, fileMap }) => {
+            const dest = path.resolve(general.localChartPublishRoot, chart.publicId);
+
+            for (const [file, dir] of fileMap) {
+                const out = dir ? path.resolve(dest, '..', dir, file) : path.resolve(dest, file);
+                await fs.copy(path.join(outDir, file), out, { overwrite: !dir });
+            }
+
+            await fs.remove(outDir);
+
+            return `${protocol}://${general.chart_domain}/${chart.publicId}`;
+        });
     }
 
     server.route({
@@ -236,6 +297,12 @@ function loadSchemaFromUrl(baseUrl) {
 
         return body;
     };
+}
+
+function getDataPath(date) {
+    const year = date.getUTCFullYear();
+    const month = (date.getUTCMonth() + 1).toString().padStart(2, '0');
+    return `${year}${month}`;
 }
 
 module.exports = { init, start };


### PR DESCRIPTION
Changes: 
* The `publish` function now creates a temporary directory with a `lib` folder and `index.html`. Before, everything was directly in the top level of the temp directory. That means publishing plugins can upload `index.html` in a versioned directory like before, eg. `/{chart-id}/4` and the other files are copied directly into a common lib directory.  
~**Example from S3:**~

* Visualization plugins can define JS libraries that will get copied together with other assets into the `lib` directory. You can see the Mapbox script file with hash in the image above. 
Example: 
```js
// https://github.com/datawrapper/plugin-locator-maps/commit/f69d4dc04f06d637a01c2eb323efa741f49a132b
server.methods.registerVisualization('locator-map', [
    {
        id: 'locator-map',
        /* ... */
        libraries: [
            {
                file: path.join(__dirname, 'static', 'vendor', 'mapbox-gl.min.js'),
                uri: '/static/plugins/locator-maps/vendor/mapbox-gl.min.js'
            }
        ]
    }
]);
```
`uri` is a path that's served via our app and used for the chart **preview**.

In my tests this worked fine with the [`publish-cloud`](https://github.com/datawrapper/plugin-publish-cloud/tree/node-publishing) plugin. S3 had no issues at all and GCS worked but sometimes threw an error that didn't help me much. That might have been because of a configuration issue on my side.
> Cannot insert legacy ACL for an object when uniform bucket-level access is enabled. Read more at https://cloud.google.com/storage/docs/uniform-bucket-level-access

* I moved the fallback data and publish event listeners after the plugin registration into `server.js`. Otherwise they would register event handlers even though a plugin already provided them.