### PR TITLE
api token scopes

### DIFF
--- a/src/auth/cookie-auth.js
+++ b/src/auth/cookie-auth.js
@@ -18,7 +18,7 @@ async function cookieValidation(request, session, h) {
     });
 
     return getUser(row.data['dw-user-id'], {
-        credentials: { session, data: row },
+        credentials: { session, data: row, scope: ['all'] },
         strategy: 'Session',
         logger: request.server.logger()
     });

--- a/src/auth/cookie-auth.js
+++ b/src/auth/cookie-auth.js
@@ -17,11 +17,16 @@ async function cookieValidation(request, session, h) {
         }
     });
 
-    return getUser(row.data['dw-user-id'], {
-        credentials: { session, data: row, scope: ['all'] },
+    const auth = await getUser(row.data['dw-user-id'], {
+        credentials: { session, data: row },
         strategy: 'Session',
         logger: request.server.logger()
     });
+    if (auth.isValid) {
+        // add all scopes to cookie session
+        auth.credentials.scope = request.server.methods.getScopes(auth.artifacts.isAdmin());
+    }
+    return auth;
 }
 
 function cookieAuth(server, options) {

--- a/src/auth/dw-auth.js
+++ b/src/auth/dw-auth.js
@@ -15,10 +15,17 @@ async function bearerValidation(request, token, h) {
 
     await row.update({ last_used_at: new Date() });
 
-    return getUser(row.user_id, {
-        credentials: { token, scope: row.data.scopes || ['all'] },
+    const auth = await getUser(row.user_id, {
+        credentials: { token },
         strategy: 'Token'
     });
+    if (auth.isValid) {
+        auth.credentials.scope =
+            !row.data.scopes || row.data.scopes.includes('all')
+                ? request.server.methods.getScopes(auth.artifacts.isAdmin())
+                : row.data.scopes;
+    }
+    return auth;
 }
 
 function dwAuth(server, options = {}) {

--- a/src/auth/dw-auth.js
+++ b/src/auth/dw-auth.js
@@ -15,7 +15,10 @@ async function bearerValidation(request, token, h) {
 
     await row.update({ last_used_at: new Date() });
 
-    return getUser(row.user_id, { credentials: { token }, strategy: 'Token' });
+    return getUser(row.user_id, {
+        credentials: { token, scope: row.data.scopes || ['all'] },
+        strategy: 'Token'
+    });
 }
 
 function dwAuth(server, options = {}) {

--- a/src/auth/dw-auth.test.js
+++ b/src/auth/dw-auth.test.js
@@ -22,7 +22,7 @@ test('Should accept valid token', async t => {
     const { auth } = res.request;
 
     t.true(auth.isAuthenticated);
-    t.deepEqual(auth.credentials, { token: token, scope: ['all'] });
+    t.is(auth.credentials.token, token);
     t.is(auth.artifacts.id, user.id);
 });
 

--- a/src/auth/dw-auth.test.js
+++ b/src/auth/dw-auth.test.js
@@ -22,7 +22,7 @@ test('Should accept valid token', async t => {
     const { auth } = res.request;
 
     t.true(auth.isAuthenticated);
-    t.deepEqual(auth.credentials, { token: token });
+    t.deepEqual(auth.credentials, { token: token, scope: ['all'] });
     t.is(auth.artifacts.id, user.id);
 });
 

--- a/src/routes/admin/plugins.js
+++ b/src/routes/admin/plugins.js
@@ -28,7 +28,10 @@ function register(server, options) {
         method: 'GET',
         path: '/',
         options: {
-            auth: 'admin'
+            auth: {
+                strategy: 'admin',
+                scope: ['plugin', 'all']
+            }
         },
         handler: getAllPlugins
     });

--- a/src/routes/admin/plugins.js
+++ b/src/routes/admin/plugins.js
@@ -23,7 +23,8 @@ module.exports = {
 };
 
 function register(server, options) {
-    server.app.adminScopes.add('plugin');
+    server.app.adminScopes.add('plugin:read');
+    server.app.adminScopes.add('plugin:write');
     // GET /v3/admin/plugins
     server.route({
         method: 'GET',
@@ -31,7 +32,7 @@ function register(server, options) {
         options: {
             auth: {
                 strategy: 'admin',
-                access: { scope: ['plugin', 'all'] }
+                access: { scope: ['plugin:read'] }
             }
         },
         handler: getAllPlugins
@@ -58,7 +59,10 @@ function register(server, options) {
         method: 'POST',
         path: '/update',
         options: {
-            auth: 'admin',
+            auth: {
+                strategy: 'admin',
+                access: { scope: ['plugin:write'] }
+            },
             validate: {
                 payload: {
                     name: Joi.string().required(),

--- a/src/routes/admin/plugins.js
+++ b/src/routes/admin/plugins.js
@@ -23,6 +23,7 @@ module.exports = {
 };
 
 function register(server, options) {
+    server.app.adminScopes.add('plugin');
     // GET /v3/admin/plugins
     server.route({
         method: 'GET',

--- a/src/routes/admin/plugins.js
+++ b/src/routes/admin/plugins.js
@@ -31,7 +31,7 @@ function register(server, options) {
         options: {
             auth: {
                 strategy: 'admin',
-                scope: ['plugin', 'all']
+                access: { scope: ['plugin', 'all'] }
             }
         },
         handler: getAllPlugins

--- a/src/routes/admin/teams.js
+++ b/src/routes/admin/teams.js
@@ -18,7 +18,7 @@ function register(server, options) {
         options: {
             auth: {
                 strategy: 'admin',
-                access: { scope: ['team', 'all'] }
+                access: { scope: ['team:read'] }
             },
             validate: {
                 query: {

--- a/src/routes/admin/teams.js
+++ b/src/routes/admin/teams.js
@@ -16,7 +16,10 @@ function register(server, options) {
         method: 'GET',
         path: '/',
         options: {
-            auth: 'admin',
+            auth: {
+                strategy: 'admin',
+                scope: ['team', 'all']
+            },
             validate: {
                 query: {
                     userId: Joi.number(),

--- a/src/routes/admin/teams.js
+++ b/src/routes/admin/teams.js
@@ -18,7 +18,7 @@ function register(server, options) {
         options: {
             auth: {
                 strategy: 'admin',
-                scope: ['team', 'all']
+                access: { scope: ['team', 'all'] }
             },
             validate: {
                 query: {

--- a/src/routes/auth/change-password.js
+++ b/src/routes/auth/change-password.js
@@ -10,7 +10,7 @@ module.exports = async (server, options) => {
         options: {
             auth: {
                 mode: 'try',
-                access: { scope: ['auth', 'all'] }
+                access: { scope: ['auth'] }
             },
             validate: {
                 payload: Joi.object({

--- a/src/routes/auth/change-password.js
+++ b/src/routes/auth/change-password.js
@@ -9,7 +9,8 @@ module.exports = async (server, options) => {
         path: '/change-password',
         options: {
             auth: {
-                mode: 'try'
+                mode: 'try',
+                scope: ['auth', 'all']
             },
             validate: {
                 payload: Joi.object({

--- a/src/routes/auth/change-password.js
+++ b/src/routes/auth/change-password.js
@@ -10,7 +10,7 @@ module.exports = async (server, options) => {
         options: {
             auth: {
                 mode: 'try',
-                scope: ['auth', 'all']
+                access: { scope: ['auth', 'all'] }
             },
             validate: {
                 payload: Joi.object({

--- a/src/routes/auth/change-password.js
+++ b/src/routes/auth/change-password.js
@@ -10,7 +10,7 @@ module.exports = async (server, options) => {
         options: {
             auth: {
                 mode: 'try',
-                access: { scope: ['auth'] }
+                access: { scope: ['auth:write'] }
             },
             validate: {
                 payload: Joi.object({

--- a/src/routes/auth/index.js
+++ b/src/routes/auth/index.js
@@ -1,7 +1,9 @@
 module.exports = {
     name: 'routes/auth',
     version: '1.0.0',
-    register: (server, options) => {
+    register(server, options) {
+        server.app.scopes.add('auth');
+
         require('./activate')(server, options);
         require('./change-password')(server, options);
         require('./login')(server, options);

--- a/src/routes/auth/index.js
+++ b/src/routes/auth/index.js
@@ -2,7 +2,8 @@ module.exports = {
     name: 'routes/auth',
     version: '1.0.0',
     register(server, options) {
-        server.app.scopes.add('auth');
+        server.app.scopes.add('auth:read');
+        server.app.scopes.add('auth:write');
 
         require('./activate')(server, options);
         require('./change-password')(server, options);

--- a/src/routes/auth/resend-activation.js
+++ b/src/routes/auth/resend-activation.js
@@ -11,7 +11,7 @@ module.exports = async (server, options) => {
         path: '/resend-activation',
         options: {
             auth: {
-                access: { scope: ['auth'] }
+                access: { scope: ['auth:write'] }
             },
             validate: {
                 payload: Joi.object({

--- a/src/routes/auth/resend-activation.js
+++ b/src/routes/auth/resend-activation.js
@@ -11,7 +11,7 @@ module.exports = async (server, options) => {
         path: '/resend-activation',
         options: {
             auth: {
-                access: { scope: ['auth', 'all'] }
+                access: { scope: ['auth'] }
             },
             validate: {
                 payload: Joi.object({

--- a/src/routes/auth/resend-activation.js
+++ b/src/routes/auth/resend-activation.js
@@ -11,7 +11,7 @@ module.exports = async (server, options) => {
         path: '/resend-activation',
         options: {
             auth: {
-                scope: ['auth', 'all']
+                access: { scope: ['auth', 'all'] }
             },
             validate: {
                 payload: Joi.object({

--- a/src/routes/auth/resend-activation.js
+++ b/src/routes/auth/resend-activation.js
@@ -10,6 +10,9 @@ module.exports = async (server, options) => {
         method: 'POST',
         path: '/resend-activation',
         options: {
+            auth: {
+                scope: ['auth', 'all']
+            },
             validate: {
                 payload: Joi.object({
                     email: Joi.string()

--- a/src/routes/auth/reset-password.js
+++ b/src/routes/auth/reset-password.js
@@ -10,7 +10,7 @@ module.exports = async (server, options) => {
         options: {
             auth: {
                 mode: 'try',
-                access: { scope: ['auth', 'all'] }
+                access: { scope: ['auth'] }
             },
             validate: {
                 payload: Joi.object({

--- a/src/routes/auth/reset-password.js
+++ b/src/routes/auth/reset-password.js
@@ -10,7 +10,7 @@ module.exports = async (server, options) => {
         options: {
             auth: {
                 mode: 'try',
-                scope: ['auth', 'all']
+                access: { scope: ['auth', 'all'] }
             },
             validate: {
                 payload: Joi.object({

--- a/src/routes/auth/reset-password.js
+++ b/src/routes/auth/reset-password.js
@@ -9,7 +9,8 @@ module.exports = async (server, options) => {
         path: '/reset-password',
         options: {
             auth: {
-                mode: 'try'
+                mode: 'try',
+                scope: ['auth', 'all']
             },
             validate: {
                 payload: Joi.object({

--- a/src/routes/auth/reset-password.js
+++ b/src/routes/auth/reset-password.js
@@ -10,7 +10,7 @@ module.exports = async (server, options) => {
         options: {
             auth: {
                 mode: 'try',
-                access: { scope: ['auth'] }
+                access: { scope: ['auth:write'] }
             },
             validate: {
                 payload: Joi.object({

--- a/src/routes/auth/session.js
+++ b/src/routes/auth/session.js
@@ -8,7 +8,7 @@ module.exports = async (server, options) => {
         options: {
             auth: {
                 mode: 'try',
-                access: { scope: ['auth', 'all'] }
+                access: { scope: ['auth'] }
             }
         },
         async handler(request, h) {

--- a/src/routes/auth/session.js
+++ b/src/routes/auth/session.js
@@ -8,7 +8,7 @@ module.exports = async (server, options) => {
         options: {
             auth: {
                 mode: 'try',
-                scope: ['auth', 'all']
+                access: { scope: ['auth', 'all'] }
             }
         },
         async handler(request, h) {

--- a/src/routes/auth/session.js
+++ b/src/routes/auth/session.js
@@ -8,7 +8,7 @@ module.exports = async (server, options) => {
         options: {
             auth: {
                 mode: 'try',
-                access: { scope: ['auth'] }
+                access: { scope: ['auth:write'] }
             }
         },
         async handler(request, h) {

--- a/src/routes/auth/session.js
+++ b/src/routes/auth/session.js
@@ -7,7 +7,8 @@ module.exports = async (server, options) => {
         path: '/session',
         options: {
             auth: {
-                mode: 'try'
+                mode: 'try',
+                scope: ['auth', 'all']
             }
         },
         async handler(request, h) {

--- a/src/routes/auth/tokens.js
+++ b/src/routes/auth/tokens.js
@@ -161,7 +161,7 @@ module.exports = async (server, options) => {
             }
         },
         async handler(request, h) {
-            const scopes = Array.from(server.app.scopes.values());
+            const scopes = Array.from(server.app.scopes);
             if (!request.server.methods.isAdmin(request)) return scopes;
             const adminScopes = Array.from(server.app.adminScopes.values());
             return [...scopes, ...adminScopes];

--- a/src/routes/auth/tokens.js
+++ b/src/routes/auth/tokens.js
@@ -140,6 +140,22 @@ module.exports = async (server, options) => {
             return h.response().code(204);
         }
     });
+
+    // GET /v3/auth/token-scopes
+    server.route({
+        method: 'GET',
+        path: '/token-scopes',
+        options: {
+            tags: ['api'],
+            description: 'Get list of valid token scopes'
+        },
+        async handler(request, h) {
+            const scopes = Array.from(server.app.scopes.values());
+            if (!request.server.methods.isAdmin(request)) return scopes;
+            const adminScopes = Array.from(server.app.adminScopes.values());
+            return [...scopes, ...adminScopes];
+        }
+    });
 };
 
 async function getAllTokens(request, h) {

--- a/src/routes/auth/tokens.js
+++ b/src/routes/auth/tokens.js
@@ -84,7 +84,11 @@ module.exports = async (server, options) => {
                 // validate scopes
                 for (let i = 0; i < payload.scopes.length; i++) {
                     const scope = payload.scopes[i];
-                    if (!server.app.scopes.has(scope) && !server.app.adminScopes.has(scope)) {
+                    if (
+                        scope !== 'all' &&
+                        !server.app.scopes.has(scope) &&
+                        !server.app.adminScopes.has(scope)
+                    ) {
                         return Boom.badRequest(`Invalid scope "${scope}"`);
                     }
                 }

--- a/src/routes/auth/tokens.js
+++ b/src/routes/auth/tokens.js
@@ -17,7 +17,7 @@ module.exports = async (server, options) => {
         options: {
             tags: ['api'],
             auth: {
-                access: { scope: ['auth'] }
+                access: { scope: ['auth:read'] }
             },
             description: 'List API tokens',
             notes: 'Response will not include full tokens for security reasons.',
@@ -49,7 +49,7 @@ module.exports = async (server, options) => {
                      It is possible to create a comment with every token to have a reference where it is used.
                      Make sure to save the token somewhere, since you won't be able to see it again.`,
             auth: {
-                access: { scope: ['auth'] }
+                access: { scope: ['auth:write'] }
             },
             validate: {
                 payload: Joi.object({
@@ -122,7 +122,7 @@ module.exports = async (server, options) => {
             notes:
                 'Delete an API access token. Check [/v3/auth/tokens](ref:authtokens) to get the IDs of your available tokens.',
             auth: {
-                access: { scope: ['auth'] }
+                access: { scope: ['auth:write'] }
             },
             validate: {
                 params: Joi.object({
@@ -157,7 +157,7 @@ module.exports = async (server, options) => {
             tags: ['api'],
             description: 'Get list of valid token scopes',
             auth: {
-                access: { scope: ['auth'] }
+                access: { scope: ['auth:read'] }
             }
         },
         async handler(request, h) {

--- a/src/routes/auth/tokens.js
+++ b/src/routes/auth/tokens.js
@@ -48,6 +48,9 @@ module.exports = async (server, options) => {
             notes: `This endpoint will create a new API Token and show it in the response body.
                      It is possible to create a comment with every token to have a reference where it is used.
                      Make sure to save the token somewhere, since you won't be able to see it again.`,
+            auth: {
+                scope: ['auth', 'all']
+            },
             validate: {
                 payload: Joi.object({
                     comment: Joi.string()
@@ -116,6 +119,9 @@ module.exports = async (server, options) => {
             description: 'Delete API token',
             notes:
                 'Delete an API access token. Check [/v3/auth/tokens](ref:authtokens) to get the IDs of your available tokens.',
+            auth: {
+                scope: ['auth', 'all']
+            },
             validate: {
                 params: Joi.object({
                     id: Joi.number()
@@ -147,7 +153,10 @@ module.exports = async (server, options) => {
         path: '/token-scopes',
         options: {
             tags: ['api'],
-            description: 'Get list of valid token scopes'
+            description: 'Get list of valid token scopes',
+            auth: {
+                scope: ['auth', 'all']
+            }
         },
         async handler(request, h) {
             const scopes = Array.from(server.app.scopes.values());

--- a/src/routes/auth/tokens.js
+++ b/src/routes/auth/tokens.js
@@ -17,7 +17,7 @@ module.exports = async (server, options) => {
         options: {
             tags: ['api'],
             auth: {
-                scope: ['auth', 'all']
+                access: { scope: ['auth', 'all'] }
             },
             description: 'List API tokens',
             notes: 'Response will not include full tokens for security reasons.',
@@ -49,7 +49,7 @@ module.exports = async (server, options) => {
                      It is possible to create a comment with every token to have a reference where it is used.
                      Make sure to save the token somewhere, since you won't be able to see it again.`,
             auth: {
-                scope: ['auth', 'all']
+                access: { scope: ['auth', 'all'] }
             },
             validate: {
                 payload: Joi.object({
@@ -122,7 +122,7 @@ module.exports = async (server, options) => {
             notes:
                 'Delete an API access token. Check [/v3/auth/tokens](ref:authtokens) to get the IDs of your available tokens.',
             auth: {
-                scope: ['auth', 'all']
+                access: { scope: ['auth', 'all'] }
             },
             validate: {
                 params: Joi.object({
@@ -157,7 +157,7 @@ module.exports = async (server, options) => {
             tags: ['api'],
             description: 'Get list of valid token scopes',
             auth: {
-                scope: ['auth', 'all']
+                access: { scope: ['auth', 'all'] }
             }
         },
         async handler(request, h) {

--- a/src/routes/auth/tokens.js
+++ b/src/routes/auth/tokens.js
@@ -17,7 +17,7 @@ module.exports = async (server, options) => {
         options: {
             tags: ['api'],
             auth: {
-                access: { scope: ['auth', 'all'] }
+                access: { scope: ['auth'] }
             },
             description: 'List API tokens',
             notes: 'Response will not include full tokens for security reasons.',
@@ -49,7 +49,7 @@ module.exports = async (server, options) => {
                      It is possible to create a comment with every token to have a reference where it is used.
                      Make sure to save the token somewhere, since you won't be able to see it again.`,
             auth: {
-                access: { scope: ['auth', 'all'] }
+                access: { scope: ['auth'] }
             },
             validate: {
                 payload: Joi.object({
@@ -122,7 +122,7 @@ module.exports = async (server, options) => {
             notes:
                 'Delete an API access token. Check [/v3/auth/tokens](ref:authtokens) to get the IDs of your available tokens.',
             auth: {
-                access: { scope: ['auth', 'all'] }
+                access: { scope: ['auth'] }
             },
             validate: {
                 params: Joi.object({
@@ -157,7 +157,7 @@ module.exports = async (server, options) => {
             tags: ['api'],
             description: 'Get list of valid token scopes',
             auth: {
-                access: { scope: ['auth', 'all'] }
+                access: { scope: ['auth'] }
             }
         },
         async handler(request, h) {

--- a/src/routes/auth/tokens.js
+++ b/src/routes/auth/tokens.js
@@ -163,7 +163,7 @@ module.exports = async (server, options) => {
         async handler(request, h) {
             const scopes = Array.from(server.app.scopes);
             if (!request.server.methods.isAdmin(request)) return scopes;
-            const adminScopes = Array.from(server.app.adminScopes.values());
+            const adminScopes = Array.from(server.app.adminScopes);
             return [...scopes, ...adminScopes];
         }
     });

--- a/src/routes/auth/tokens.js
+++ b/src/routes/auth/tokens.js
@@ -16,6 +16,9 @@ module.exports = async (server, options) => {
         path: '/tokens',
         options: {
             tags: ['api'],
+            auth: {
+                scope: ['auth', 'all']
+            },
             description: 'List API tokens',
             notes: 'Response will not include full tokens for security reasons.',
             validate: {

--- a/src/routes/auth/tokens.test.js
+++ b/src/routes/auth/tokens.test.js
@@ -23,7 +23,7 @@ test.before(async t => {
 test('Tokens can be created, fetched and deleted', async t => {
     const auth = {
         strategy: 'session',
-        credentials: { session: t.context.session },
+        credentials: { session: t.context.session, scope: ['auth'] },
         artifacts: { id: t.context.user.id }
     };
 

--- a/src/routes/auth/tokens.test.js
+++ b/src/routes/auth/tokens.test.js
@@ -23,7 +23,7 @@ test.before(async t => {
 test('Tokens can be created, fetched and deleted', async t => {
     const auth = {
         strategy: 'session',
-        credentials: { session: t.context.session, scope: ['auth'] },
+        credentials: { session: t.context.session, access: { scope: ['auth'] } },
         artifacts: { id: t.context.user.id }
     };
 

--- a/src/routes/auth/tokens.test.js
+++ b/src/routes/auth/tokens.test.js
@@ -23,7 +23,7 @@ test.before(async t => {
 test('Tokens can be created, fetched and deleted', async t => {
     const auth = {
         strategy: 'session',
-        credentials: { session: t.context.session, access: { scope: ['auth'] } },
+        credentials: { session: t.context.session, scope: ['auth:read', 'auth:write'] },
         artifacts: { id: t.context.user.id }
     };
 

--- a/src/routes/charts/index.js
+++ b/src/routes/charts/index.js
@@ -11,6 +11,7 @@ module.exports = {
     name: 'routes/charts',
     version: '1.0.0',
     register(server, options) {
+        server.app.scopes.add('chart');
         server.route({
             method: 'GET',
             path: '/',

--- a/src/routes/charts/index.js
+++ b/src/routes/charts/index.js
@@ -11,7 +11,8 @@ module.exports = {
     name: 'routes/charts',
     version: '1.0.0',
     register(server, options) {
-        server.app.scopes.add('chart');
+        server.app.scopes.add('chart:read');
+        server.app.scopes.add('chart:write');
         server.route({
             method: 'GET',
             path: '/',
@@ -19,7 +20,7 @@ module.exports = {
                 tags: ['api'],
                 description: 'List charts',
                 auth: {
-                    scope: ['chart', 'all']
+                    access: { scope: ['chart:read', 'all'] }
                 },
                 notes: `Search and filter a list of your charts.
                         The returned chart objects, do not include the full chart metadata.
@@ -63,6 +64,9 @@ module.exports = {
             options: {
                 tags: ['api'],
                 description: 'Create new chart',
+                auth: {
+                    access: { scope: ['chart:write', 'all'] }
+                },
                 validate: {
                     payload: Joi.object({
                         title: Joi.string()

--- a/src/routes/charts/index.js
+++ b/src/routes/charts/index.js
@@ -20,7 +20,7 @@ module.exports = {
                 tags: ['api'],
                 description: 'List charts',
                 auth: {
-                    access: { scope: ['chart:read', 'all'] }
+                    access: { scope: ['chart:read'] }
                 },
                 notes: `Search and filter a list of your charts.
                         The returned chart objects, do not include the full chart metadata.
@@ -65,7 +65,7 @@ module.exports = {
                 tags: ['api'],
                 description: 'Create new chart',
                 auth: {
-                    access: { scope: ['chart:write', 'all'] }
+                    access: { scope: ['chart:write'] }
                 },
                 validate: {
                     payload: Joi.object({

--- a/src/routes/charts/index.js
+++ b/src/routes/charts/index.js
@@ -17,6 +17,9 @@ module.exports = {
             options: {
                 tags: ['api'],
                 description: 'List charts',
+                auth: {
+                    scope: ['chart', 'all']
+                },
                 notes: `Search and filter a list of your charts.
                         The returned chart objects, do not include the full chart metadata.
                         To get the full metadata use [/v3/charts/{id}](ref:getchartsid).`,

--- a/src/routes/charts/{id}/assets.js
+++ b/src/routes/charts/{id}/assets.js
@@ -14,7 +14,7 @@ module.exports = (server, options) => {
             tags: ['api'],
             description: 'Fetch chart asset',
             auth: {
-                scope: ['chart', 'all']
+                access: { scope: ['chart:read', 'all'] }
             },
             notes: `Request an asset associated with a chart.`,
             plugins: {
@@ -46,7 +46,7 @@ module.exports = (server, options) => {
             notes: `Upload data for a chart, which is usually a CSV.
                         An example looks like this: \`/v3/charts/{id}/assets/{id}.csv.\``,
             auth: {
-                scope: ['chart', 'all']
+                access: { scope: ['chart:write', 'all'] }
             },
             plugins: {
                 'hapi-swagger': {

--- a/src/routes/charts/{id}/assets.js
+++ b/src/routes/charts/{id}/assets.js
@@ -13,6 +13,9 @@ module.exports = (server, options) => {
         options: {
             tags: ['api'],
             description: 'Fetch chart asset',
+            auth: {
+                scope: ['chart', 'all']
+            },
             notes: `Request an asset associated with a chart.`,
             plugins: {
                 'hapi-swagger': {
@@ -42,6 +45,9 @@ module.exports = (server, options) => {
             description: 'Upload chart data',
             notes: `Upload data for a chart, which is usually a CSV.
                         An example looks like this: \`/v3/charts/{id}/assets/{id}.csv.\``,
+            auth: {
+                scope: ['chart', 'all']
+            },
             plugins: {
                 'hapi-swagger': {
                     consumes: ['text/csv', 'application/json']

--- a/src/routes/charts/{id}/assets.js
+++ b/src/routes/charts/{id}/assets.js
@@ -14,7 +14,7 @@ module.exports = (server, options) => {
             tags: ['api'],
             description: 'Fetch chart asset',
             auth: {
-                access: { scope: ['chart:read', 'all'] }
+                access: { scope: ['chart:read'] }
             },
             notes: `Request an asset associated with a chart.`,
             plugins: {
@@ -46,7 +46,7 @@ module.exports = (server, options) => {
             notes: `Upload data for a chart, which is usually a CSV.
                         An example looks like this: \`/v3/charts/{id}/assets/{id}.csv.\``,
             auth: {
-                access: { scope: ['chart:write', 'all'] }
+                access: { scope: ['chart:write'] }
             },
             plugins: {
                 'hapi-swagger': {

--- a/src/routes/charts/{id}/data.js
+++ b/src/routes/charts/{id}/data.js
@@ -12,7 +12,7 @@ module.exports = (server, options) => {
             description: 'Fetch chart data',
             notes: `Request the data of a chart, which is usually a CSV.`,
             auth: {
-                access: { scope: ['chart:read', 'all'] }
+                access: { scope: ['chart:read'] }
             },
             plugins: {
                 'hapi-swagger': {
@@ -39,7 +39,7 @@ module.exports = (server, options) => {
             description: 'Upload chart data',
             notes: `Upload data for a chart or map.`,
             auth: {
-                access: { scope: ['chart:write', 'all'] }
+                access: { scope: ['chart:write'] }
             },
             plugins: {
                 'hapi-swagger': {

--- a/src/routes/charts/{id}/data.js
+++ b/src/routes/charts/{id}/data.js
@@ -12,7 +12,7 @@ module.exports = (server, options) => {
             description: 'Fetch chart data',
             notes: `Request the data of a chart, which is usually a CSV.`,
             auth: {
-                scope: ['chart', 'all']
+                access: { scope: ['chart:read', 'all'] }
             },
             plugins: {
                 'hapi-swagger': {
@@ -39,7 +39,7 @@ module.exports = (server, options) => {
             description: 'Upload chart data',
             notes: `Upload data for a chart or map.`,
             auth: {
-                scope: ['chart', 'all']
+                access: { scope: ['chart:write', 'all'] }
             },
             plugins: {
                 'hapi-swagger': {

--- a/src/routes/charts/{id}/data.js
+++ b/src/routes/charts/{id}/data.js
@@ -11,6 +11,9 @@ module.exports = (server, options) => {
             tags: ['api'],
             description: 'Fetch chart data',
             notes: `Request the data of a chart, which is usually a CSV.`,
+            auth: {
+                scope: ['chart', 'all']
+            },
             plugins: {
                 'hapi-swagger': {
                     produces: ['text/csv', 'application/json']
@@ -35,6 +38,9 @@ module.exports = (server, options) => {
             tags: ['api'],
             description: 'Upload chart data',
             notes: `Upload data for a chart or map.`,
+            auth: {
+                scope: ['chart', 'all']
+            },
             plugins: {
                 'hapi-swagger': {
                     consumes: ['text/csv', 'application/json']

--- a/src/routes/charts/{id}/embed-codes.js
+++ b/src/routes/charts/{id}/embed-codes.js
@@ -23,7 +23,7 @@ module.exports = async (server, options) => {
             notes: `Request the responsive and static embed code of a chart.`,
             auth: {
                 access: {
-                    scope: ['chart:read', 'all']
+                    scope: ['chart:read']
                 }
             },
             plugins: {

--- a/src/routes/charts/{id}/embed-codes.js
+++ b/src/routes/charts/{id}/embed-codes.js
@@ -21,6 +21,11 @@ module.exports = async (server, options) => {
             tags: ['api'],
             description: 'Get embed codes for a chart',
             notes: `Request the responsive and static embed code of a chart.`,
+            auth: {
+                access: {
+                    scope: ['chart:read', 'all']
+                }
+            },
             plugins: {
                 'hapi-swagger': {
                     produces: ['application/json']

--- a/src/routes/charts/{id}/export.js
+++ b/src/routes/charts/{id}/export.js
@@ -9,6 +9,11 @@ module.exports = (server, options) => {
         method: 'POST',
         path: '/export/{format}',
         options: {
+            auth: {
+                access: {
+                    scope: ['chart:read', 'all']
+                }
+            },
             validate: {
                 params: Joi.object({
                     id: Joi.string()
@@ -52,6 +57,11 @@ module.exports = (server, options) => {
             description: 'Export chart',
             notes: `Export your chart as image or document for use in print or presentations.
                         Not all formats might be available to you, based on your account.`,
+            auth: {
+                access: {
+                    scope: ['chart:read', 'all']
+                }
+            },
             plugins: {
                 'hapi-swagger': {
                     produces: ['image/png', 'image/svg+xml', 'application/pdf']

--- a/src/routes/charts/{id}/export.js
+++ b/src/routes/charts/{id}/export.js
@@ -11,7 +11,7 @@ module.exports = (server, options) => {
         options: {
             auth: {
                 access: {
-                    scope: ['chart:read', 'all']
+                    scope: ['chart:read']
                 }
             },
             validate: {
@@ -59,7 +59,7 @@ module.exports = (server, options) => {
                         Not all formats might be available to you, based on your account.`,
             auth: {
                 access: {
-                    scope: ['chart:read', 'all']
+                    scope: ['chart:read']
                 }
             },
             plugins: {

--- a/src/routes/charts/{id}/index.js
+++ b/src/routes/charts/{id}/index.js
@@ -21,7 +21,7 @@ module.exports = {
                 tags: ['api'],
                 description: 'Fetch chart metadata',
                 auth: {
-                    scope: ['chart', 'all']
+                    access: { scope: ['chart:read', 'all'] }
                 },
                 validate: {
                     params: Joi.object({
@@ -50,7 +50,7 @@ module.exports = {
                         If this endpoint should be used in an application (CMS), it is recommended to
                         ask the user for confirmation.`,
                 auth: {
-                    scope: ['chart', 'all']
+                    access: { scope: ['chart', 'chart:write', 'all'] }
                 },
                 validate: {
                     params: Joi.object({
@@ -105,7 +105,7 @@ module.exports = {
                 tags: ['api'],
                 description: 'Update chart. Allows for partial metadata updates (JSON merge patch)',
                 auth: {
-                    scope: ['chart', 'all']
+                    access: { scope: ['chart', 'all'] }
                 },
                 validate: {
                     params: Joi.object({
@@ -129,7 +129,7 @@ module.exports = {
                 tags: ['api'],
                 description: 'Update chart. Replaces the entire metadata object.',
                 auth: {
-                    scope: ['chart', 'all']
+                    access: { scope: ['chart', 'all'] }
                 },
                 validate: {
                     params: Joi.object({

--- a/src/routes/charts/{id}/index.js
+++ b/src/routes/charts/{id}/index.js
@@ -21,7 +21,7 @@ module.exports = {
                 tags: ['api'],
                 description: 'Fetch chart metadata',
                 auth: {
-                    access: { scope: ['chart:read'] }
+                    access: { scope: ['chart:read', 'chart:write'] }
                 },
                 validate: {
                     params: Joi.object({

--- a/src/routes/charts/{id}/index.js
+++ b/src/routes/charts/{id}/index.js
@@ -21,7 +21,7 @@ module.exports = {
                 tags: ['api'],
                 description: 'Fetch chart metadata',
                 auth: {
-                    access: { scope: ['chart:read', 'all'] }
+                    access: { scope: ['chart:read'] }
                 },
                 validate: {
                     params: Joi.object({
@@ -50,7 +50,7 @@ module.exports = {
                         If this endpoint should be used in an application (CMS), it is recommended to
                         ask the user for confirmation.`,
                 auth: {
-                    access: { scope: ['chart', 'chart:write', 'all'] }
+                    access: { scope: ['chart', 'chart:write'] }
                 },
                 validate: {
                     params: Joi.object({
@@ -105,7 +105,7 @@ module.exports = {
                 tags: ['api'],
                 description: 'Update chart. Allows for partial metadata updates (JSON merge patch)',
                 auth: {
-                    access: { scope: ['chart', 'all'] }
+                    access: { scope: ['chart'] }
                 },
                 validate: {
                     params: Joi.object({
@@ -129,7 +129,7 @@ module.exports = {
                 tags: ['api'],
                 description: 'Update chart. Replaces the entire metadata object.',
                 auth: {
-                    access: { scope: ['chart', 'all'] }
+                    access: { scope: ['chart'] }
                 },
                 validate: {
                     params: Joi.object({

--- a/src/routes/charts/{id}/index.js
+++ b/src/routes/charts/{id}/index.js
@@ -20,6 +20,9 @@ module.exports = {
             options: {
                 tags: ['api'],
                 description: 'Fetch chart metadata',
+                auth: {
+                    scope: ['chart', 'all']
+                },
                 validate: {
                     params: Joi.object({
                         id: Joi.string()
@@ -46,6 +49,9 @@ module.exports = {
                 notes: `This action is permanent. Be careful when using this endpoint.
                         If this endpoint should be used in an application (CMS), it is recommended to
                         ask the user for confirmation.`,
+                auth: {
+                    scope: ['chart', 'all']
+                },
                 validate: {
                     params: Joi.object({
                         id: Joi.string()
@@ -98,6 +104,9 @@ module.exports = {
             options: {
                 tags: ['api'],
                 description: 'Update chart. Allows for partial metadata updates (JSON merge patch)',
+                auth: {
+                    scope: ['chart', 'all']
+                },
                 validate: {
                     params: Joi.object({
                         id: Joi.string()
@@ -119,6 +128,9 @@ module.exports = {
             options: {
                 tags: ['api'],
                 description: 'Update chart. Replaces the entire metadata object.',
+                auth: {
+                    scope: ['chart', 'all']
+                },
                 validate: {
                     params: Joi.object({
                         id: Joi.string()

--- a/src/routes/charts/{id}/index.js
+++ b/src/routes/charts/{id}/index.js
@@ -105,7 +105,7 @@ module.exports = {
                 tags: ['api'],
                 description: 'Update chart. Allows for partial metadata updates (JSON merge patch)',
                 auth: {
-                    access: { scope: ['chart'] }
+                    access: { scope: ['chart:write'] }
                 },
                 validate: {
                     params: Joi.object({
@@ -129,7 +129,7 @@ module.exports = {
                 tags: ['api'],
                 description: 'Update chart. Replaces the entire metadata object.',
                 auth: {
-                    access: { scope: ['chart'] }
+                    access: { scope: ['chart:write'] }
                 },
                 validate: {
                     params: Joi.object({

--- a/src/routes/charts/{id}/publish.js
+++ b/src/routes/charts/{id}/publish.js
@@ -16,6 +16,9 @@ module.exports = (server, options) => {
         options: {
             tags: ['api'],
             description: 'Publish a chart',
+            auth: {
+                scope: ['chart', 'all']
+            },
             validate: {
                 params: Joi.object({
                     id: Joi.string()
@@ -39,6 +42,9 @@ module.exports = (server, options) => {
         method: 'GET',
         path: '/publish/data',
         options: {
+            auth: {
+                scope: ['chart', 'all']
+            },
             validate: {
                 params: Joi.object({
                     id: Joi.string()
@@ -57,6 +63,9 @@ module.exports = (server, options) => {
         options: {
             tags: ['api'],
             description: 'Check the publish status of a chart',
+            auth: {
+                scope: ['chart', 'all']
+            },
             validate: {
                 params: Joi.object({
                     id: Joi.string()

--- a/src/routes/charts/{id}/publish.js
+++ b/src/routes/charts/{id}/publish.js
@@ -17,7 +17,7 @@ module.exports = (server, options) => {
             tags: ['api'],
             description: 'Publish a chart',
             auth: {
-                access: { scope: ['chart:write', 'all'] }
+                access: { scope: ['chart:write'] }
             },
             validate: {
                 params: Joi.object({
@@ -43,7 +43,7 @@ module.exports = (server, options) => {
         path: '/publish/data',
         options: {
             auth: {
-                access: { scope: ['chart:write', 'all'] }
+                access: { scope: ['chart:write'] }
             },
             validate: {
                 params: Joi.object({
@@ -64,7 +64,7 @@ module.exports = (server, options) => {
             tags: ['api'],
             description: 'Check the publish status of a chart',
             auth: {
-                access: { scope: ['chart:read', 'all'] }
+                access: { scope: ['chart:read'] }
             },
             validate: {
                 params: Joi.object({

--- a/src/routes/charts/{id}/publish.js
+++ b/src/routes/charts/{id}/publish.js
@@ -17,7 +17,7 @@ module.exports = (server, options) => {
             tags: ['api'],
             description: 'Publish a chart',
             auth: {
-                scope: ['chart', 'all']
+                access: { scope: ['chart:write', 'all'] }
             },
             validate: {
                 params: Joi.object({
@@ -43,7 +43,7 @@ module.exports = (server, options) => {
         path: '/publish/data',
         options: {
             auth: {
-                scope: ['chart', 'all']
+                access: { scope: ['chart:write', 'all'] }
             },
             validate: {
                 params: Joi.object({
@@ -64,7 +64,7 @@ module.exports = (server, options) => {
             tags: ['api'],
             description: 'Check the publish status of a chart',
             auth: {
-                scope: ['chart', 'all']
+                access: { scope: ['chart:read', 'all'] }
             },
             validate: {
                 params: Joi.object({

--- a/src/routes/folders.js
+++ b/src/routes/folders.js
@@ -8,6 +8,7 @@ const routes = [
     {
         method: 'GET',
         path: '/',
+        scope: 'folder:read',
         description: 'List folders',
         notes: 'Get a list of folders and their associated charts.',
         response: listResponse,
@@ -91,6 +92,7 @@ const routes = [
         method: 'POST',
         path: '/',
         description: 'Create a folder',
+        scope: 'folder:write',
         payload: Joi.object({
             organizationId: Joi.string()
                 .optional()
@@ -159,7 +161,8 @@ module.exports = {
     name: 'routes/folders',
     version: '1.0.0',
     register: (server, options) => {
-        server.app.scopes.add('folder');
+        server.app.scopes.add('folder:read');
+        server.app.scopes.add('folder:write');
         routes.forEach(route => {
             server.route({
                 method: route.method,
@@ -168,7 +171,7 @@ module.exports = {
                     tags: ['api'],
                     description: route.description,
                     auth: {
-                        access: { scope: ['folder', 'all'] }
+                        access: { scope: [route.scope] }
                     },
                     validate: {
                         params: route.params,

--- a/src/routes/folders.js
+++ b/src/routes/folders.js
@@ -168,7 +168,7 @@ module.exports = {
                     tags: ['api'],
                     description: route.description,
                     auth: {
-                        scope: ['folder', 'all']
+                        access: { scope: ['folder', 'all'] }
                     },
                     validate: {
                         params: route.params,

--- a/src/routes/folders.js
+++ b/src/routes/folders.js
@@ -159,6 +159,7 @@ module.exports = {
     name: 'routes/folders',
     version: '1.0.0',
     register: (server, options) => {
+        server.app.scopes.add('folder');
         routes.forEach(route => {
             server.route({
                 method: route.method,

--- a/src/routes/folders.js
+++ b/src/routes/folders.js
@@ -166,6 +166,9 @@ module.exports = {
                 options: {
                     tags: ['api'],
                     description: route.description,
+                    auth: {
+                        scope: ['folder', 'all']
+                    },
                     validate: {
                         params: route.params,
                         query: route.query,

--- a/src/routes/me/data.js
+++ b/src/routes/me/data.js
@@ -9,7 +9,7 @@ module.exports = async (server, options) => {
         options: {
             description: 'Update your account data',
             auth: {
-                scope: ['user', 'all']
+                access: { scope: ['user', 'all'] }
             },
             validate: {
                 payload: Joi.object()

--- a/src/routes/me/data.js
+++ b/src/routes/me/data.js
@@ -9,7 +9,7 @@ module.exports = async (server, options) => {
         options: {
             description: 'Update your account data',
             auth: {
-                access: { scope: ['user', 'all'] }
+                access: { scope: ['user:write'] }
             },
             validate: {
                 payload: Joi.object()

--- a/src/routes/me/data.js
+++ b/src/routes/me/data.js
@@ -8,6 +8,9 @@ module.exports = async (server, options) => {
         path: '/data',
         options: {
             description: 'Update your account data',
+            auth: {
+                scope: ['user', 'all']
+            },
             validate: {
                 payload: Joi.object()
             },

--- a/src/routes/me/index.js
+++ b/src/routes/me/index.js
@@ -23,7 +23,7 @@ module.exports = {
             options: {
                 tags: ['api'],
                 auth: {
-                    scope: ['user', 'all']
+                    access: { scope: ['user', 'all'] }
                 },
                 description: 'Fetch your account information',
                 response: meResponse
@@ -38,7 +38,7 @@ module.exports = {
             options: {
                 tags: ['api'],
                 auth: {
-                    scope: ['user', 'all']
+                    access: { scope: ['user', 'all'] }
                 },
                 description: 'Update your account information',
                 validate: {
@@ -81,7 +81,7 @@ module.exports = {
             options: {
                 tags: ['api'],
                 auth: {
-                    scope: ['user', 'all']
+                    access: { scope: ['user', 'all'] }
                 },
                 description: 'Delete your account',
                 notes: `**Be careful!** This is a destructive action.

--- a/src/routes/me/index.js
+++ b/src/routes/me/index.js
@@ -22,6 +22,9 @@ module.exports = {
             path: '/',
             options: {
                 tags: ['api'],
+                auth: {
+                    scope: ['user', 'all']
+                },
                 description: 'Fetch your account information',
                 response: meResponse
             },
@@ -34,6 +37,9 @@ module.exports = {
             path: '/',
             options: {
                 tags: ['api'],
+                auth: {
+                    scope: ['user', 'all']
+                },
                 description: 'Update your account information',
                 validate: {
                     payload: Joi.object({
@@ -74,6 +80,9 @@ module.exports = {
             path: '/',
             options: {
                 tags: ['api'],
+                auth: {
+                    scope: ['user', 'all']
+                },
                 description: 'Delete your account',
                 notes: `**Be careful!** This is a destructive action.
                         By deleting your account you will loose access to all of your charts.

--- a/src/routes/me/index.js
+++ b/src/routes/me/index.js
@@ -23,7 +23,7 @@ module.exports = {
             options: {
                 tags: ['api'],
                 auth: {
-                    access: { scope: ['user', 'all'] }
+                    access: { scope: ['user:read'] }
                 },
                 description: 'Fetch your account information',
                 response: meResponse
@@ -38,7 +38,7 @@ module.exports = {
             options: {
                 tags: ['api'],
                 auth: {
-                    access: { scope: ['user', 'all'] }
+                    access: { scope: ['user:write'] }
                 },
                 description: 'Update your account information',
                 validate: {
@@ -81,7 +81,7 @@ module.exports = {
             options: {
                 tags: ['api'],
                 auth: {
-                    access: { scope: ['user', 'all'] }
+                    access: { scope: ['user:write'] }
                 },
                 description: 'Delete your account',
                 notes: `**Be careful!** This is a destructive action.

--- a/src/routes/me/settings.js
+++ b/src/routes/me/settings.js
@@ -8,6 +8,9 @@ module.exports = async (server, options) => {
         options: {
             tags: ['api'],
             description: 'Update your account settings',
+            auth: {
+                scope: ['user', 'all']
+            },
             notes: 'Use this endpoint to change your active team.',
             validate: {
                 payload: {

--- a/src/routes/me/settings.js
+++ b/src/routes/me/settings.js
@@ -9,7 +9,7 @@ module.exports = async (server, options) => {
             tags: ['api'],
             description: 'Update your account settings',
             auth: {
-                scope: ['user', 'all']
+                access: { scope: ['user', 'all'] }
             },
             notes: 'Use this endpoint to change your active team.',
             validate: {

--- a/src/routes/me/settings.js
+++ b/src/routes/me/settings.js
@@ -9,7 +9,7 @@ module.exports = async (server, options) => {
             tags: ['api'],
             description: 'Update your account settings',
             auth: {
-                access: { scope: ['user', 'all'] }
+                access: { scope: ['user:write'] }
             },
             notes: 'Use this endpoint to change your active team.',
             validate: {

--- a/src/routes/products.js
+++ b/src/routes/products.js
@@ -7,6 +7,12 @@ module.exports = {
         server.route({
             method: 'GET',
             path: '/',
+            options: {
+                auth: {
+                    strategy: 'admin',
+                    scope: ['product', 'all']
+                }
+            },
             handler: async function getAllProducts(request, h) {
                 request.server.methods.isAdmin(request, { throwError: true });
 

--- a/src/routes/products.js
+++ b/src/routes/products.js
@@ -4,14 +4,14 @@ module.exports = {
     name: 'routes/products',
     version: '1.0.0',
     register: (server, options) => {
-        server.app.adminScopes.add('product');
+        server.app.adminScopes.add('product:read');
         server.route({
             method: 'GET',
             path: '/',
             options: {
                 auth: {
                     strategy: 'admin',
-                    access: { scope: ['product', 'all'] }
+                    access: { scope: ['product:read'] }
                 }
             },
             handler: async function getAllProducts(request, h) {

--- a/src/routes/products.js
+++ b/src/routes/products.js
@@ -4,6 +4,7 @@ module.exports = {
     name: 'routes/products',
     version: '1.0.0',
     register: (server, options) => {
+        server.app.adminScopes.add('product');
         server.route({
             method: 'GET',
             path: '/',

--- a/src/routes/products.js
+++ b/src/routes/products.js
@@ -11,7 +11,7 @@ module.exports = {
             options: {
                 auth: {
                     strategy: 'admin',
-                    scope: ['product', 'all']
+                    access: { scope: ['product', 'all'] }
                 }
             },
             handler: async function getAllProducts(request, h) {

--- a/src/routes/teams/index.js
+++ b/src/routes/teams/index.js
@@ -9,7 +9,8 @@ module.exports = {
     name: 'routes/teams',
     version: '1.0.0',
     register: (server, options) => {
-        server.app.scopes.add('team');
+        server.app.scopes.add('team:read');
+        server.app.scopes.add('team:write');
         // GET /v3/teams
         server.route({
             method: 'GET',
@@ -19,7 +20,7 @@ module.exports = {
                 description: 'List teams',
                 notes: 'Get a list of teams you are part of.',
                 auth: {
-                    access: { scope: ['team', 'all'] }
+                    access: { scope: ['team:read'] }
                 },
                 validate: {
                     query: Joi.object({
@@ -58,7 +59,7 @@ module.exports = {
                 tags: ['api'],
                 description: 'Create a team',
                 auth: {
-                    access: { scope: ['team', 'all'] }
+                    access: { scope: ['team:write'] }
                 },
                 validate: {
                     payload: Joi.object({

--- a/src/routes/teams/index.js
+++ b/src/routes/teams/index.js
@@ -9,6 +9,7 @@ module.exports = {
     name: 'routes/teams',
     version: '1.0.0',
     register: (server, options) => {
+        server.app.scopes.add('team');
         // GET /v3/teams
         server.route({
             method: 'GET',

--- a/src/routes/teams/index.js
+++ b/src/routes/teams/index.js
@@ -17,6 +17,9 @@ module.exports = {
                 tags: ['api'],
                 description: 'List teams',
                 notes: 'Get a list of teams you are part of.',
+                auth: {
+                    scope: ['team', 'all']
+                },
                 validate: {
                     query: Joi.object({
                         search: Joi.string().description(
@@ -53,6 +56,9 @@ module.exports = {
             options: {
                 tags: ['api'],
                 description: 'Create a team',
+                auth: {
+                    scope: ['team', 'all']
+                },
                 validate: {
                     payload: Joi.object({
                         id: Joi.string()

--- a/src/routes/teams/index.js
+++ b/src/routes/teams/index.js
@@ -19,7 +19,7 @@ module.exports = {
                 description: 'List teams',
                 notes: 'Get a list of teams you are part of.',
                 auth: {
-                    scope: ['team', 'all']
+                    access: { scope: ['team', 'all'] }
                 },
                 validate: {
                     query: Joi.object({
@@ -58,7 +58,7 @@ module.exports = {
                 tags: ['api'],
                 description: 'Create a team',
                 auth: {
-                    scope: ['team', 'all']
+                    access: { scope: ['team', 'all'] }
                 },
                 validate: {
                     payload: Joi.object({

--- a/src/routes/teams/index.test.js
+++ b/src/routes/teams/index.test.js
@@ -162,7 +162,7 @@ test('admins can create teams', async t => {
     const { user: admin } = await t.context.getUser('admin');
     const auth = {
         strategy: 'simple',
-        credentials: { session: '', scope: ['team'] },
+        credentials: { session: '', access: { scope: ['team'] } },
         artifacts: admin
     };
 

--- a/src/routes/teams/index.test.js
+++ b/src/routes/teams/index.test.js
@@ -162,7 +162,7 @@ test('admins can create teams', async t => {
     const { user: admin } = await t.context.getUser('admin');
     const auth = {
         strategy: 'simple',
-        credentials: { session: '', access: { scope: ['team'] } },
+        credentials: { session: '', scope: ['team:write'] },
         artifacts: admin
     };
 

--- a/src/routes/teams/index.test.js
+++ b/src/routes/teams/index.test.js
@@ -160,7 +160,11 @@ test('[/v3/teams] check that owners and admins can see settings, but members can
 test('admins can create teams', async t => {
     const teamId = `team-admin-${nanoid(5)}`;
     const { user: admin } = await t.context.getUser('admin');
-    const auth = { strategy: 'simple', credentials: { session: '' }, artifacts: admin };
+    const auth = {
+        strategy: 'simple',
+        credentials: { session: '', scope: ['team'] },
+        artifacts: admin
+    };
 
     await t.context.addToCleanup('team', teamId);
 

--- a/src/routes/teams/{id}/index.js
+++ b/src/routes/teams/{id}/index.js
@@ -26,6 +26,9 @@ module.exports = {
             options: {
                 tags: ['api'],
                 description: 'Fetch team information',
+                auth: {
+                    scope: ['team', 'all']
+                },
                 validate: {
                     params: Joi.object({
                         id: Joi.string()
@@ -46,6 +49,9 @@ module.exports = {
                 tags: ['api'],
                 description: 'Delete a team',
                 notes: `**Be careful!** This is a destructive action that can only be performed by team owners.`,
+                auth: {
+                    scope: ['team', 'all']
+                },
                 validate: {
                     params: Joi.object({
                         id: Joi.string()
@@ -65,6 +71,9 @@ module.exports = {
             options: {
                 tags: ['api'],
                 description: 'Update a team',
+                auth: {
+                    scope: ['team', 'all']
+                },
                 validate: {
                     params: Joi.object({
                         id: Joi.string()

--- a/src/routes/teams/{id}/index.js
+++ b/src/routes/teams/{id}/index.js
@@ -27,7 +27,7 @@ module.exports = {
                 tags: ['api'],
                 description: 'Fetch team information',
                 auth: {
-                    access: { scope: ['team:read'] }
+                    access: { scope: ['team:read', 'team:write'] }
                 },
                 validate: {
                     params: Joi.object({

--- a/src/routes/teams/{id}/index.js
+++ b/src/routes/teams/{id}/index.js
@@ -27,7 +27,7 @@ module.exports = {
                 tags: ['api'],
                 description: 'Fetch team information',
                 auth: {
-                    access: { scope: ['team', 'all'] }
+                    access: { scope: ['team:read'] }
                 },
                 validate: {
                     params: Joi.object({
@@ -50,7 +50,7 @@ module.exports = {
                 description: 'Delete a team',
                 notes: `**Be careful!** This is a destructive action that can only be performed by team owners.`,
                 auth: {
-                    access: { scope: ['team', 'all'] }
+                    access: { scope: ['team:write'] }
                 },
                 validate: {
                     params: Joi.object({
@@ -72,7 +72,7 @@ module.exports = {
                 tags: ['api'],
                 description: 'Update a team',
                 auth: {
-                    access: { scope: ['team', 'all'] }
+                    access: { scope: ['team:write'] }
                 },
                 validate: {
                     params: Joi.object({

--- a/src/routes/teams/{id}/index.js
+++ b/src/routes/teams/{id}/index.js
@@ -27,7 +27,7 @@ module.exports = {
                 tags: ['api'],
                 description: 'Fetch team information',
                 auth: {
-                    scope: ['team', 'all']
+                    access: { scope: ['team', 'all'] }
                 },
                 validate: {
                     params: Joi.object({
@@ -50,7 +50,7 @@ module.exports = {
                 description: 'Delete a team',
                 notes: `**Be careful!** This is a destructive action that can only be performed by team owners.`,
                 auth: {
-                    scope: ['team', 'all']
+                    access: { scope: ['team', 'all'] }
                 },
                 validate: {
                     params: Joi.object({
@@ -72,7 +72,7 @@ module.exports = {
                 tags: ['api'],
                 description: 'Update a team',
                 auth: {
-                    scope: ['team', 'all']
+                    access: { scope: ['team', 'all'] }
                 },
                 validate: {
                     params: Joi.object({

--- a/src/routes/teams/{id}/index.test.js
+++ b/src/routes/teams/{id}/index.test.js
@@ -158,7 +158,7 @@ test('admin can edit team', async t => {
         url: `/v3/teams/${t.context.data.team.id}`,
         auth: {
             strategy: 'simple',
-            credentials: { session: '', access: { scope: ['team'] } },
+            credentials: { session: '', access: { scope: ['team:write'] } },
             artifacts: user
         },
         payload: {
@@ -179,7 +179,7 @@ test('member can not edit team', async t => {
         url: `/v3/teams/${t.context.data.team.id}`,
         auth: {
             strategy: 'simple',
-            credentials: { session: '', access: { scope: ['team'] } },
+            credentials: { session: '', access: { scope: ['team:write'] } },
             artifacts: user
         },
         payload: {

--- a/src/routes/teams/{id}/index.test.js
+++ b/src/routes/teams/{id}/index.test.js
@@ -158,7 +158,7 @@ test('admin can edit team', async t => {
         url: `/v3/teams/${t.context.data.team.id}`,
         auth: {
             strategy: 'simple',
-            credentials: { session: '', scope: ['team'] },
+            credentials: { session: '', access: { scope: ['team'] } },
             artifacts: user
         },
         payload: {
@@ -179,7 +179,7 @@ test('member can not edit team', async t => {
         url: `/v3/teams/${t.context.data.team.id}`,
         auth: {
             strategy: 'simple',
-            credentials: { session: '', scope: ['team'] },
+            credentials: { session: '', access: { scope: ['team'] } },
             artifacts: user
         },
         payload: {

--- a/src/routes/teams/{id}/index.test.js
+++ b/src/routes/teams/{id}/index.test.js
@@ -156,7 +156,11 @@ test('admin can edit team', async t => {
     const team = await t.context.server.inject({
         method: 'PATCH',
         url: `/v3/teams/${t.context.data.team.id}`,
-        auth: { strategy: 'simple', credentials: { session: '' }, artifacts: user },
+        auth: {
+            strategy: 'simple',
+            credentials: { session: '', scope: ['team'] },
+            artifacts: user
+        },
         payload: {
             name: 'Testy'
         }

--- a/src/routes/teams/{id}/index.test.js
+++ b/src/routes/teams/{id}/index.test.js
@@ -177,7 +177,11 @@ test('member can not edit team', async t => {
     const team = await t.context.server.inject({
         method: 'PATCH',
         url: `/v3/teams/${t.context.data.team.id}`,
-        auth: { strategy: 'simple', credentials: { session: '' }, artifacts: user },
+        auth: {
+            strategy: 'simple',
+            credentials: { session: '', scope: ['team'] },
+            artifacts: user
+        },
         payload: {
             name: 'Testy'
         }

--- a/src/routes/teams/{id}/index.test.js
+++ b/src/routes/teams/{id}/index.test.js
@@ -158,7 +158,7 @@ test('admin can edit team', async t => {
         url: `/v3/teams/${t.context.data.team.id}`,
         auth: {
             strategy: 'simple',
-            credentials: { session: '', access: { scope: ['team:write'] } },
+            credentials: { session: '', scope: ['team:write'] },
             artifacts: user
         },
         payload: {
@@ -179,7 +179,7 @@ test('member can not edit team', async t => {
         url: `/v3/teams/${t.context.data.team.id}`,
         auth: {
             strategy: 'simple',
-            credentials: { session: '', access: { scope: ['team:write'] } },
+            credentials: { session: '', scope: ['team:write'] },
             artifacts: user
         },
         payload: {

--- a/src/routes/teams/{id}/invites.js
+++ b/src/routes/teams/{id}/invites.js
@@ -26,6 +26,9 @@ module.exports = async (server, options) => {
         options: {
             tags: ['api'],
             description: 'Invite a person',
+            auth: {
+                scope: ['team', 'all']
+            },
             validate: {
                 params: {
                     id: Joi.string()
@@ -59,6 +62,9 @@ module.exports = async (server, options) => {
         options: {
             tags: ['api'],
             description: 'Accept a team invitation',
+            auth: {
+                scope: ['team', 'all']
+            },
             validate: {
                 params: {
                     id: Joi.string()

--- a/src/routes/teams/{id}/invites.js
+++ b/src/routes/teams/{id}/invites.js
@@ -27,7 +27,7 @@ module.exports = async (server, options) => {
             tags: ['api'],
             description: 'Invite a person',
             auth: {
-                scope: ['team', 'all']
+                access: { scope: ['team', 'all'] }
             },
             validate: {
                 params: {
@@ -63,7 +63,7 @@ module.exports = async (server, options) => {
             tags: ['api'],
             description: 'Accept a team invitation',
             auth: {
-                scope: ['team', 'all']
+                access: { scope: ['team', 'all'] }
             },
             validate: {
                 params: {

--- a/src/routes/teams/{id}/invites.js
+++ b/src/routes/teams/{id}/invites.js
@@ -27,7 +27,7 @@ module.exports = async (server, options) => {
             tags: ['api'],
             description: 'Invite a person',
             auth: {
-                access: { scope: ['team', 'all'] }
+                access: { scope: ['team:write'] }
             },
             validate: {
                 params: {
@@ -63,7 +63,7 @@ module.exports = async (server, options) => {
             tags: ['api'],
             description: 'Accept a team invitation',
             auth: {
-                access: { scope: ['team', 'all'] }
+                access: { scope: ['team:write'] }
             },
             validate: {
                 params: {

--- a/src/routes/teams/{id}/members.js
+++ b/src/routes/teams/{id}/members.js
@@ -32,7 +32,7 @@ module.exports = async (server, options) => {
             notes:
                 'Get a list of team members and some additional information like their team role.',
             auth: {
-                scope: ['team', 'all']
+                access: { scope: ['team', 'all'] }
             },
             validate: {
                 params: Joi.object({
@@ -75,7 +75,7 @@ module.exports = async (server, options) => {
         options: {
             description: 'Add a team member',
             auth: {
-                scope: ['team', 'all']
+                access: { scope: ['team', 'all'] }
             },
             validate: {
                 params: Joi.object({
@@ -108,7 +108,7 @@ module.exports = async (server, options) => {
             tags: ['api'],
             description: 'Remove a team member',
             auth: {
-                scope: ['team', 'all']
+                access: { scope: ['team', 'all'] }
             },
             validate: {
                 params: Joi.object({
@@ -133,7 +133,7 @@ module.exports = async (server, options) => {
             tags: ['api'],
             description: 'Set team member status',
             auth: {
-                scope: ['team', 'all']
+                access: { scope: ['team', 'all'] }
             },
             validate: {
                 params: Joi.object({

--- a/src/routes/teams/{id}/members.js
+++ b/src/routes/teams/{id}/members.js
@@ -108,7 +108,7 @@ module.exports = async (server, options) => {
             tags: ['api'],
             description: 'Remove a team member',
             auth: {
-                access: { scope: ['team'] }
+                access: { scope: ['team:write'] }
             },
             validate: {
                 params: Joi.object({
@@ -133,7 +133,7 @@ module.exports = async (server, options) => {
             tags: ['api'],
             description: 'Set team member status',
             auth: {
-                access: { scope: ['team'] }
+                access: { scope: ['team:write'] }
             },
             validate: {
                 params: Joi.object({

--- a/src/routes/teams/{id}/members.js
+++ b/src/routes/teams/{id}/members.js
@@ -32,7 +32,7 @@ module.exports = async (server, options) => {
             notes:
                 'Get a list of team members and some additional information like their team role.',
             auth: {
-                access: { scope: ['team', 'all'] }
+                access: { scope: ['+team:read', '+user:read'] }
             },
             validate: {
                 params: Joi.object({
@@ -75,7 +75,7 @@ module.exports = async (server, options) => {
         options: {
             description: 'Add a team member',
             auth: {
-                access: { scope: ['team', 'all'] }
+                access: { scope: ['team:write'] }
             },
             validate: {
                 params: Joi.object({
@@ -108,7 +108,7 @@ module.exports = async (server, options) => {
             tags: ['api'],
             description: 'Remove a team member',
             auth: {
-                access: { scope: ['team', 'all'] }
+                access: { scope: ['team'] }
             },
             validate: {
                 params: Joi.object({
@@ -133,7 +133,7 @@ module.exports = async (server, options) => {
             tags: ['api'],
             description: 'Set team member status',
             auth: {
-                access: { scope: ['team', 'all'] }
+                access: { scope: ['team'] }
             },
             validate: {
                 params: Joi.object({

--- a/src/routes/teams/{id}/members.js
+++ b/src/routes/teams/{id}/members.js
@@ -31,6 +31,9 @@ module.exports = async (server, options) => {
             description: 'List team members',
             notes:
                 'Get a list of team members and some additional information like their team role.',
+            auth: {
+                scope: ['team', 'all']
+            },
             validate: {
                 params: Joi.object({
                     id: Joi.string()
@@ -70,6 +73,10 @@ module.exports = async (server, options) => {
         method: 'POST',
         path: `/members`,
         options: {
+            description: 'Add a team member',
+            auth: {
+                scope: ['team', 'all']
+            },
             validate: {
                 params: Joi.object({
                     id: Joi.string()
@@ -80,7 +87,7 @@ module.exports = async (server, options) => {
                     userId: Joi.number()
                         .integer()
                         .required()
-                        .description('ID of the team member you want to change the status of.'),
+                        .description('ID of the team member you want add.'),
                     role: Joi.string()
                         .valid(...ROLES)
                         .required()
@@ -100,6 +107,9 @@ module.exports = async (server, options) => {
         options: {
             tags: ['api'],
             description: 'Remove a team member',
+            auth: {
+                scope: ['team', 'all']
+            },
             validate: {
                 params: Joi.object({
                     id: Joi.string()
@@ -122,6 +132,9 @@ module.exports = async (server, options) => {
         options: {
             tags: ['api'],
             description: 'Set team member status',
+            auth: {
+                scope: ['team', 'all']
+            },
             validate: {
                 params: Joi.object({
                     id: Joi.string()

--- a/src/routes/teams/{id}/members.test.js
+++ b/src/routes/teams/{id}/members.test.js
@@ -237,7 +237,6 @@ test('admins can remove members, themselves but not owners', async t => {
             artifacts: admin
         }
     });
-
     /* check if api call was successful */
     t.is(res.statusCode, 204);
 

--- a/src/routes/teams/{id}/products.js
+++ b/src/routes/teams/{id}/products.js
@@ -9,7 +9,7 @@ module.exports = async (server, options) => {
         path: '/products',
         options: {
             auth: {
-                access: { scope: ['team', 'all'] }
+                access: { scope: ['+team:read', '+product:read'] }
             },
             validate: {
                 params: {
@@ -56,7 +56,7 @@ module.exports = async (server, options) => {
         path: '/products',
         options: {
             auth: {
-                access: { scope: ['team', 'all'] }
+                access: { scope: ['team'] }
             },
             validate: {
                 params: {
@@ -107,7 +107,7 @@ module.exports = async (server, options) => {
         path: '/products/{productId}',
         options: {
             auth: {
-                access: { scope: ['team', 'all'] }
+                access: { scope: ['team'] }
             },
             validate: {
                 params: {
@@ -157,7 +157,7 @@ module.exports = async (server, options) => {
         path: '/products/{productId}',
         options: {
             auth: {
-                access: { scope: ['team', 'all'] }
+                access: { scope: ['team'] }
             },
             validate: {
                 params: {

--- a/src/routes/teams/{id}/products.js
+++ b/src/routes/teams/{id}/products.js
@@ -9,7 +9,7 @@ module.exports = async (server, options) => {
         path: '/products',
         options: {
             auth: {
-                scope: ['team', 'all']
+                access: { scope: ['team', 'all'] }
             },
             validate: {
                 params: {
@@ -56,7 +56,7 @@ module.exports = async (server, options) => {
         path: '/products',
         options: {
             auth: {
-                scope: ['team', 'all']
+                access: { scope: ['team', 'all'] }
             },
             validate: {
                 params: {
@@ -107,7 +107,7 @@ module.exports = async (server, options) => {
         path: '/products/{productId}',
         options: {
             auth: {
-                scope: ['team', 'all']
+                access: { scope: ['team', 'all'] }
             },
             validate: {
                 params: {
@@ -157,7 +157,7 @@ module.exports = async (server, options) => {
         path: '/products/{productId}',
         options: {
             auth: {
-                scope: ['team', 'all']
+                access: { scope: ['team', 'all'] }
             },
             validate: {
                 params: {

--- a/src/routes/teams/{id}/products.js
+++ b/src/routes/teams/{id}/products.js
@@ -8,6 +8,9 @@ module.exports = async (server, options) => {
         method: 'GET',
         path: '/products',
         options: {
+            auth: {
+                scope: ['team', 'all']
+            },
             validate: {
                 params: {
                     id: Joi.string()
@@ -52,6 +55,9 @@ module.exports = async (server, options) => {
         method: 'POST',
         path: '/products',
         options: {
+            auth: {
+                scope: ['team', 'all']
+            },
             validate: {
                 params: {
                     id: Joi.string()
@@ -100,6 +106,9 @@ module.exports = async (server, options) => {
         method: 'PUT',
         path: '/products/{productId}',
         options: {
+            auth: {
+                scope: ['team', 'all']
+            },
             validate: {
                 params: {
                     id: Joi.string()
@@ -147,6 +156,9 @@ module.exports = async (server, options) => {
         method: 'DELETE',
         path: '/products/{productId}',
         options: {
+            auth: {
+                scope: ['team', 'all']
+            },
             validate: {
                 params: {
                     id: Joi.string()

--- a/src/routes/themes.js
+++ b/src/routes/themes.js
@@ -7,7 +7,7 @@ module.exports = {
     name: 'routes/themes',
     version: '1.0.0',
     register: (server, options) => {
-        server.app.adminScopes.add('theme:read');
+        server.app.scopes.add('theme:read');
         server.route({
             method: 'GET',
             path: '/{id}',

--- a/src/routes/themes.js
+++ b/src/routes/themes.js
@@ -14,7 +14,7 @@ module.exports = {
             options: {
                 auth: {
                     mode: 'try',
-                    scope: ['theme', 'all']
+                    access: { scope: ['theme', 'all'] }
                 },
                 validate: {
                     params: Joi.object({

--- a/src/routes/themes.js
+++ b/src/routes/themes.js
@@ -7,6 +7,7 @@ module.exports = {
     name: 'routes/themes',
     version: '1.0.0',
     register: (server, options) => {
+        server.app.adminScopes.add('theme');
         server.route({
             method: 'GET',
             path: '/{id}',

--- a/src/routes/themes.js
+++ b/src/routes/themes.js
@@ -11,7 +11,10 @@ module.exports = {
             method: 'GET',
             path: '/{id}',
             options: {
-                auth: { mode: 'try' },
+                auth: {
+                    mode: 'try',
+                    scope: ['theme', 'all']
+                },
                 validate: {
                     params: Joi.object({
                         id: Joi.string().required()

--- a/src/routes/themes.js
+++ b/src/routes/themes.js
@@ -7,14 +7,14 @@ module.exports = {
     name: 'routes/themes',
     version: '1.0.0',
     register: (server, options) => {
-        server.app.adminScopes.add('theme');
+        server.app.adminScopes.add('theme:read');
         server.route({
             method: 'GET',
             path: '/{id}',
             options: {
                 auth: {
                     mode: 'try',
-                    access: { scope: ['theme', 'all'] }
+                    access: { scope: ['theme:read'] }
                 },
                 validate: {
                     params: Joi.object({

--- a/src/routes/users/index.js
+++ b/src/routes/users/index.js
@@ -23,6 +23,9 @@ module.exports = {
             path: '/',
             options: {
                 tags: ['api'],
+                auth: {
+                    scope: ['user', 'all']
+                },
                 description: 'List users',
                 validate: {
                     query: Joi.object({

--- a/src/routes/users/index.js
+++ b/src/routes/users/index.js
@@ -17,6 +17,7 @@ module.exports = {
     name: 'routes/users',
     version: '1.0.0',
     register: (server, options) => {
+        server.app.scopes.add('user');
         // GET /v3/users
         server.route({
             method: 'GET',

--- a/src/routes/users/index.js
+++ b/src/routes/users/index.js
@@ -25,7 +25,7 @@ module.exports = {
             options: {
                 tags: ['api'],
                 auth: {
-                    scope: ['user', 'all']
+                    access: { scope: ['user', 'all'] }
                 },
                 description: 'List users',
                 validate: {

--- a/src/routes/users/index.js
+++ b/src/routes/users/index.js
@@ -17,7 +17,8 @@ module.exports = {
     name: 'routes/users',
     version: '1.0.0',
     register: (server, options) => {
-        server.app.scopes.add('user');
+        server.app.scopes.add('user:read');
+        server.app.scopes.add('user:write');
         // GET /v3/users
         server.route({
             method: 'GET',
@@ -25,7 +26,7 @@ module.exports = {
             options: {
                 tags: ['api'],
                 auth: {
-                    access: { scope: ['user', 'all'] }
+                    access: { scope: ['user:read'] }
                 },
                 description: 'List users',
                 validate: {

--- a/src/routes/users/{id}/data.js
+++ b/src/routes/users/{id}/data.js
@@ -11,6 +11,9 @@ module.exports = async (server, options) => {
         path: '/data',
         options: {
             description: 'Update user data',
+            auth: {
+                scope: ['user', 'all']
+            },
             validate: {
                 params: {
                     id: Joi.number()

--- a/src/routes/users/{id}/data.js
+++ b/src/routes/users/{id}/data.js
@@ -12,7 +12,7 @@ module.exports = async (server, options) => {
         options: {
             description: 'Update user data',
             auth: {
-                access: { scope: ['user', 'all'] }
+                access: { scope: ['user:write'] }
             },
             validate: {
                 params: {

--- a/src/routes/users/{id}/data.js
+++ b/src/routes/users/{id}/data.js
@@ -12,7 +12,7 @@ module.exports = async (server, options) => {
         options: {
             description: 'Update user data',
             auth: {
-                scope: ['user', 'all']
+                access: { scope: ['user', 'all'] }
             },
             validate: {
                 params: {

--- a/src/routes/users/{id}/index.js
+++ b/src/routes/users/{id}/index.js
@@ -21,7 +21,7 @@ module.exports = {
                 tags: ['api'],
                 description: 'Fetch user information',
                 auth: {
-                    scope: ['user', 'all']
+                    access: { scope: ['user', 'all'] }
                 },
                 validate: {
                     params: Joi.object({
@@ -43,7 +43,7 @@ module.exports = {
                 tags: ['api'],
                 description: 'Update user information',
                 auth: {
-                    scope: ['user', 'all']
+                    access: { scope: ['user', 'all'] }
                 },
                 validate: {
                     params: Joi.object({
@@ -90,7 +90,7 @@ module.exports = {
             options: {
                 tags: ['api'],
                 auth: {
-                    scope: ['user', 'all']
+                    access: { scope: ['user', 'all'] }
                 },
                 description: 'Delete user',
                 validate: {

--- a/src/routes/users/{id}/index.js
+++ b/src/routes/users/{id}/index.js
@@ -21,7 +21,7 @@ module.exports = {
                 tags: ['api'],
                 description: 'Fetch user information',
                 auth: {
-                    access: { scope: ['user', 'all'] }
+                    access: { scope: ['user:read'] }
                 },
                 validate: {
                     params: Joi.object({
@@ -43,7 +43,7 @@ module.exports = {
                 tags: ['api'],
                 description: 'Update user information',
                 auth: {
-                    access: { scope: ['user', 'all'] }
+                    access: { scope: ['user:write'] }
                 },
                 validate: {
                     params: Joi.object({
@@ -90,7 +90,7 @@ module.exports = {
             options: {
                 tags: ['api'],
                 auth: {
-                    access: { scope: ['user', 'all'] }
+                    access: { scope: ['user'] }
                 },
                 description: 'Delete user',
                 validate: {

--- a/src/routes/users/{id}/index.js
+++ b/src/routes/users/{id}/index.js
@@ -90,7 +90,7 @@ module.exports = {
             options: {
                 tags: ['api'],
                 auth: {
-                    access: { scope: ['user'] }
+                    access: { scope: ['user:write'] }
                 },
                 description: 'Delete user',
                 validate: {
@@ -276,7 +276,6 @@ async function deleteUser(request, h) {
     const { auth, server, payload } = request;
     const { id } = request.params;
     const { isAdmin, userIsDeleted, comparePassword } = server.methods;
-
     await userIsDeleted(id);
 
     const isSameUser = id === auth.artifacts.id;

--- a/src/routes/users/{id}/index.js
+++ b/src/routes/users/{id}/index.js
@@ -20,6 +20,9 @@ module.exports = {
             options: {
                 tags: ['api'],
                 description: 'Fetch user information',
+                auth: {
+                    scope: ['user', 'all']
+                },
                 validate: {
                     params: Joi.object({
                         id: Joi.number()
@@ -39,6 +42,9 @@ module.exports = {
             options: {
                 tags: ['api'],
                 description: 'Update user information',
+                auth: {
+                    scope: ['user', 'all']
+                },
                 validate: {
                     params: Joi.object({
                         id: Joi.number()
@@ -83,6 +89,9 @@ module.exports = {
             path: '/',
             options: {
                 tags: ['api'],
+                auth: {
+                    scope: ['user', 'all']
+                },
                 description: 'Delete user',
                 validate: {
                     params: Joi.object({

--- a/src/routes/users/{id}/settings.js
+++ b/src/routes/users/{id}/settings.js
@@ -14,7 +14,7 @@ module.exports = async (server, options) => {
             tags: ['api'],
             description: 'Update user settings',
             auth: {
-                scope: ['user', 'all']
+                access: { scope: ['user', 'all'] }
             },
             validate: {
                 params: {

--- a/src/routes/users/{id}/settings.js
+++ b/src/routes/users/{id}/settings.js
@@ -14,7 +14,7 @@ module.exports = async (server, options) => {
             tags: ['api'],
             description: 'Update user settings',
             auth: {
-                access: { scope: ['user', 'all'] }
+                access: { scope: ['user:write'] }
             },
             validate: {
                 params: {

--- a/src/routes/users/{id}/settings.js
+++ b/src/routes/users/{id}/settings.js
@@ -13,6 +13,9 @@ module.exports = async (server, options) => {
         options: {
             tags: ['api'],
             description: 'Update user settings',
+            auth: {
+                scope: ['user', 'all']
+            },
             validate: {
                 params: {
                     id: Joi.number()

--- a/src/routes/users/{id}/setup.js
+++ b/src/routes/users/{id}/setup.js
@@ -9,7 +9,7 @@ module.exports = (server, options) => {
         path: '/setup',
         options: {
             auth: {
-                scope: ['user', 'all']
+                access: { scope: ['user', 'all'] }
             },
             validate: {
                 params: Joi.object({

--- a/src/routes/users/{id}/setup.js
+++ b/src/routes/users/{id}/setup.js
@@ -8,6 +8,9 @@ module.exports = (server, options) => {
         method: 'POST',
         path: '/setup',
         options: {
+            auth: {
+                scope: ['user', 'all']
+            },
             validate: {
                 params: Joi.object({
                     id: Joi.number()

--- a/src/routes/users/{id}/setup.js
+++ b/src/routes/users/{id}/setup.js
@@ -9,7 +9,7 @@ module.exports = (server, options) => {
         path: '/setup',
         options: {
             auth: {
-                access: { scope: ['user', 'all'] }
+                access: { scope: ['user:write'] }
             },
             validate: {
                 params: Joi.object({

--- a/src/routes/visualizations.js
+++ b/src/routes/visualizations.js
@@ -19,7 +19,7 @@ async function register(server, options) {
         options: {
             auth: {
                 mode: 'try',
-                scope: ['visualization', 'all']
+                access: { scope: ['visualization', 'all'] }
             }
         },
         handler: getVisualization

--- a/src/routes/visualizations.js
+++ b/src/routes/visualizations.js
@@ -12,14 +12,14 @@ module.exports = {
 };
 
 async function register(server, options) {
-    server.app.adminScopes.add('visualization');
+    server.app.adminScopes.add('visualization:read');
     server.route({
         method: 'GET',
         path: '/{id}',
         options: {
             auth: {
                 mode: 'try',
-                access: { scope: ['visualization'] }
+                access: { scope: ['visualization:read'] }
             }
         },
         handler: getVisualization
@@ -39,7 +39,8 @@ async function register(server, options) {
         path: '/{id}/styles.css',
         options: {
             auth: {
-                mode: 'try'
+                mode: 'try',
+                access: { scope: ['visualization:read'] }
             },
             validate: {
                 query: Joi.object({
@@ -75,7 +76,8 @@ async function register(server, options) {
         path: '/{id}/script.js',
         options: {
             auth: {
-                mode: 'try'
+                mode: 'try',
+                access: { scope: ['visualization:read'] }
             }
         },
         handler: getVisualizationScript

--- a/src/routes/visualizations.js
+++ b/src/routes/visualizations.js
@@ -12,7 +12,7 @@ module.exports = {
 };
 
 async function register(server, options) {
-    server.app.adminScopes.add('visualization:read');
+    server.app.scopes.add('visualization:read');
     server.route({
         method: 'GET',
         path: '/{id}',

--- a/src/routes/visualizations.js
+++ b/src/routes/visualizations.js
@@ -12,6 +12,7 @@ module.exports = {
 };
 
 async function register(server, options) {
+    server.app.adminScopes.add('visualization');
     server.route({
         method: 'GET',
         path: '/{id}',

--- a/src/routes/visualizations.js
+++ b/src/routes/visualizations.js
@@ -17,7 +17,8 @@ async function register(server, options) {
         path: '/{id}',
         options: {
             auth: {
-                mode: 'try'
+                mode: 'try',
+                scope: ['visualization', 'all']
             }
         },
         handler: getVisualization

--- a/src/routes/visualizations.js
+++ b/src/routes/visualizations.js
@@ -19,7 +19,7 @@ async function register(server, options) {
         options: {
             auth: {
                 mode: 'try',
-                access: { scope: ['visualization', 'all'] }
+                access: { scope: ['visualization'] }
             }
         },
         handler: getVisualization

--- a/src/server.js
+++ b/src/server.js
@@ -165,6 +165,8 @@ async function configure(options = { usePlugins: true, useOpenAPI: true }) {
     server.app.events = new ApiEventEmitter({ logger: server.logger });
     server.app.visualizations = new Map();
     server.app.exportFormats = new Set();
+    server.app.scopes = new Set();
+    server.app.adminScopes = new Set();
 
     server.method('getModel', name => ORM.db.models[name]);
     server.method('config', key => (key ? config[key] : config));
@@ -207,11 +209,9 @@ async function configure(options = { usePlugins: true, useOpenAPI: true }) {
     const routeOptions = {
         routes: { prefix: '/v3' }
     };
-
     if (options.useOpenAPI) {
         await server.register(OpenAPI, routeOptions);
     }
-
     if (options.usePlugins) {
         await server.register([require('./plugin-loader')], routeOptions);
     }

--- a/src/server.js
+++ b/src/server.js
@@ -192,6 +192,11 @@ async function configure(options = { usePlugins: true, useOpenAPI: true }) {
             server.app.visualizations.set(vis.id, vis);
         });
     });
+    server.method('getScopes', (admin = false) => {
+        return admin
+            ? [...server.app.scopes, ...server.app.adminScopes]
+            : Array.from(server.app.scopes);
+    });
 
     const { validateThemeData } = schemas.initialize({
         getSchema: config.api.schemaBaseUrl

--- a/test/helpers/setup.js
+++ b/test/helpers/setup.js
@@ -15,8 +15,7 @@ const PASSWORD_HASH = '$2a$05$6B584QgS5SOXi1m.jM/H9eV.2tCaqNc5atHnWfYlFe5riXVW9z
 function getCredentials() {
     return {
         email: `test-${nanoid(5)}@ava.de`,
-        password: 'test-password',
-        scopes: ['all']
+        password: 'test-password'
     };
 }
 
@@ -61,7 +60,13 @@ async function setup(options) {
             addToCleanup('user', user.id)
         ]);
 
-        return { user, session, token };
+        session.scope = ['all'];
+
+        return {
+            user,
+            session,
+            token
+        };
     }
 
     async function getTeamWithUser(role = 'owner') {

--- a/test/helpers/setup.js
+++ b/test/helpers/setup.js
@@ -15,7 +15,8 @@ const PASSWORD_HASH = '$2a$05$6B584QgS5SOXi1m.jM/H9eV.2tCaqNc5atHnWfYlFe5riXVW9z
 function getCredentials() {
     return {
         email: `test-${nanoid(5)}@ava.de`,
-        password: 'test-password'
+        password: 'test-password',
+        scopes: ['all']
     };
 }
 
@@ -48,7 +49,10 @@ async function setup(options) {
         const { token } = await models.AccessToken.newToken({
             user_id: user.id,
             type: 'api-token',
-            comment: 'API TEST'
+            data: {
+                comment: 'API TEST',
+                scopes: ['all']
+            }
         });
 
         await Promise.all([

--- a/test/helpers/setup.js
+++ b/test/helpers/setup.js
@@ -27,6 +27,24 @@ async function setup(options) {
         await appendFile(cleanupFile, `${name};${id}\n`, { encoding: 'utf-8' });
     }
 
+    const allScopes = [
+        'user:read',
+        'user:write',
+        'auth:read',
+        'auth:write',
+        'chart:read',
+        'chart:write',
+        'team:read',
+        'team:write',
+        'folder:read',
+        'folder:write',
+        'plugin:read',
+        'plugin:write',
+        'theme:read',
+        'product:read',
+        'visualization'
+    ];
+
     async function getUser(role = 'editor', pwd = PASSWORD_HASH) {
         const credentials = getCredentials();
         const user = await models.User.create({
@@ -50,7 +68,7 @@ async function setup(options) {
             type: 'api-token',
             data: {
                 comment: 'API TEST',
-                scopes: ['all']
+                scopes: allScopes
             }
         });
 
@@ -60,7 +78,7 @@ async function setup(options) {
             addToCleanup('user', user.id)
         ]);
 
-        session.scope = ['all'];
+        session.scope = allScopes;
 
         return {
             user,
@@ -100,6 +118,8 @@ async function setup(options) {
         const data = `team;${team.id}\n`;
 
         await appendFile(cleanupFile, data, { encoding: 'utf-8' });
+
+        session.scope = allScopes;
 
         return { team, user, session, addUser };
     }

--- a/test/helpers/setup.js
+++ b/test/helpers/setup.js
@@ -42,7 +42,7 @@ async function setup(options) {
         'plugin:write',
         'theme:read',
         'product:read',
-        'visualization'
+        'visualization:read'
     ];
 
     async function getUser(role = 'editor', pwd = PASSWORD_HASH) {


### PR DESCRIPTION
quick implementation of api token scopes (not all scopes have been defined for the routes)

The *user-facing* scopes are:
- `auth`
- `user`
- `team`
- `folder`
- `chart`

Plus there are also *internal* scopes which don't make sense for users. Which means they should only be allowed to set by admins (and not be offered as part of the create api-token UI)
- `product`
- `plugin`
- `theme`
- `visualization`

There are likely more scopes when it comes to plugins. We could either use the plugin name as scope here or allow plugins to define custom scopes. Using plugin names would have the advantage of making it easier for us to validate them.