### PR TITLE
Support full vector chart export

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,10 +122,12 @@
         }
     },
     "prettier": {
-        "tabWidth": 4,
-        "semi": true,
+        "arrowParens": "avoid",
         "printWidth": 100,
-        "singleQuote": true
+        "semi": true,
+        "singleQuote": true,
+        "tabWidth": 4,
+        "trailingComma": "none"
     },
     "husky": {
         "hooks": {

--- a/src/routes/charts.js
+++ b/src/routes/charts.js
@@ -252,7 +252,8 @@ function register(server, options) {
                     border: Joi.object().keys({
                         width: Joi.number(),
                         color: Joi.string().default('auto')
-                    })
+                    }),
+                    fullVector: Joi.boolean().default(false)
                 })
             }
         },
@@ -300,7 +301,8 @@ function register(server, options) {
                     zoom: Joi.number().default(2),
                     borderWidth: Joi.number(),
                     borderColor: Joi.string(),
-                    download: Joi.boolean().default(false)
+                    download: Joi.boolean().default(false),
+                    fullVector: Joi.boolean().default(false)
                 })
             }
         },


### PR DESCRIPTION
### Motivation

Allow the user of the API to request a full vector export of a locator map.

Requirement for:

- https://github.com/datawrapper/render-client/pull/19
- https://github.com/datawrapper/plugin-export-pdf/pull/93

### Changes

- Add GET/POST param `fullVector` which render-client then passed down to ExportPrint. See https://github.com/datawrapper/render-client/pull/19

### Unrelated changes

- Update linting config.