### PR TITLE
include vendor locales (dayjs + numeral) in published charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,14 +52,14 @@
             },
             "dependencies": {
                 "browserslist": {
-                    "version": "4.11.0",
-                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.0.tgz",
-                    "integrity": "sha512-WqEC7Yr5wUH5sg6ruR++v2SGOQYpyUdYYd4tZoAq1F7y+QXoLoYGXVbxhtaIqWmAJjtNTRjVD3HuJc1OXTel2A==",
+                    "version": "4.11.1",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.1.tgz",
+                    "integrity": "sha512-DCTr3kDrKEYNw6Jb9HFxVLQNaue8z+0ZfRBRjmCunKDEXEBajKDj2Y+Uelg+Pi29OnvaSGwjOsnRyNEkXzHg5g==",
                     "requires": {
-                        "caniuse-lite": "^1.0.30001035",
-                        "electron-to-chromium": "^1.3.380",
-                        "node-releases": "^1.1.52",
-                        "pkg-up": "^3.1.0"
+                        "caniuse-lite": "^1.0.30001038",
+                        "electron-to-chromium": "^1.3.390",
+                        "node-releases": "^1.1.53",
+                        "pkg-up": "^2.0.0"
                     }
                 },
                 "caniuse-lite": {
@@ -68,9 +68,9 @@
                     "integrity": "sha512-zii9quPo96XfOiRD4TrfYGs+QsGZpb2cGiMAzPjtf/hpFgB6zCPZgJb7I1+EATeMw/o+lG8FyRAnI+CWStHcaQ=="
                 },
                 "electron-to-chromium": {
-                    "version": "1.3.390",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.390.tgz",
-                    "integrity": "sha512-4RvbM5x+002gKI8sltkqWEk5pptn0UnzekUx8RTThAMPDSb8jjpm6SwGiSnEve7f85biyZl8DMXaipaCxDjXag=="
+                    "version": "1.3.391",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.391.tgz",
+                    "integrity": "sha512-WOi6loSnDmfICOqGRrgeK7bZeWDAbGjCptDhI5eyJAqSzWfoeRuOOU1rOTZRL29/9AaxTndZB6Uh8YrxRfZJqw=="
                 },
                 "node-releases": {
                     "version": "1.1.53",
@@ -272,14 +272,14 @@
             },
             "dependencies": {
                 "browserslist": {
-                    "version": "4.11.0",
-                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.0.tgz",
-                    "integrity": "sha512-WqEC7Yr5wUH5sg6ruR++v2SGOQYpyUdYYd4tZoAq1F7y+QXoLoYGXVbxhtaIqWmAJjtNTRjVD3HuJc1OXTel2A==",
+                    "version": "4.11.1",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.1.tgz",
+                    "integrity": "sha512-DCTr3kDrKEYNw6Jb9HFxVLQNaue8z+0ZfRBRjmCunKDEXEBajKDj2Y+Uelg+Pi29OnvaSGwjOsnRyNEkXzHg5g==",
                     "requires": {
-                        "caniuse-lite": "^1.0.30001035",
-                        "electron-to-chromium": "^1.3.380",
-                        "node-releases": "^1.1.52",
-                        "pkg-up": "^3.1.0"
+                        "caniuse-lite": "^1.0.30001038",
+                        "electron-to-chromium": "^1.3.390",
+                        "node-releases": "^1.1.53",
+                        "pkg-up": "^2.0.0"
                     }
                 },
                 "caniuse-lite": {
@@ -288,9 +288,9 @@
                     "integrity": "sha512-zii9quPo96XfOiRD4TrfYGs+QsGZpb2cGiMAzPjtf/hpFgB6zCPZgJb7I1+EATeMw/o+lG8FyRAnI+CWStHcaQ=="
                 },
                 "electron-to-chromium": {
-                    "version": "1.3.390",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.390.tgz",
-                    "integrity": "sha512-4RvbM5x+002gKI8sltkqWEk5pptn0UnzekUx8RTThAMPDSb8jjpm6SwGiSnEve7f85biyZl8DMXaipaCxDjXag=="
+                    "version": "1.3.391",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.391.tgz",
+                    "integrity": "sha512-WOi6loSnDmfICOqGRrgeK7bZeWDAbGjCptDhI5eyJAqSzWfoeRuOOU1rOTZRL29/9AaxTndZB6Uh8YrxRfZJqw=="
                 },
                 "node-releases": {
                     "version": "1.1.53",
@@ -2575,14 +2575,14 @@
                     }
                 },
                 "browserslist": {
-                    "version": "4.11.0",
-                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.0.tgz",
-                    "integrity": "sha512-WqEC7Yr5wUH5sg6ruR++v2SGOQYpyUdYYd4tZoAq1F7y+QXoLoYGXVbxhtaIqWmAJjtNTRjVD3HuJc1OXTel2A==",
+                    "version": "4.11.1",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.1.tgz",
+                    "integrity": "sha512-DCTr3kDrKEYNw6Jb9HFxVLQNaue8z+0ZfRBRjmCunKDEXEBajKDj2Y+Uelg+Pi29OnvaSGwjOsnRyNEkXzHg5g==",
                     "requires": {
-                        "caniuse-lite": "^1.0.30001035",
-                        "electron-to-chromium": "^1.3.380",
-                        "node-releases": "^1.1.52",
-                        "pkg-up": "^3.1.0"
+                        "caniuse-lite": "^1.0.30001038",
+                        "electron-to-chromium": "^1.3.390",
+                        "node-releases": "^1.1.53",
+                        "pkg-up": "^2.0.0"
                     }
                 },
                 "caniuse-lite": {
@@ -2609,9 +2609,9 @@
                     }
                 },
                 "electron-to-chromium": {
-                    "version": "1.3.390",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.390.tgz",
-                    "integrity": "sha512-4RvbM5x+002gKI8sltkqWEk5pptn0UnzekUx8RTThAMPDSb8jjpm6SwGiSnEve7f85biyZl8DMXaipaCxDjXag=="
+                    "version": "1.3.391",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.391.tgz",
+                    "integrity": "sha512-WOi6loSnDmfICOqGRrgeK7bZeWDAbGjCptDhI5eyJAqSzWfoeRuOOU1rOTZRL29/9AaxTndZB6Uh8YrxRfZJqw=="
                 },
                 "node-releases": {
                     "version": "1.1.53",
@@ -2720,9 +2720,9 @@
             }
         },
         "@datawrapper/chart-core": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-8.0.0.tgz",
