### PR TITLE
Switch authentication method precedence

### DIFF
--- a/src/auth/dw-auth.js
+++ b/src/auth/dw-auth.js
@@ -25,14 +25,14 @@ function dwAuth(server, options = {}) {
             let artifacts = {};
 
             try {
-                const cookie = await server.auth.test('session', request);
-                credentials = cookie.credentials;
-                artifacts = cookie.artifacts;
+                const bearer = await server.auth.test('bearer', request);
+                credentials = bearer.credentials;
+                artifacts = bearer.artifacts;
             } catch (error) {
                 try {
-                    const bearer = await server.auth.test('bearer', request);
-                    credentials = bearer.credentials;
-                    artifacts = bearer.artifacts;
+                    const cookie = await server.auth.test('session', request);
+                    credentials = cookie.credentials;
+                    artifacts = cookie.artifacts;
                 } catch (error) {
                     throw Boom.unauthorized('Invalid authentication credentials', [
                         'Session',


### PR DESCRIPTION
This changes the behavior of the auth strategies:
- the bearer token strategy is evaluated first
- then, the cookie strategy is evaluated

The only practical difference is that if both methods are passed, the token takes precedence. This does not have any impact for requests that have no `Authorization` header set, performance or otherwise, as the entire strategy is not executed in that case (which I verified).

This aligns behavior with our prior PHP API and also makes more sense in my opinion, as one is way more likely to accidentally send a cookie than an API token.