### PR TITLE
revert: downgrade joi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -262,18 +262,18 @@
             "integrity": "sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q=="
         },
         "@hapi/ammo": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
-            "integrity": "sha512-FbCNwcTbnQP4VYYhLNGZmA76xb2aHg9AMPiy18NZyWMG310P5KdFGyA9v2rm5ujrIny77dEEIkMOwl0Xv+fSSA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-3.1.2.tgz",
+            "integrity": "sha512-ej9OtFmiZv1qr45g1bxEZNGyaR4jRpyMxU6VhbxjaYThymvOwsyIsUKMZnP5Qw2tfYFuwqCJuIBHGpeIbdX9gQ==",
             "dev": true,
             "requires": {
-                "@hapi/hoek": "9.x.x"
+                "@hapi/hoek": "8.x.x"
             },
             "dependencies": {
                 "@hapi/hoek": {
-                    "version": "9.0.4",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.4.tgz",
-                    "integrity": "sha512-EwaJS7RjoXUZ2cXXKZZxZqieGtc7RbvQhUy8FwDoMQtxWVi14tFjeFCYPZAM1mBCpOpiBpyaZbb9NeHc7eGKgw==",
+                    "version": "8.5.1",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+                    "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
                     "dev": true
                 }
             }
@@ -309,28 +309,28 @@
             }
         },
         "@hapi/bounce": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
-            "integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-1.3.2.tgz",
+            "integrity": "sha512-3bnb1AlcEByFZnpDIidxQyw1Gds81z/1rSqlx4bIEE+wUN0ATj0D49B5cE1wGocy90Rp/de4tv7GjsKd5RQeew==",
             "dev": true,
             "requires": {
-                "@hapi/boom": "9.x.x",
-                "@hapi/hoek": "9.x.x"
+                "@hapi/boom": "7.x.x",
+                "@hapi/hoek": "^8.3.1"
             },
             "dependencies": {
                 "@hapi/boom": {
-                    "version": "9.1.0",
-                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.0.tgz",
-                    "integrity": "sha512-4nZmpp4tXbm162LaZT45P7F7sgiem8dwAh2vHWT6XX24dozNjGMg6BvKCRvtCUcmcXqeMIUqWN8Rc5X8yKuROQ==",
+                    "version": "7.4.11",
+                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
+                    "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
                     "dev": true,
                     "requires": {
-                        "@hapi/hoek": "9.x.x"
+                        "@hapi/hoek": "8.x.x"
                     }
                 },
                 "@hapi/hoek": {
-                    "version": "9.0.4",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.4.tgz",
-                    "integrity": "sha512-EwaJS7RjoXUZ2cXXKZZxZqieGtc7RbvQhUy8FwDoMQtxWVi14tFjeFCYPZAM1mBCpOpiBpyaZbb9NeHc7eGKgw==",
+                    "version": "8.5.1",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+                    "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
                     "dev": true
                 }
             }
@@ -666,48 +666,46 @@
             "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A=="
         },
         "@hapi/inert": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/@hapi/inert/-/inert-6.0.1.tgz",
