### PR TITLE
Don't expose invite token

### DIFF
--- a/src/routes/teams/{id}/members.js
+++ b/src/routes/teams/{id}/members.js
@@ -214,7 +214,6 @@ async function getTeamMembers(request, h) {
                 charts: user.charts.length,
                 isAdmin: user.role === 'admin' || user.role === 'sysadmin',
                 role: user_team.team_role,
-                token,
                 isNewUser: token ? user.activate_token === token : undefined,
                 url: `/v3/users/${user.id}`
             };


### PR DESCRIPTION
We currently expose team invitee's `activate_token`s in the `/teams/{id}/members` endpoint for team admins. This would allow team admins to accept invitations on behalf of their invitees, which would give them control of activated accounts with email addresses they don't control.