### PR TITLE
Don't send Clear-Site-Data header on logout

### DIFF
--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -370,8 +370,7 @@ async function logout(request, h) {
     return h
         .response()
         .code(205)
-        .unstate(api.sessionID)
-        .header('Clear-Site-Data', '"cookies", "storage", "executionContexts"');
+        .unstate(api.sessionID);
 }
 
 async function getAllTokens(request, h) {

--- a/src/routes/auth.test.js
+++ b/src/routes/auth.test.js
@@ -54,7 +54,6 @@ test('Login and logout work with correct credentials', async t => {
     });
 
     t.is(res.statusCode, 205);
-    t.is(res.headers['clear-site-data'], '"cookies", "storage", "executionContexts"');
     t.true(res.headers['set-cookie'][0].includes('DW-SESSION=;'));
     t.false(res.headers['set-cookie'].includes(session));
 });

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -670,8 +670,6 @@ async function deleteUser(request, h) {
         if (session) {
             await session.destroy();
         }
-
-        response.header('Clear-Site-Data', '"cookies", "storage", "executionContexts"');
     }
 
     await server.app.events.emit(server.app.event.USER_DELETED, {

--- a/src/routes/users.test.js
+++ b/src/routes/users.test.js
@@ -67,7 +67,6 @@ test('It should be possible to create a user, login and logout', async t => {
 
     t.is(res.statusCode, 205);
     t.false(res.headers['set-cookie'].join().includes(cookieString));
-    t.is(res.headers[('clear-site-data', '"cookies", "storage", "executionContexts"')]);
 });
 
 test('New user passwords should be saved as bcrypt hash', async t => {


### PR DESCRIPTION
Currently, we send the `Clear-Site-Data` header to instruct the browser to clear the session data, **in addition** to deleting the session from the database and unsetting the cookie.

This is annoying because `Clear-Site-Data` is not scoped to the cookie domain, so a logout on `app.staging.datawrapper.de` also logs the user out from `app.datawrapper.de`. This PR changes that by removing the header.