### PR TITLE
Pass through access token to asset endpoint

### DIFF
--- a/src/routes/charts/{id}/data.js
+++ b/src/routes/charts/{id}/data.js
@@ -71,7 +71,7 @@ async function getChartData(request, h) {
 
     const res = await request.server.inject({
         method: 'GET',
-        url: `/v3/charts/${params.id}/assets/${filename}`,
+        url: `/v3/charts/${params.id}/assets/${filename}${query.ott ? `?ott=${query.ott}` : ''}`,
         auth: request.auth
     });
 


### PR DESCRIPTION
The one-time access token needs to be passed from the `/charts/{id}/publish/data` endpoint to the `/charts/{id}/assets` endpoint to read chart assets.