### PR TITLE
Fix setting empty object in PATCH /charts/:id

### DIFF
--- a/src/routes/charts.js
+++ b/src/routes/charts.js
@@ -5,7 +5,6 @@ const Boom = require('@hapi/boom');
 const { Op } = require('@datawrapper/orm').db;
 const { camelizeKeys, decamelizeKeys, decamelize } = require('humps');
 const set = require('lodash/set');
-const assign = require('assign-deep');
 const mime = require('mime');
 const { Chart, ChartPublic, User, Folder, Plugin } = require('@datawrapper/orm/models');
 const CodedError = require('@datawrapper/shared/CodedError');
@@ -731,7 +730,7 @@ async function editChart(request, h) {
         delete payload.authorId;
     }
 
-    const newData = assign(prepareChart(chart), payload);
+    const newData = Object.assign(prepareChart(chart), payload);
 
     await Chart.update(
         { ...decamelizeKeys(newData), metadata: newData.metadata },

--- a/src/routes/charts.js
+++ b/src/routes/charts.js
@@ -12,6 +12,7 @@ const { promisify } = require('util');
 const mkdirAsync = promisify(fs.mkdir);
 const writeFileAsync = promisify(fs.writeFile);
 const accessAsync = promisify(fs.access);
+const assignWithEmptyObjects = require('../utils/assignWithEmptyObjects');
 
 const { listResponse, createResponseConfig, noContentResponse } = require('../schemas/response');
 
@@ -730,7 +731,7 @@ async function editChart(request, h) {
         delete payload.authorId;
     }
 
-    const newData = Object.assign(prepareChart(chart), payload);
+    const newData = assignWithEmptyObjects(prepareChart(chart), payload);
 
     await Chart.update(
         { ...decamelizeKeys(newData), metadata: newData.metadata },

--- a/src/routes/charts.test.js
+++ b/src/routes/charts.test.js
@@ -203,6 +203,7 @@ test('Users can edit chart medatata', async t => {
                     notes: 'note-2'
                 },
                 visualize: {
+                    'base-color': 'red',
                     'custom-colors': {
                         column1: '#ff0000'
                     }
@@ -212,6 +213,7 @@ test('Users can edit chart medatata', async t => {
     });
 
     t.is(chart.result.metadata.annotate.notes, 'note-2');
+    t.is(chart.result.metadata.visualize['base-color'], 'red');
     t.log('overwrite existing metadata property: ', chart.result.metadata.annotate.notes);
 
     t.is(chart.result.metadata.visualize['custom-colors'].column1, '#ff0000');
@@ -238,6 +240,7 @@ test('Users can edit chart medatata', async t => {
     );
 
     t.is(chart.result.metadata.annotate.notes, 'note-2');
+    t.is(chart.result.metadata.visualize['base-color'], 'red');
     t.log(
         'previously existing metadata property still exists: ',
         chart.result.metadata.annotate.notes

--- a/src/routes/charts.test.js
+++ b/src/routes/charts.test.js
@@ -200,12 +200,38 @@ test('Users can edit chart medatata', async t => {
             metadata: {
                 annotate: {
                     notes: 'note-2'
+                },
+                visualize: {
+                    'custom-colors': {
+                        column1: '#ff0000'
+                    }
                 }
             }
         }
     });
 
     t.is(chart.result.metadata.annotate.notes, 'note-2');
+    t.is(chart.result.metadata.visualize['custom-colors'].column1, '#ff0000');
+
+    chart = await t.context.server.inject({
+        method: 'PATCH',
+        url: `/v3/charts/${chart.result.id}`,
+        headers: {
+            cookie: `DW-SESSION=${session.id}`
+        },
+        payload: {
+            metadata: {
+                annotate: {
+                    notes: 'note-2'
+                },
+                visualize: {
+                    'custom-colors': {}
+                }
+            }
+        }
+    });
+
+    t.deepEqual(chart.result.metadata.visualize['custom-colors'], {});
 
     chart = await t.context.server.inject({
         method: 'GET',

--- a/src/routes/charts.test.js
+++ b/src/routes/charts.test.js
@@ -189,6 +189,7 @@ test('Users can edit chart medatata', async t => {
     });
 
     t.is(chart.result.metadata.annotate.notes, 'note-1');
+    t.log('set new metadata property: ', chart.result.metadata.annotate.notes);
 
     chart = await t.context.server.inject({
         method: 'PATCH',
@@ -211,6 +212,8 @@ test('Users can edit chart medatata', async t => {
     });
 
     t.is(chart.result.metadata.annotate.notes, 'note-2');
+    t.log('overwrite existing metadata property: ', chart.result.metadata.annotate.notes);
+
     t.is(chart.result.metadata.visualize['custom-colors'].column1, '#ff0000');
 
     chart = await t.context.server.inject({
@@ -228,8 +231,17 @@ test('Users can edit chart medatata', async t => {
         }
     });
 
-    t.is(chart.result.metadata.annotate.notes, 'note-2');
     t.deepEqual(chart.result.metadata.visualize['custom-colors'], {});
+    t.log(
+        'set an existing metadata property to empty object: ',
+        chart.result.metadata.visualize['custom-colors']
+    );
+
+    t.is(chart.result.metadata.annotate.notes, 'note-2');
+    t.log(
+        'previously existing metadata property still exists: ',
+        chart.result.metadata.annotate.notes
+    );
 
     chart = await t.context.server.inject({
         method: 'GET',

--- a/src/routes/charts.test.js
+++ b/src/routes/charts.test.js
@@ -221,9 +221,6 @@ test('Users can edit chart medatata', async t => {
         },
         payload: {
             metadata: {
-                annotate: {
-                    notes: 'note-2'
-                },
                 visualize: {
                     'custom-colors': {}
                 }
@@ -231,6 +228,7 @@ test('Users can edit chart medatata', async t => {
         }
     });
 
+    t.is(chart.result.metadata.annotate.notes, 'note-2');
     t.deepEqual(chart.result.metadata.visualize['custom-colors'], {});
 
     chart = await t.context.server.inject({

--- a/src/utils/assignWithEmptyObjects.js
+++ b/src/utils/assignWithEmptyObjects.js
@@ -1,0 +1,57 @@
+/**
+ * Deeply assign the values of all enumerable-own-properties
+ * from one or more source objects to a target object. Returns the target object.
+ *
+ * Based on and is almost identical to assign-deep (https://github.com/jonschlinkert/assign-deep/)
+ *
+ * There are 2 differences to assign-deep:
+ *
+ * 1. If a source object in any of the keys is empty, an empty object gets assigned
+ *    instead of retaining entries from the target object
+ * 2. No symbol assignment
+ *
+ * @param {Object} target object
+ * @param {...Object} args - source object(s)
+ *
+ * @returns {Object}
+ */
+
+const assignWithEmptyObjects = (target, ...args) => {
+    let i = 0;
+    if (isPrimitive(target)) target = args[i++];
+    if (!target) target = {};
+    for (; i < args.length; i++) {
+        if (isObject(args[i])) {
+            for (const key of Object.keys(args[i])) {
+                if (isValidKey(key)) {
+                    if (isObject(target[key]) && isObject(args[i][key]) && !isEmpty(args[i][key])) {
+                        assignWithEmptyObjects(target[key], args[i][key]);
+                    } else {
+                        target[key] = args[i][key];
+                    }
+                }
+            }
+        }
+    }
+    return target;
+};
+
+module.exports = assignWithEmptyObjects;
+
+function isObject(val) {
+    return typeof val === 'function' || toString.call(val) === '[object Object]';
+}
+
+function isPrimitive(val) {
+    return typeof val === 'object' ? val === null : typeof val !== 'function';
+}
+
+function isEmpty(val) {
+    return !val || Object.keys(val).length === 0;
+}
+
+const toString = Object.prototype.toString;
+
+const isValidKey = key => {
+    return key !== '__proto__' && key !== 'constructor' && key !== 'prototype';
+};


### PR DESCRIPTION
**Issue**

We are currently using `assign-deep` when merging incoming changes with existing chart data in the `PATCH /charts/:id` endpoint. I identified a case where using it leads to unwanted behaviour: if an object **already has some properties** and we want to **set it to an empty object**, the result will **still include these properties**.

Here is a quick demo that shows the problem, observe how output object has `b: { key: "original value" }` while we want it to be set to `b: {}` instead: https://runkit.com/embed/yfz49aw81pgd

An example of this problem in our codebase is if we try use this endpoint to set `metadata.visualize.['custom-colors']` object to `{}` after it's already been populated with properties. In the current implementation this fails.

**Changes**

This PR changes the behaviour in the endpoint by ~~using `Object.assign` instead of `assign-deep`~~ switching to use a [slightly adjusted custom version of assign-deep](https://github.com/datawrapper/api/blob/fix-metadata-empty-object/src/utils/assignWithEmptyObjects.js). It is essentially a copy of `assign-deep` with one key difference: if an object entry in the source has a value of empty object, an empty object will get assigned to the target, instead of retaining entries from the target object.

It also expands the tests to check for this exact scenario.

**Testing**

I tested this PR with chart metadata and it works well. When reviewing, I would appreciate some more testing - there might be cases that I'm not aware of that may break due to this change.