### PR TITLE
Fix standard iframe embed

### DIFF
--- a/src/routes/charts/embed-codes.js
+++ b/src/routes/charts/embed-codes.js
@@ -87,7 +87,7 @@ module.exports = async (server, options) => {
                     preferred: preferred === 'iframe',
                     title: __('publish / embed / iframe'),
                     ...getTemplate(
-                        `<iframe title="%chart_title%" aria-label="%chart_type%" id="datawrapper-chart-%chart_id%" src="%chart_url%" scrolling="no" frameborder="0" style="width: 0; min-width: 100% !important; border: none;" height="%chart_height%"></iframe>`
+                        `<iframe title="%chart_title%" aria-label="%chart_type%" id="datawrapper-chart-%chart_id%" src="%chart_url%" scrolling="no" frameborder="0" style="border: none;" width="%chart_width%" height="%chart_height%"></iframe>`
                     )
                 }
             ];


### PR DESCRIPTION
Both width & height should be included in the standard iframe embed, as was previously the case.

![image](https://user-images.githubusercontent.com/19191012/81201327-71df2480-8fc5-11ea-8453-773aa3c8c80d.png)
