### PR TITLE
enable graceful start and shutdown

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -335,7 +335,7 @@ async function start() {
     }, 100);
 
     process.on('SIGINT', async function() {
-        server.logger().info('received SHUTDOWN signal, closing all connections...');
+        server.logger().info('received SIGINT signal, closing all connections...');
         await server.stop();
         server.logger().info('server has stopped');
         process.exit(0);

--- a/src/server.js
+++ b/src/server.js
@@ -328,6 +328,19 @@ async function start() {
     }
 
     server.start();
+    setTimeout(() => {
+        server.logger().info('sending READY signal to pm2');
+        process.send('ready');
+    }, 100);
+
+    process.on('message', async function(msg) {
+        if (msg === 'shutdown') {
+            server.logger().info('received SHUTDOWN signal, closing all connections...');
+            await server.stop();
+            server.logger().info('server has stopped');
+            process.exit(0);
+        }
+    });
 
     return server;
 }

--- a/src/server.js
+++ b/src/server.js
@@ -328,18 +328,17 @@ async function start() {
     }
 
     server.start();
+
     setTimeout(() => {
         server.logger().info('sending READY signal to pm2');
         process.send('ready');
     }, 100);
 
-    process.on('message', async function(msg) {
-        if (msg === 'shutdown') {
-            server.logger().info('received SHUTDOWN signal, closing all connections...');
-            await server.stop();
-            server.logger().info('server has stopped');
-            process.exit(0);
-        }
+    process.on('SIGINT', async function() {
+        server.logger().info('received SHUTDOWN signal, closing all connections...');
+        await server.stop();
+        server.logger().info('server has stopped');
+        process.exit(0);
     });
 
     return server;


### PR DESCRIPTION
This PR implements the recommendations for [graceful start/shutdown with pm2](https://pm2.keymetrics.io/docs/usage/signals-clean-restart/).

more specifically:
* we send out the `ready` signal after all plugins have been loaded. Otherwise `pm2` is hooking into the `server.listen` function to decide when a service is "ready". To activate this we need to add `wait_ready: true` to the `apps.json` file. We also should increase the default `ready_timeout` from 3 to 5 seconds, I think. That's the time that `pm2` is waiting for the ready signal.
* we listen to the `shutdown` signal which is sent out by `pm2` to trigger a graceful shutdown. Rather than just killing the app it gives it time to close existing connections properly. For this we need to add `shutdown_with_message: true` to the `apps.json` file

Both turn `pm2 reload` into a zero-downtime operation. The instances are shutdown and reloaded one after the other, each is given time to close connections and the next shutdown is waiting for the ready signal of the previous instance.