### PR TITLE
Pass one-time access token to CHART_PUBLISH_DATA event

### DIFF
--- a/src/routes/charts/{id}/publish.js
+++ b/src/routes/charts/{id}/publish.js
@@ -293,16 +293,6 @@ async function publishData(request, h) {
         auth
     });
 
-    if (query.ott) {
-        await ChartAccessToken.destroy({
-            where: {
-                chart_id: params.id,
-                token: query.ott
-            },
-            limit: 1
-        });
-    }
-
     const additionalData = await getAdditionalMetadata(chart, { server });
 
     const data = { data: res.result, chart: prepareChart(chart, additionalData) };
@@ -324,8 +314,19 @@ async function publishData(request, h) {
     await server.app.events.emit(server.app.event.CHART_PUBLISH_DATA, {
         chart,
         auth,
+        ott: query.ott,
         data
     });
+
+    if (query.ott) {
+        await ChartAccessToken.destroy({
+            where: {
+                chart_id: params.id,
+                token: query.ott
+            },
+            limit: 1
+        });
+    }
 
     const chartBlocks = await server.app.events.emit(
         server.app.event.CHART_BLOCKS,


### PR DESCRIPTION
We need to pass the one-time token to the `CHART_PUBLISH_DATA` event so visualizations that make requests to the chart asset endpoints (like [d3-maps](https://github.com/datawrapper/plugin-d3-maps/pull/28) or [locator maps](https://github.com/datawrapper/plugin-locator-maps/pull/61)) can use it to authenticate themselves.