### PR TITLE
team members may delete team charts, too

### DIFF
--- a/src/routes/charts.js
+++ b/src/routes/charts.js
@@ -841,7 +841,7 @@ async function deleteChart(request, h) {
 
     if (!chart) return Boom.notFound();
 
-    if (!server.methods.isAdmin(request) || !(await chart.isWritableBy(auth.artifacts))) {
+    if (!server.methods.isAdmin(request) || !(await chart.isEditableBy(auth.artifacts))) {
         return Boom.forbidden();
     }
 

--- a/src/routes/charts.js
+++ b/src/routes/charts.js
@@ -834,17 +834,13 @@ async function deleteChart(request, h) {
         }
     };
 
-    if (!server.methods.isAdmin(request)) {
-        if (auth.artifacts.role === 'guest') {
-            set(options, ['where', 'guest_session'], auth.credentials.session);
-        } else {
-            set(options, ['where', 'author_id'], auth.artifacts.id);
-        }
-    }
-
     const chart = await Chart.findOne(options);
 
-    if (!chart) return Boom.forbidden();
+    if (!chart) return Boom.notFound();
+
+    if (!server.methods.isAdmin(request) || !(await chart.isWritableBy(auth.artifacts))) {
+        return Boom.forbidden();
+    }
 
     await chart.update({
         deleted: true,


### PR DESCRIPTION
this PR fixes a bug that prevents team members from deleting team charts by other users. Ideally I would like to add a test that checks that both the edit team chart and delete team chart by other users work.