### PR TITLE
expose validation error in dev mode

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -71,11 +71,9 @@ const server = Hapi.server({
             credentials: true
         },
         validate: {
-            failAction: !DW_DEV_MODE
-                ? 'error'
-                : async function(request, h, err) {
-                      throw Boom.badRequest('Invalid request payload input: ' + err.message);
-                  }
+            async failAction(request, h, err) {
+                throw Boom.badRequest('Invalid request payload input: ' + err.message);
+            }
         }
     }
 });

--- a/src/server.js
+++ b/src/server.js
@@ -74,7 +74,7 @@ const server = Hapi.server({
             failAction: !DW_DEV_MODE
                 ? 'error'
                 : async function(request, h, err) {
-                      throw err;
+                      throw Boom.badRequest('Invalid request payload input: ' + err.message);
                   }
         }
     }

--- a/src/server.js
+++ b/src/server.js
@@ -69,6 +69,13 @@ const server = Hapi.server({
         cors: {
             origin: config.api.cors,
             credentials: true
+        },
+        validate: {
+            failAction: !DW_DEV_MODE
+                ? 'error'
+                : async function(request, h, err) {
+                      throw err;
+                  }
         }
     }
 });


### PR DESCRIPTION
this PR registers a default `failAction` handler that will throw custom errors on failed payload validations in dev mode. This means instead of

```json
{
  "statusCode": 400,
  "error": "Bad Request",
  "message": "Invalid request payload input"
}
```

the API is returning more useful information about **why** the validation failed:

```json
{
  "statusCode": 400,
  "error": "Bad Request",
  "message": "Invalid request payload input: \"name\" is not allowed"
}
```

@sto3psl @davidkokkelink I think in terms of increasing the usablity of our API I would almost be inclined to include this error message in production as well. But maybe it is a security concern, as it would also leak information about undocumented routes.