### PR TITLE
Make chart blocks ready for publishing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,29 +63,19 @@
                     }
                 },
                 "caniuse-lite": {
-                    "version": "1.0.30001036",
-                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001036.tgz",
-                    "integrity": "sha512-jU8CIFIj2oR7r4W+5AKcsvWNVIb6Q6OZE3UsrXrZBHFtreT4YgTeOJtTucp+zSedEpTi3L5wASSP0LYIE3if6w=="
+                    "version": "1.0.30001038",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001038.tgz",
+                    "integrity": "sha512-zii9quPo96XfOiRD4TrfYGs+QsGZpb2cGiMAzPjtf/hpFgB6zCPZgJb7I1+EATeMw/o+lG8FyRAnI+CWStHcaQ=="
                 },
                 "electron-to-chromium": {
-                    "version": "1.3.382",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.382.tgz",
-                    "integrity": "sha512-gJfxOcgnBlXhfnUUObsq3n3ReU8CT6S8je97HndYRkKsNZMJJ38zO/pI5aqO7L3Myfq+E3pqPyKK/ynyLEQfBA=="
+                    "version": "1.3.390",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.390.tgz",
+                    "integrity": "sha512-4RvbM5x+002gKI8sltkqWEk5pptn0UnzekUx8RTThAMPDSb8jjpm6SwGiSnEve7f85biyZl8DMXaipaCxDjXag=="
                 },
                 "node-releases": {
-                    "version": "1.1.52",
-                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.52.tgz",
-                    "integrity": "sha512-snSiT1UypkgGt2wxPqS6ImEUICbNCMb31yaxWrOLXjhlt2z2/IBpaOxzONExqSm4y5oLnAqjjRWu+wsDzK5yNQ==",
-                    "requires": {
-                        "semver": "^6.3.0"
-                    },
-                    "dependencies": {
-                        "semver": {
-                            "version": "6.3.0",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-                        }
-                    }
+                    "version": "1.1.53",
+                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.53.tgz",
+                    "integrity": "sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ=="
                 }
             }
         },
@@ -293,29 +283,19 @@
                     }
                 },
                 "caniuse-lite": {
-                    "version": "1.0.30001036",
-                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001036.tgz",
-                    "integrity": "sha512-jU8CIFIj2oR7r4W+5AKcsvWNVIb6Q6OZE3UsrXrZBHFtreT4YgTeOJtTucp+zSedEpTi3L5wASSP0LYIE3if6w=="
+                    "version": "1.0.30001038",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001038.tgz",
+                    "integrity": "sha512-zii9quPo96XfOiRD4TrfYGs+QsGZpb2cGiMAzPjtf/hpFgB6zCPZgJb7I1+EATeMw/o+lG8FyRAnI+CWStHcaQ=="
                 },
                 "electron-to-chromium": {
-                    "version": "1.3.382",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.382.tgz",
-                    "integrity": "sha512-gJfxOcgnBlXhfnUUObsq3n3ReU8CT6S8je97HndYRkKsNZMJJ38zO/pI5aqO7L3Myfq+E3pqPyKK/ynyLEQfBA=="
+                    "version": "1.3.390",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.390.tgz",
+                    "integrity": "sha512-4RvbM5x+002gKI8sltkqWEk5pptn0UnzekUx8RTThAMPDSb8jjpm6SwGiSnEve7f85biyZl8DMXaipaCxDjXag=="
                 },
                 "node-releases": {
-                    "version": "1.1.52",
-                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.52.tgz",
-                    "integrity": "sha512-snSiT1UypkgGt2wxPqS6ImEUICbNCMb31yaxWrOLXjhlt2z2/IBpaOxzONExqSm4y5oLnAqjjRWu+wsDzK5yNQ==",
-                    "requires": {
-                        "semver": "^6.3.0"
-                    },
-                    "dependencies": {
-                        "semver": {
-                            "version": "6.3.0",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-                        }
-                    }
+                    "version": "1.1.53",
+                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.53.tgz",
+                    "integrity": "sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ=="
                 }
             }
         },
