### PR TITLE
Add protocol-less embed code placeholder

### DIFF
--- a/src/routes/charts/embed-codes.js
+++ b/src/routes/charts/embed-codes.js
@@ -117,6 +117,10 @@ module.exports = async (server, options) => {
                     code: template
                         .replace(/%chart_id%/g, chart.id)
                         .replace(/%chart_url%/g, chart.public_url)
+                        .replace(
+                            /%chart_url_without_protocol%/g,
+                            chart.public_url.replace(new URL(chart.public_url).protocol, '')
+                        )
                         .replace(/%chart_type%/g, ariaLabel)
                         .replace(/%chart_title%/g, clean(chart.title))
                         .replace(/%chart_intro%/g, clean(get(chart, 'metadata.describe.intro')))


### PR DESCRIPTION
So that users have the option to define a custom embed code without the protocol as the iframe src, as is a requirement for some.