-            "integrity": "sha512-oLxAmtWni3nH4INU2gcXFnHBw0GhHYF3HR71hAWrPc91dq+iFYGfawfaMbonwGr5DkzFiGe8Ir5sZAt2AqeINA==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/@hapi/inert/-/inert-5.2.2.tgz",
+            "integrity": "sha512-8IaGfAEF8SwZtpdaTq0G3aDPG35ZTfWKjnMNniG2N3kE+qioMsBuImIGxna8TNQ+sYMXYK78aqmvzbQHno8qSQ==",
             "dev": true,
             "requires": {
-                "@hapi/ammo": "5.x.x",
-                "@hapi/boom": "9.x.x",
-                "@hapi/bounce": "2.x.x",
-                "@hapi/hoek": "9.x.x",
-                "@hapi/joi": "17.x.x",
-                "lru-cache": "5.x.x"
+                "@hapi/ammo": "3.x.x",
+                "@hapi/boom": "7.x.x",
+                "@hapi/bounce": "1.x.x",
+                "@hapi/hoek": "8.x.x",
+                "@hapi/joi": "16.x.x",
+                "lru-cache": "4.1.x"
             },
             "dependencies": {
                 "@hapi/boom": {
-                    "version": "9.1.0",
-                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.0.tgz",
-                    "integrity": "sha512-4nZmpp4tXbm162LaZT45P7F7sgiem8dwAh2vHWT6XX24dozNjGMg6BvKCRvtCUcmcXqeMIUqWN8Rc5X8yKuROQ==",
+                    "version": "7.4.11",
+                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
+                    "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
                     "dev": true,
                     "requires": {
-                        "@hapi/hoek": "9.x.x"
+                        "@hapi/hoek": "8.x.x"
                     }
                 },
                 "@hapi/hoek": {
-                    "version": "9.0.4",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.4.tgz",
-                    "integrity": "sha512-EwaJS7RjoXUZ2cXXKZZxZqieGtc7RbvQhUy8FwDoMQtxWVi14tFjeFCYPZAM1mBCpOpiBpyaZbb9NeHc7eGKgw==",
+                    "version": "8.5.1",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+                    "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
                     "dev": true
                 },
-                "lru-cache": {
-                    "version": "5.1.1",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-                    "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+                "@hapi/joi": {
+                    "version": "16.1.8",
+                    "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
+                    "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
                     "dev": true,
                     "requires": {
-                        "yallist": "^3.0.2"
+                        "@hapi/address": "^2.1.2",
+                        "@hapi/formula": "^1.2.0",
+                        "@hapi/hoek": "^8.2.4",
+                        "@hapi/pinpoint": "^1.0.2",
+                        "@hapi/topo": "^3.1.3"
                     }
-                },
-                "yallist": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-                    "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-                    "dev": true
                 }
             }
         },
@@ -744,39 +742,20 @@
             }
         },
         "@hapi/joi": {
-            "version": "17.1.1",
-            "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-17.1.1.tgz",
-            "integrity": "sha512-p4DKeZAoeZW4g3u7ZeRo+vCDuSDgSvtsB/NpfjXEHTUjSeINAi/RrVOWiVQ1isaoLzMvFEhe8n5065mQq1AdQg==",
+            "version": "15.1.1",
+            "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+            "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
             "requires": {
-                "@hapi/address": "^4.0.1",
-                "@hapi/formula": "^2.0.0",
-                "@hapi/hoek": "^9.0.0",
-                "@hapi/pinpoint": "^2.0.0",
-                "@hapi/topo": "^5.0.0"
+                "@hapi/address": "2.x.x",
+                "@hapi/bourne": "1.x.x",
+                "@hapi/hoek": "8.x.x",
+                "@hapi/topo": "3.x.x"
             },
             "dependencies": {
-                "@hapi/address": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.0.1.tgz",
-                    "integrity": "sha512-0oEP5UiyV4f3d6cBL8F3Z5S7iWSX39Knnl0lY8i+6gfmmIBj44JCBNtcMgwyS+5v7j3VYavNay0NFHDS+UGQcw==",
-                    "requires": {
-                        "@hapi/hoek": "^9.0.0"
-                    }
-                },
-                "@hapi/formula": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
-                    "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A=="
-                },
                 "@hapi/hoek": {
-                    "version": "9.0.4",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.4.tgz",
-                    "integrity": "sha512-EwaJS7RjoXUZ2cXXKZZxZqieGtc7RbvQhUy8FwDoMQtxWVi14tFjeFCYPZAM1mBCpOpiBpyaZbb9NeHc7eGKgw=="
-                },
-                "@hapi/pinpoint": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz",
-                    "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw=="
+                    "version": "8.5.1",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+                    "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
                 }
             }
         },
@@ -1106,17 +1085,17 @@
             "integrity": "sha512-V6xYOrr5aFv/IJqNPneaYCu8vuGTKisamqHVRS3JJnbZr18TrpXdsJOYk9pjPhFti+M2YETPebQLUr820N5NoQ=="
         },
         "@hapi/topo": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
-            "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+            "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
             "requires": {
-                "@hapi/hoek": "^9.0.0"
+                "@hapi/hoek": "^8.3.0"
             },
             "dependencies": {
                 "@hapi/hoek": {
-                    "version": "9.0.4",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.4.tgz",
-                    "integrity": "sha512-EwaJS7RjoXUZ2cXXKZZxZqieGtc7RbvQhUy8FwDoMQtxWVi14tFjeFCYPZAM1mBCpOpiBpyaZbb9NeHc7eGKgw=="
+                    "version": "8.5.1",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+                    "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
                 }
             }
         },