@@ -2606,9 +2586,9 @@
                     }
                 },
                 "caniuse-lite": {
-                    "version": "1.0.30001036",
-                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001036.tgz",
-                    "integrity": "sha512-jU8CIFIj2oR7r4W+5AKcsvWNVIb6Q6OZE3UsrXrZBHFtreT4YgTeOJtTucp+zSedEpTi3L5wASSP0LYIE3if6w=="
+                    "version": "1.0.30001038",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001038.tgz",
+                    "integrity": "sha512-zii9quPo96XfOiRD4TrfYGs+QsGZpb2cGiMAzPjtf/hpFgB6zCPZgJb7I1+EATeMw/o+lG8FyRAnI+CWStHcaQ=="
                 },
                 "chalk": {
                     "version": "2.4.2",
@@ -2629,24 +2609,14 @@
                     }
                 },
                 "electron-to-chromium": {
-                    "version": "1.3.382",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.382.tgz",
-                    "integrity": "sha512-gJfxOcgnBlXhfnUUObsq3n3ReU8CT6S8je97HndYRkKsNZMJJ38zO/pI5aqO7L3Myfq+E3pqPyKK/ynyLEQfBA=="
+                    "version": "1.3.390",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.390.tgz",
+                    "integrity": "sha512-4RvbM5x+002gKI8sltkqWEk5pptn0UnzekUx8RTThAMPDSb8jjpm6SwGiSnEve7f85biyZl8DMXaipaCxDjXag=="
                 },
                 "node-releases": {
-                    "version": "1.1.52",
-                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.52.tgz",
-                    "integrity": "sha512-snSiT1UypkgGt2wxPqS6ImEUICbNCMb31yaxWrOLXjhlt2z2/IBpaOxzONExqSm4y5oLnAqjjRWu+wsDzK5yNQ==",
-                    "requires": {
-                        "semver": "^6.3.0"
-                    },
-                    "dependencies": {
-                        "semver": {
-                            "version": "6.3.0",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-                        }
-                    }
+                    "version": "1.1.53",
+                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.53.tgz",
+                    "integrity": "sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ=="
                 }
             }
         },