-            "integrity": "sha512-0rFqyVygvsDS2+8m/PKc4JR1WHUD8Ts75/1j7+/cviVm4p31Xc3cUp21mEsMDGXMK2zCx7B/5NRZmNG+qWWXEQ==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-8.1.0.tgz",
+            "integrity": "sha512-eZ6xs+MWCMhU1NEG4RUuNqKAo4rj2TDv5oMSPfFB7qPDR7HsQwd+0D/WeM49WaMefn89ARH984lXlfVUjKZyrg==",
             "requires": {
                 "@babel/core": "7.9.0",
                 "@babel/plugin-transform-runtime": "7.9.0",
@@ -2939,17 +2939,17 @@
                         "minimist": "^1.2.5"
                     }
                 },
-                "minimist": {
-                    "version": "1.2.5",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-                },
                 "svelte": {
                     "version": "3.20.1",
                     "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.20.1.tgz",
                     "integrity": "sha512-m/dw52BZf+p6KYnyKLErIcGalu4pwJrQbUM7VZriRw6ZlJj1qMAZsLcIWzEB3I0hhdJwkKb7LrrvUIeqmbO92Q=="
                 }
             }
+        },
+        "@datawrapper/locales": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@datawrapper/locales/-/locales-1.0.0.tgz",
+            "integrity": "sha512-NRtvAa/f4IvDoBrglZ8CxXGyyE4wgDvqceMKK1Qd8l6dzMvYf8G8gftxEOUCegN+cGF2TXwCx9U5iRymDOmKrA=="
         },
         "@datawrapper/orm": {
             "version": "3.11.0",
@@ -6011,14 +6011,14 @@
             },
             "dependencies": {
                 "browserslist": {
-                    "version": "4.11.0",
-                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.0.tgz",
-                    "integrity": "sha512-WqEC7Yr5wUH5sg6ruR++v2SGOQYpyUdYYd4tZoAq1F7y+QXoLoYGXVbxhtaIqWmAJjtNTRjVD3HuJc1OXTel2A==",
+                    "version": "4.11.1",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.1.tgz",
+                    "integrity": "sha512-DCTr3kDrKEYNw6Jb9HFxVLQNaue8z+0ZfRBRjmCunKDEXEBajKDj2Y+Uelg+Pi29OnvaSGwjOsnRyNEkXzHg5g==",
                     "requires": {
-                        "caniuse-lite": "^1.0.30001035",
-                        "electron-to-chromium": "^1.3.380",
-                        "node-releases": "^1.1.52",
-                        "pkg-up": "^3.1.0"
+                        "caniuse-lite": "^1.0.30001038",
+                        "electron-to-chromium": "^1.3.390",
+                        "node-releases": "^1.1.53",
+                        "pkg-up": "^2.0.0"
                     }
                 },
                 "caniuse-lite": {
@@ -6027,9 +6027,9 @@
                     "integrity": "sha512-zii9quPo96XfOiRD4TrfYGs+QsGZpb2cGiMAzPjtf/hpFgB6zCPZgJb7I1+EATeMw/o+lG8FyRAnI+CWStHcaQ=="
                 },
                 "electron-to-chromium": {
-                    "version": "1.3.390",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.390.tgz",
-                    "integrity": "sha512-4RvbM5x+002gKI8sltkqWEk5pptn0UnzekUx8RTThAMPDSb8jjpm6SwGiSnEve7f85biyZl8DMXaipaCxDjXag=="
+                    "version": "1.3.391",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.391.tgz",
+                    "integrity": "sha512-WOi6loSnDmfICOqGRrgeK7bZeWDAbGjCptDhI5eyJAqSzWfoeRuOOU1rOTZRL29/9AaxTndZB6Uh8YrxRfZJqw=="
                 },
                 "node-releases": {
                     "version": "1.1.53",
@@ -9856,8 +9856,7 @@
         "minimist": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-            "dev": true
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "minimist-options": {
             "version": "3.0.2",
@@ -10770,6 +10769,7 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
             "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+            "dev": true,
             "requires": {
                 "p-try": "^2.0.0"
             }
@@ -10800,7 +10800,8 @@
         "p-try": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+            "dev": true
         },
         "package-hash": {
             "version": "4.0.0",
@@ -11205,37 +11206,50 @@
             }
         },
         "pkg-up": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
-            "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+            "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
             "requires": {
-                "find-up": "^3.0.0"
+                "find-up": "^2.1.0"
             },
             "dependencies": {
                 "find-up": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
                     "requires": {
-                        "locate-path": "^3.0.0"
+                        "locate-path": "^2.0.0"
                     }
                 },
                 "locate-path": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                    "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
                     "requires": {
-                        "p-locate": "^3.0.0",
+                        "p-locate": "^2.0.0",
                         "path-exists": "^3.0.0"
                     }
                 },