@@ -1136,31 +1115,44 @@
             }
         },
         "@hapi/vision": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/@hapi/vision/-/vision-6.0.0.tgz",
-            "integrity": "sha512-NRG87SLS8evCTwAGlVHykmlk1i9z+7TD2pUwoDHRpjwqX/syt0ecrEKMLV/VdMijE9tCAtKIIXt+Myb16tT7Sw==",
+            "version": "5.5.4",
+            "resolved": "https://registry.npmjs.org/@hapi/vision/-/vision-5.5.4.tgz",
+            "integrity": "sha512-/DFgnQtcrlf2eQNkh/DHnjrCRHLSmHraU+PHe1SlxLUJxATQCw8VIEt6rJraM2jGTpFgHNk6B6ELtu3sBJCClg==",
             "dev": true,
             "requires": {
-                "@hapi/boom": "9.x.x",
-                "@hapi/bounce": "2.x.x",
-                "@hapi/hoek": "9.x.x",
-                "@hapi/joi": "17.x.x"
+                "@hapi/boom": "7.x.x",
+                "@hapi/bounce": "1.x.x",
+                "@hapi/hoek": "8.x.x",
+                "@hapi/joi": "16.x.x"
             },
             "dependencies": {
                 "@hapi/boom": {
-                    "version": "9.1.0",
-                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.0.tgz",
-                    "integrity": "sha512-4nZmpp4tXbm162LaZT45P7F7sgiem8dwAh2vHWT6XX24dozNjGMg6BvKCRvtCUcmcXqeMIUqWN8Rc5X8yKuROQ==",
+                    "version": "7.4.11",
+                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
+                    "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
                     "dev": true,
                     "requires": {
-                        "@hapi/hoek": "9.x.x"
+                        "@hapi/hoek": "8.x.x"
                     }
                 },
                 "@hapi/hoek": {
-                    "version": "9.0.4",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.4.tgz",
-                    "integrity": "sha512-EwaJS7RjoXUZ2cXXKZZxZqieGtc7RbvQhUy8FwDoMQtxWVi14tFjeFCYPZAM1mBCpOpiBpyaZbb9NeHc7eGKgw==",
+                    "version": "8.5.1",
+                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+                    "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
                     "dev": true
+                },
+                "@hapi/joi": {
+                    "version": "16.1.8",
+                    "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
+                    "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
+                    "dev": true,
+                    "requires": {
+                        "@hapi/address": "^2.1.2",
+                        "@hapi/formula": "^1.2.0",
+                        "@hapi/hoek": "^8.2.4",
+                        "@hapi/pinpoint": "^1.0.2",
+                        "@hapi/topo": "^3.1.3"
+                    }
                 }
             }
         },
@@ -2616,9 +2608,9 @@
             "dev": true
         },
         "core-js": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-            "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+            "version": "2.6.11",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+            "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
         },
         "core-util-is": {
             "version": "1.0.2",
@@ -3800,12 +3792,6 @@
             "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
             "dev": true
         },
