### PR TITLE
Fix delete permission check

### DIFF
--- a/src/routes/charts.js
+++ b/src/routes/charts.js
@@ -878,7 +878,7 @@ async function deleteChart(request, h) {
     if (!chart) return Boom.notFound();
 
     if (
-        !server.methods.isAdmin(request) ||
+        !server.methods.isAdmin(request) &&
         !(await chart.isEditableBy(auth.artifacts, auth.credentials.session))
     ) {
         return Boom.forbidden();


### PR DESCRIPTION
User should be able to delete a chart if they can edit it _or_ they are an admin, not only if they are an admin.