### PR TITLE
fix: await inside loadVendorLocale to catch errors

### DIFF
--- a/src/publish/publish.js
+++ b/src/publish/publish.js
@@ -290,7 +290,7 @@ async function publishChart(request, h) {
     };
 }
 
-function loadVendorLocale(vendor, locale) {
+async function loadVendorLocale(vendor, locale) {
     const basePath = path.resolve(
         __dirname,
         '../../node_modules/@datawrapper/locales/locales/',
@@ -305,7 +305,7 @@ function loadVendorLocale(vendor, locale) {
     for (let i = 0; i < tryFiles.length; i++) {
         const file = path.join(basePath, tryFiles[i]);
         try {
-            return fs.readFile(file, 'utf-8');
+            return await fs.readFile(file, 'utf-8');
         } catch (e) {
             // file not found, so try next
         }


### PR DESCRIPTION
While working for a chart with locale `en-us`, the publishing crashed with this error:
```
Error: ENOENT: no such file or directory, 
open '/app/node_modules/@datawrapper/locales/locales/dayjs/en-us.js'
```
The correct file for my locale would have been `en.js`. I remembered that @gka did implement code that falls back to a more generic locale. This is done with a `try {} catch () {}` block. Since we directly returned the `fs.readFile` promise, it's error was never catched inside `loadVendorLocale`, which caused the fallback to not trigger. `await`-ing inside the `try` block gives us the expected behaviour.

I apologize that my suggestion to remove the `await` actually introduced a bug. Nevertheless I learned something.