-        "esm": {
-            "version": "3.2.25",
-            "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-            "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-            "dev": true
-        },
         "espree": {
             "version": "6.1.2",
             "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
@@ -4368,14 +4354,14 @@
             }
         },
         "hapi-swagger": {
-            "version": "12.1.3",
-            "resolved": "https://registry.npmjs.org/hapi-swagger/-/hapi-swagger-12.1.3.tgz",
-            "integrity": "sha512-p5Y3/z1DnyBD5Z5uUg83w6rPmk4omCjkozdCrLxBwEx2CytCnvQ9VmaiPsl2D532005WzeiCcFGKUCBJyZsveA==",
+            "version": "10.3.0",
+            "resolved": "https://registry.npmjs.org/hapi-swagger/-/hapi-swagger-10.3.0.tgz",
+            "integrity": "sha512-orbco5/gCBfViQElGpoJVnP9wwtEY6zd6o4xgR3rGLfGV6KAr/Q5o0qjvABd20gO5lQCsP5Bo66B+rO/v0xBcA==",
             "requires": {
-                "@hapi/boom": "^8.0.1",
-                "@hapi/hoek": "^9.0.2",
-                "@hapi/joi": "^17.1.0",
-                "handlebars": "^4.5.3",
+                "@hapi/boom": "^7.1.1",
+                "@hapi/hoek": "^6.1.2",
+                "@hapi/joi": "^15.0.1",
+                "handlebars": "^4.3.3",
                 "http-status": "^1.0.1",
                 "json-schema-ref-parser": "^6.1.0",
                 "swagger-parser": "4.0.2",
@@ -4383,9 +4369,9 @@
             },
             "dependencies": {
                 "@hapi/boom": {
-                    "version": "8.0.1",
-                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-8.0.1.tgz",
-                    "integrity": "sha512-SnBM2GzEYEA6AGFKXBqNLWXR3uNBui0bkmklYXX1gYtevVhDTy2uakwkSauxvIWMtlANGRhzChYg95If3FWCwA==",
+                    "version": "7.4.11",
+                    "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
+                    "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
                     "requires": {
                         "@hapi/hoek": "8.x.x"
                     },
@@ -4396,11 +4382,6 @@
                             "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
                         }
                     }
-                },
-                "@hapi/hoek": {
-                    "version": "9.0.4",
-                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.4.tgz",
-                    "integrity": "sha512-EwaJS7RjoXUZ2cXXKZZxZqieGtc7RbvQhUy8FwDoMQtxWVi14tFjeFCYPZAM1mBCpOpiBpyaZbb9NeHc7eGKgw=="
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@datawrapper/shared": "0.19.4",
         "@hapi/boom": "9.1.0",
         "@hapi/hapi": "19.1.1",
-        "@hapi/joi": "17.1.1",
+        "@hapi/joi": "15.1.1",
         "arg": "4.1.2",
         "assign-deep": "1.0.1",
         "bcryptjs": "2.4.3",
@@ -49,7 +49,7 @@
         "got": "10.0.3",
         "hapi-auth-bearer-token": "6.2.1",
         "hapi-pino": "6.5.0",
-        "hapi-swagger": "12.1.3",
+        "hapi-swagger": "10.3.0",
         "humps": "2.0.1",
         "jsesc": "2.5.2",
         "less": "3.10.3",
@@ -59,8 +59,8 @@
         "tar": "6.0.1"
     },
     "devDependencies": {
-        "@hapi/inert": "^6.0.1",
-        "@hapi/vision": "~6.0.0",
+        "@hapi/inert": "5.2.2",
+        "@hapi/vision": "5.5.4",
         "ava": "~3.5.2",
         "babel-eslint": "~10.0.3",
         "dotenv": "~8.2.0",

--- a/src/routes/teams.test.js
+++ b/src/routes/teams.test.js
@@ -416,6 +416,25 @@ test('users can create teams', async t => {
     t.is(team.statusCode, 201);
 });
 
+test('users can create teams with "Content-Type: text/plain"', async t => {
+    const team = await t.context.server.inject({
+        method: 'POST',
+        url: `/v3/teams`,
+        auth: t.context.auth,
+        headers: {
+            'content-type': 'text/plain'
+        },
+        payload: {
+            id: 'test-user-plain',
+            name: 'Test'
+        }
+    });
+
+    await t.context.addToCleanup('team', team.result.id);
+    t.is(team.result.name, 'Test');
+    t.is(team.statusCode, 201);
+});
+
 test('owners can edit team', async t => {
     const team = await t.context.server.inject({
         method: 'PATCH',


### PR DESCRIPTION
@ilokhov discovered that some requests, like `POST /v3/teams` in our app failed after the `@hapi/joi` update. It turned out that the app sends these requests with `Content-Type: text/plain`. Joi doesn't like that since it is supposed to be `application/json`. This PR reverts the Joi version to the previous one that doesn't validate as strict.

In the future we should make sure that the app sends correct `Content-Type` headers so we can update Joi and with that the Swagger plugin that generates documentation.

I added a test case that uses `Content-Type: text/plain` so that we see it breaking the next time someone tries to update Joi.