### PR TITLE
exit if localChartPublishRoot is undefined and no publish plugin exists

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -240,6 +240,15 @@ async function configure(options = { usePlugins: true, useOpenAPI: true }) {
 
     const hasRegisteredPublishPlugin = registeredEvents.includes(event.PUBLISH_CHART);
 
+    if (general.localChartPublishRoot === undefined && !hasRegisteredPublishPlugin) {
+        server
+            .logger()
+            .error(
+                '[Config] You need to configure `general.localChartPublishRoot` or install a plugin that implements chart publication.'
+            );
+        process.exit(1);
+    }
+
     if (!hasRegisteredPublishPlugin) {
         const protocol = frontend.https ? 'https' : 'http';
         events.on(event.PUBLISH_CHART, async ({ chart, outDir, fileMap }) => {


### PR DESCRIPTION
this would have saved me 30 minutes of debugging on staging, so let's add this... we have a similar check for `localChartAssetRoot`.