### PR TITLE
Allow guests to edit their charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -227,9 +227,9 @@
             "integrity": "sha512-NRtvAa/f4IvDoBrglZ8CxXGyyE4wgDvqceMKK1Qd8l6dzMvYf8G8gftxEOUCegN+cGF2TXwCx9U5iRymDOmKrA=="
         },
         "@datawrapper/orm": {
-            "version": "3.12.0",
-            "resolved": "https://registry.npmjs.org/@datawrapper/orm/-/orm-3.12.0.tgz",
-            "integrity": "sha512-QvjauihfflQnudjR/T1k2E7JGRF4+efWKr0tYPcbdv7JxXfdQ4yIRY86Z5lPzI2h9dfTSIfJZQ3YLWofhKEs8g==",
+            "version": "3.14.0",
+            "resolved": "https://registry.npmjs.org/@datawrapper/orm/-/orm-3.14.0.tgz",
+            "integrity": "sha512-f3jmYaSxxMVYzfTlVEwK3BSrgKl1iTvWsQK1fcrklyNmGY9cyDxtfJcSr5YI7c0VbvFt/oAcSSqCGKAZCGHAbg==",
             "requires": {
                 "assign-deep": "^1.0.1",
                 "merge-deep": "^3.0.2",
@@ -9264,9 +9264,9 @@
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         },
         "sqlstring": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
-            "integrity": "sha1-R1OT/56RR5rqYtyvDKPRSYOn+0A="
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.2.tgz",
+            "integrity": "sha512-vF4ZbYdKS8OnoJAWBmMxCQDkiEBkGQYU7UZPtL8flbDRSNkhaXvRJ279ZtI6M+zDaQovVU4tuRgzK5fVhvFAhg=="
         },
         "srcset": {
             "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
         "@datawrapper/chart-core": "^8.6.1",
         "@datawrapper/locales": "1.0.0",
-        "@datawrapper/orm": "^3.12.0",
+        "@datawrapper/orm": "^3.14.0",
         "@datawrapper/schemas": "^1.3.0",
         "@datawrapper/shared": "0.25.1",
         "@hapi/boom": "9.1.0",

--- a/src/publish/publish.js
+++ b/src/publish/publish.js
@@ -350,7 +350,8 @@ async function publishChartStatus(request, h) {
     const { params, auth } = request;
 
     const chart = await Chart.findByPk(params.id);
-    if (!(await chart.isEditableBy(auth.artifacts))) {
+
+    if (!(await chart.isEditableBy(auth.artifacts, auth.credentials.session))) {
         return Boom.unauthorized();
     }
 
@@ -377,12 +378,13 @@ async function publishData(request, h) {
           })
         : Chart.findOne({
               where: { id: params.id, deleted: { [Op.not]: true } },
-              attributes: { exclude: ['deleted', 'deleted_at', 'guest_session', 'utf8'] }
+              attributes: { exclude: ['deleted', 'deleted_at', 'utf8'] }
           });
 
     const chart = await chartQuery;
 
-    let hasAccess = query.published || (await chart.isEditableBy(auth.artifacts));
+    let hasAccess =
+        query.published || (await chart.isEditableBy(auth.artifacts, auth.credentials.session));
     if (!hasAccess && query.ott) {
         const count = await ChartAccessToken.destroy({
             where: {

--- a/src/routes/charts.js
+++ b/src/routes/charts.js
@@ -858,7 +858,10 @@ async function deleteChart(request, h) {
 
     if (!chart) return Boom.notFound();
 
-    if (!server.methods.isAdmin(request) || !(await chart.isEditableBy(auth.artifacts))) {
+    if (
+        !server.methods.isAdmin(request) ||
+        !(await chart.isEditableBy(auth.artifacts, auth.credentials.session))
+    ) {
         return Boom.forbidden();
     }
 
@@ -930,7 +933,9 @@ async function writeChartAsset(request, h) {
     const chart = await loadChart(request);
 
     const isGuestChart = chart.guest_session === request.auth.credentials.session;
-    const isEditable = isGuestChart || (await chart.isEditableBy(request.auth.artifacts));
+    const isEditable =
+        isGuestChart ||
+        (await chart.isEditableBy(request.auth.artifacts, auth.credentials.session));
 
     if (!isEditable) {
         return Boom.forbidden();

--- a/src/routes/charts/embed-codes.js
+++ b/src/routes/charts/embed-codes.js
@@ -40,7 +40,7 @@ module.exports = async (server, options) => {
             if (!chart) {
                 return Boom.notFound();
             }
-            if (!(await chart.isEditableBy(auth.artifacts))) {
+            if (!(await chart.isEditableBy(auth.artifacts, auth.credentials.session))) {
                 return Boom.unauthorized();
             }
 


### PR DESCRIPTION
_Note: This PR depends on https://github.com/datawrapper/orm/pull/31 being merged and published_

This PR fixes a couple of similar bugs where `Chart.isEditableBy` is called with only the user as the parameter, and not the session ID. Without the session ID, the ORM cannot check whether the chart might be editable based on the current guest session.