### PR TITLE
Ignore src/ and static/ folders in vis plugins in dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,18 @@
         "api": "node src/index.js",
         "start": "node src/index.js"
     },
+    "nodemonConfig": {
+        "ignore": [
+            "d3*/src/*",
+            "d3*/static/*",
+            "locator-maps/src/*",
+            "locator-maps/static/*",
+            "tables/src/*",
+            "tables/static/*",
+            "visualization*/src/*",
+            "visualization*/static/*"
+        ]
+    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/datawrapper/datawrapper-api.git"


### PR DESCRIPTION
When starting API in dev mode, we currently [use nodemon to watch all `js` files in `/plugins`](https://github.com/datawrapper/docker/blob/4fe02a048a69cef3fea1ba7aefa11de35a5ee484/entrypoints/api-entrypoint.sh#L5).

So an edit to any `js` file in any vis plugin leads to an API restart. The restart process typically takes around 10 seconds and leads to a frustrating experience when developing or debugging a vis plugin.

This PR adds a `nodemonConfig` to `package.json` with rules which ignore `src/` and `static/` folders in all vis plugins. As a result the API will no longer automatically restart when edits are made there, saving a lot of time when developing. The frontend preview and publishing charts use the currently available static files, so no API restart is necessary here.

I tried to find a way to ignore the whole vis plugin folder and include only `api.js`, but did not find a way to do so in `nodemon` as [ignoring a whole folder can not be overridden with exceptions](https://github.com/remy/nodemon/blob/master/faq.md#what-has-precedence-ignore-or-watch). Ignoring `src/` and `static/` folders is a decent compromise since edits in vis plugins only get made there.

---

This PR could theoretically be expanded to include all plugins and not just vis plugins. In my understanding some other plugins use files eg from the `static/` folder ([example here](https://github.com/datawrapper/plugin-screenshots/blob/5cf164e3eafa0d922adff4e9cee3ffacdc681142/api.js#L19-L26)), so we would need to either create more complex ignore rules or universally define and adhere to a plugin folder structure where for example all files used by API where a restart is necessary live in a folder like `api/`.

I'd be happy to hear any suggestions or ideas.