@@ -2750,9 +2720,9 @@
             }
         },
         "@datawrapper/chart-core": {
-            "version": "8.0.0-1",
-            "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-8.0.0-1.tgz",
-            "integrity": "sha512-ZyIjaqey9z/7A3rIao/W+sQ/BWzsUhxvUnMo9nMLbvLs809XNSJhqYi8gYgoV6iXq3D6YFBKp8e9d9twj5gKBg==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-8.0.0.tgz",
+            "integrity": "sha512-0rFqyVygvsDS2+8m/PKc4JR1WHUD8Ts75/1j7+/cviVm4p31Xc3cUp21mEsMDGXMK2zCx7B/5NRZmNG+qWWXEQ==",
             "requires": {
                 "@babel/core": "7.9.0",
                 "@babel/plugin-transform-runtime": "7.9.0",
@@ -6052,29 +6022,19 @@
                     }
                 },
                 "caniuse-lite": {
-                    "version": "1.0.30001036",
-                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001036.tgz",
-                    "integrity": "sha512-jU8CIFIj2oR7r4W+5AKcsvWNVIb6Q6OZE3UsrXrZBHFtreT4YgTeOJtTucp+zSedEpTi3L5wASSP0LYIE3if6w=="
+                    "version": "1.0.30001038",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001038.tgz",
+                    "integrity": "sha512-zii9quPo96XfOiRD4TrfYGs+QsGZpb2cGiMAzPjtf/hpFgB6zCPZgJb7I1+EATeMw/o+lG8FyRAnI+CWStHcaQ=="
                 },
                 "electron-to-chromium": {
-                    "version": "1.3.382",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.382.tgz",
-                    "integrity": "sha512-gJfxOcgnBlXhfnUUObsq3n3ReU8CT6S8je97HndYRkKsNZMJJ38zO/pI5aqO7L3Myfq+E3pqPyKK/ynyLEQfBA=="
+                    "version": "1.3.390",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.390.tgz",
+                    "integrity": "sha512-4RvbM5x+002gKI8sltkqWEk5pptn0UnzekUx8RTThAMPDSb8jjpm6SwGiSnEve7f85biyZl8DMXaipaCxDjXag=="
                 },
                 "node-releases": {
-                    "version": "1.1.52",
-                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.52.tgz",
-                    "integrity": "sha512-snSiT1UypkgGt2wxPqS6ImEUICbNCMb31yaxWrOLXjhlt2z2/IBpaOxzONExqSm4y5oLnAqjjRWu+wsDzK5yNQ==",
-                    "requires": {
-                        "semver": "^6.3.0"
-                    },
-                    "dependencies": {
-                        "semver": {
-                            "version": "6.3.0",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-                        }
-                    }
+                    "version": "1.1.53",
+                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.53.tgz",
+                    "integrity": "sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ=="
                 },
                 "semver": {
                     "version": "7.0.0",
@@ -9894,9 +9854,9 @@
             }
         },
         "minimist": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
             "dev": true
         },
         "minimist-options": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "url": "git+https://github.com/datawrapper/datawrapper-api.git"
     },
     "dependencies": {
-        "@datawrapper/chart-core": "8.0.0-1",
+        "@datawrapper/chart-core": "8.0.0",
         "@datawrapper/orm": "^3.11.0",
         "@datawrapper/schemas": "^1.3.0",
         "@datawrapper/shared": "0.23.0",

--- a/src/publish/publish.js
+++ b/src/publish/publish.js
@@ -164,6 +164,7 @@ async function publishChart(request, h) {
         .flat();
 
     props.data.publishData.blocks = publishedBlocks;
+
     /**
      * Render the visualizations entry: "index.html"
      */
@@ -327,6 +328,15 @@ async function publishData(request, h) {
     );
     data.chartAfterBodyHTML = htmlResults.join('\n');
 
+    // chart locales
+    data.locales = getScope('chart', chart.language);
+
+    await server.app.events.emit(server.app.event.CHART_PUBLISH_DATA, {
+        chart,
+        auth,
+        data
+    });
+
     const chartBlocks = await server.app.events.emit(
         server.app.event.CHART_BLOCKS,
         {
@@ -336,15 +346,6 @@ async function publishData(request, h) {
         { filter: 'success' }
     );
     data.blocks = chartBlocks.filter(d => d);
-
-    // chart locales
-    data.locales = getScope('chart', chart.language);
-
-    await server.app.events.emit(server.app.event.CHART_PUBLISH_DATA, {
-        chart,
-        auth,
-        data
-    });
 
     return data;
 }

--- a/src/publish/publish.js
+++ b/src/publish/publish.js
@@ -151,8 +151,8 @@ async function publishChart(request, h) {
             ]);
             return {
                 source: {
-                    js: `../../lib/vendor/${js}`,
-                    css: `../../lib/vendor/${css}`
+                    js: `../../lib/blocks/${js}`,
+                    css: `../../lib/blocks/${css}`
                 },
                 blocks
             };

--- a/src/publish/publish.js
+++ b/src/publish/publish.js
@@ -143,11 +143,11 @@ async function publishChart(request, h) {
     dependencies.push(path.join('lib/vis/', fileName));
 
     const blocksFilePromises = data.blocks
-        .filter(block => block.include)
-        .map(async ({ publish, blocks }) => {
+        .filter(block => block.include && block.prefix)
+        .map(async ({ prefix, publish, blocks }) => {
             const [js, css] = await Promise.all([
-                copyFileHashed(publish.js, outDir),
-                copyFileHashed(publish.css, outDir)
+                copyFileHashed(publish.js, outDir, { prefix }),
+                copyFileHashed(publish.css, outDir, { prefix })
             ]);
             return {
                 source: {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -22,9 +22,13 @@ function createHashedFileName(filePath, hash) {
     return path.format({ name, ext });
 }
 
-utils.copyFileHashed = (filePath, destination, hashLength = 8) => {
+utils.copyFileHashed = (filePath, destination, { prefix, hashLength = 8 } = {}) => {
     let hash = crypto.createHash('sha256');
-    const outFilePath = path.join(destination, path.basename(filePath));
+    let outFileName = path.basename(filePath);
+    if (prefix) {
+        outFileName = `${prefix}.${outFileName}`;
+    }
+    const outFilePath = path.join(destination, outFileName);
     const input = fs.createReadStream(filePath);
     const output = fs.createWriteStream(outFilePath);
 
@@ -40,7 +44,7 @@ utils.copyFileHashed = (filePath, destination, hashLength = 8) => {
         output.on('finish', rename);
         async function rename() {
             hash = hash.digest('hex').slice(0, hashLength);
-            const hashedFileName = createHashedFileName(filePath, hash);
+            const hashedFileName = createHashedFileName(outFilePath, hash);
             await fs.move(outFilePath, path.join(destination, hashedFileName));
             resolve(hashedFileName);
         }


### PR DESCRIPTION
How it works: 

* Plugins define a publish object with paths to their asset files (`.js`, `.css`). Similar to the source object for the frontend.
* Plugins also provide a file prefix for naming the published file and a flag if the block should be published for that specific chart:
```js
include: !!get(chart, 'metadata.visualize.sharing.enabled', false),
prefix: 'social-sharing', /* used for naming of published assets */
...
publish: {
    js: path.join(__dirname, 'static', 'chart-blocks.js'),
    css: path.join(__dirname, 'static', 'chart-blocks.css')
},
...
```

The API will then rewrite the paths in the `props` object and upload all needed files to `lib/blocks`:
![Screenshot 2020-03-26 at 16 56 27](https://user-images.githubusercontent.com/5798652/77667666-cdf46900-6f82-11ea-80f9-e1ad4b422cf3.png)

Here is an example chart with social-sharing enabled (it's not the prettiest but well):
https://dw-test-fabian.storage.googleapis.com/charts/FTuT4/136/index.html

![Screen Shot 2020-03-26 at 16 59 51](https://user-images.githubusercontent.com/5798652/77668079-422f0c80-6f83-11ea-8641-0c56344424e9.png)

