### PR TITLE
Include chart attributes in response

### DIFF
--- a/src/publish/publish.js
+++ b/src/publish/publish.js
@@ -137,6 +137,7 @@ async function publishChart(request, h) {
     logPublishStatus('done');
 
     return {
+        data: prepareChart(chart),
         version: newPublicVersion,
         url: destination
     };


### PR DESCRIPTION
A lot of prior API clients relied on the `data` key in the result of the publish response containing the chart attributes. This PR reintroduces that attribute.