### PR TITLE
Return 204 response code in PUT_CHART_ASSET

### DIFF
--- a/src/routes/charts.test.js
+++ b/src/routes/charts.test.js
@@ -275,7 +275,7 @@ test('User can read and write chart data', async t => {
     t.is(res.statusCode, 404);
     // set chart data
     res = await putData('hello world');
-    t.is(res.statusCode, 200);
+    t.is(res.statusCode, 204);
     // confirm chart data was set
     res = await getData();
     t.is(res.statusCode, 200);
@@ -286,7 +286,7 @@ test('User can read and write chart data', async t => {
     t.is(res.result, 'hello world');
     // write some JSON to another asset
     res = await putAsset(`${chart.result.id}.map.json`, { answer: 42 }, 'application/json');
-    t.is(res.statusCode, 200);
+    t.is(res.statusCode, 204);
     // see if that worked
     res = await getAsset(`${chart.result.id}.map.json`);
     t.is(res.statusCode, 200);

--- a/src/server.js
+++ b/src/server.js
@@ -252,7 +252,7 @@ async function configure(options = { usePlugins: true, useOpenAPI: true }) {
 
             await fs.mkdir(outPath, { recursive: true });
             await fs.writeFile(path.join(outPath, filename), data);
-            return { code: 200 };
+            return { code: 204 };
         });
     }
 


### PR DESCRIPTION
This PR updates the returned response code in PUT_CHART_ASSET from `200` to `204` when storing chart assets locally.

We already do it in [chart-data-s3](https://github.com/datawrapper/plugin-chart-data-s3/blob/df99147a0372cde067d47df789836087a1eaebdf/api.js#L64) and the response schema for `/:id/assets/:asset` and `/:id/data` endpoints already expects `204` response code, for example see here:

https://github.com/datawrapper/api/blob/131fc9f3b21769b4db60ede07d6cd2df0f2223cb/src/routes/charts.js#L419

and here:

https://github.com/datawrapper/api/blob/131fc9f3b21769b4db60ede07d6cd2df0f2223cb/src/schemas/response.js#L20-L22

---

Returning `200` as we do now leads to errors when trying to update `locator-maps` to use a newer version of `shared`, since [this check fails](https://github.com/datawrapper/shared/blob/a2f45acb8dff9a6646a0f80303d5d53836b5e59f/httpReq.js#L54) and [there is no content-type in an empty response which leads to a JS error](https://github.com/datawrapper/shared/blob/a2f45acb8dff9a6646a0f80303d5d53836b5e59f/httpReq.js#L56).

A bit more info on the error in locator maps can be found in a [Notion task here](https://www.notion.so/datawrapper/Update-locator-maps-to-use-API-v3-endpoints-05314567bc4049cdacd5a7b95de07101).