-                "p-locate": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                "p-limit": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+                    "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
                     "requires": {
-                        "p-limit": "^2.0.0"
+                        "p-try": "^1.0.0"
                     }
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                    "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+                    "requires": {
+                        "p-limit": "^1.1.0"
+                    }
+                },
+                "p-try": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
                 },
                 "path-exists": {
                     "version": "3.0.0",
@@ -13461,9 +13475,9 @@
             }
         },
         "terser": {
-            "version": "4.6.7",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.7.tgz",
-            "integrity": "sha512-fmr7M1f7DBly5cX2+rFDvmGBAaaZyPrHYK4mMdHEDAdNTqXSZgSOfqsfGq2HqPGT/1V0foZZuCZFx8CHKgAk3g==",
+            "version": "4.6.9",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.9.tgz",
+            "integrity": "sha512-9UuZOApK4oiTpX4AjnWhTCY3fCqntS3ggPQOku9M3Rvr70VETYsuHjSGuRy0D7X/Z994hfnzMy6TQ/H0WQSmXQ==",
             "requires": {
                 "commander": "^2.20.0",
                 "source-map": "~0.6.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     },
     "dependencies": {
         "@datawrapper/chart-core": "8.0.0",
+        "@datawrapper/locales": "1.0.0",
         "@datawrapper/orm": "^3.11.0",
         "@datawrapper/schemas": "^1.3.0",
         "@datawrapper/shared": "0.23.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "url": "git+https://github.com/datawrapper/datawrapper-api.git"
     },
     "dependencies": {
-        "@datawrapper/chart-core": "8.0.0",
+        "@datawrapper/chart-core": "8.1.0",
         "@datawrapper/locales": "1.0.0",
         "@datawrapper/orm": "^3.11.0",
         "@datawrapper/schemas": "^1.3.0",

--- a/src/publish/publish.js
+++ b/src/publish/publish.js
@@ -70,6 +70,15 @@ async function publishChart(request, h) {
         return Boom.notImplemented(`"${chart.type}" is currently not supported.`);
     }
 
+    // load vendor locales needed by visualization
+    const locales = {};
+    if (vis.dependencies.dayjs) {
+        locales.dayjs = await loadVendorLocale('dayjs', chart.language);
+    }
+    if (vis.dependencies.numeral) {
+        locales.numeral = await loadVendorLocale('numeral', chart.language);
+    }
+
     // no need to await this...
     logPublishStatus('preparing');
 
@@ -103,7 +112,7 @@ async function publishChart(request, h) {
             chartData: csv,
             isPreview: false,
             chartLocale: chart.language,
-            locales: {} /* NOTE: What about this? */,
+            locales,
             metricPrefix: {} /* NOTE: What about this? */,
             themeId: theme.id,
             fontsJSON: theme.fonts,
@@ -111,7 +120,8 @@ async function publishChart(request, h) {
             templateJS: false,
             polyfillUri: `../../lib/vendor`
         },
-        theme
+        theme,
+        translations: vis.locale
     };
 
     logPublishStatus('rendering');
@@ -279,6 +289,30 @@ async function publishChart(request, h) {
         url: destination,
         timing: `${endTiming[0]}s ${Math.round(endTiming[1] / 1000000)}ms`
     };
+}
+
+async function loadVendorLocale(vendor, locale) {
+    const basePath = path.resolve(
+        __dirname,
+        '../../node_modules/@datawrapper/locales/locales/',
+        vendor
+    );
+    const culture = locale.replace('_', '-').toLowerCase();
+    const tryFiles = [`${culture}.js`];
+    if (culture.length > 2) {
+        // also try just language as fallback
+        tryFiles.push(`${culture.substr(0, 2)}.js`);
+    }
+    for (let i = 0; i < tryFiles.length; i++) {
+        const file = path.join(basePath, tryFiles[i]);
+        try {
+            return await fs.readFile(file, 'utf-8');
+        } catch (e) {
+            // file not found, so try next
+        }
+    }
+    // no locale found at all
+    return 'null';
 }
 
 async function publishChartStatus(request, h) {

--- a/src/publish/publish.js
+++ b/src/publish/publish.js
@@ -306,7 +306,7 @@ async function loadVendorLocale(vendor, locale) {
     for (let i = 0; i < tryFiles.length; i++) {
         const file = path.join(basePath, tryFiles[i]);
         try {
-            return await fs.readFile(file, 'utf-8');
+            return fs.readFile(file, 'utf-8');
         } catch (e) {
             // file not found, so try next
         }

--- a/src/publish/publish.js
+++ b/src/publish/publish.js
@@ -291,7 +291,7 @@ async function publishChart(request, h) {
     };
 }
 
-async function loadVendorLocale(vendor, locale) {
+function loadVendorLocale(vendor, locale) {
     const basePath = path.resolve(
         __dirname,
         '../../node_modules/@datawrapper/locales/locales/',


### PR DESCRIPTION
this is a draft PR because the PRs in https://github.com/datawrapper/locales/ need to be merged and the package needs to be published to `npm` before this can work.

also I need to fix my local dev setup on which chart publications is now failing due to CORS errors :thinking: 