### PR TITLE
Set max upload size for chart assets to 2MB

### DIFF
--- a/src/routes/charts/{id}/assets.js
+++ b/src/routes/charts/{id}/assets.js
@@ -65,6 +65,7 @@ module.exports = (server, options) => {
             },
             response: noContentResponse,
             payload: {
+                maxBytes: 2048 * 1024, // 2MiB
                 defaultContentType: 'text/csv',
                 allow: ['text/csv', 'application/json']
             }

--- a/src/routes/charts/{id}/data.js
+++ b/src/routes/charts/{id}/data.js
@@ -55,6 +55,7 @@ module.exports = (server, options) => {
             },
             response: noContentResponse,
             payload: {
+                maxBytes: 2048 * 1024, // 2MiB
                 defaultContentType: 'text/csv',
                 allow: ['text/csv', 'application/json']
             }


### PR DESCRIPTION
The default max payload size for hapi file uploads is 1MB ([source](https://hapi.dev/api/?v=19.1.1#-routeoptionspayloadmaxbytes)). This PR increases it to 2MB for the `PUT /charts/{id}/assets/{asset}` endpoint.