### PR TITLE
inject custom-css into published chart css

### DIFF
--- a/src/publish/compile-css.js
+++ b/src/publish/compile-css.js
@@ -3,6 +3,7 @@ const path = require('path');
 const less = require('less');
 const postcssLess = require('postcss-less');
 const pCSS = require('postcss');
+const get = require('lodash/get');
 
 /* needed for variable parsing, otherwise postcss logs annoying messages we don't care about */
 const { noop } = require('../utils/index.js');
@@ -31,7 +32,7 @@ module.exports = { compileCSS };
  * @param {string[]} options.paths List of paths to look in for less `@import` statements
  * @returns {string} CSS string
  */
-async function compileCSS({ theme, filePaths }) {
+async function compileCSS({ theme, filePaths, chart }) {
     const paths = filePaths.map(path.dirname);
 
     const lessString = (await Promise.all(filePaths.map(saveReadFile))).join('');
@@ -54,6 +55,8 @@ async function compileCSS({ theme, filePaths }) {
             maps: theme.data.maps
         })
     });
+
+    css += get(chart, 'metadata.publish.custom-css', '');
 
     css = (await postcss.process(css, { from: undefined })).css;
 

--- a/src/publish/publish.js
+++ b/src/publish/publish.js
@@ -95,7 +95,7 @@ async function publishChart(request, h) {
      * Load assets like CSS, Javascript and translations
      */
     const [css, { fileName, content }] = await Promise.all([
-        compileCSS({ theme, filePaths: [chartCore.less, vis.less] }),
+        compileCSS({ theme, filePaths: [chartCore.less, vis.less], chart }),
         readFileAndHash(vis.script)
     ]);
     theme.less = ''; /* reset "theme.less" to not inline it twice into the HTML */


### PR DESCRIPTION
this injects custom css into **published** charts. for chart previews see https://github.com/datawrapper/chart-core/pull/12.

This *intentionally* bypasses the less compilation because we don't want LESS code in custom-css.