### PR TITLE
feat: cache visualization styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -503,6 +503,51 @@
         }
       }
     },
+    "@hapi/catbox-memory": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.0.tgz",
+      "integrity": "sha512-ByuxVJPHNaXwLzbBv4GdTr6ccpe1nG+AfYt+8ftDWEJY7EWBWzD+Klhy5oPTDGzU26pNUh1e7fcYI1ILZRxAXQ==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "9.0.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.4.tgz",
+          "integrity": "sha512-EwaJS7RjoXUZ2cXXKZZxZqieGtc7RbvQhUy8FwDoMQtxWVi14tFjeFCYPZAM1mBCpOpiBpyaZbb9NeHc7eGKgw=="
+        }
+      }
+    },
+    "@hapi/catbox-redis": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-redis/-/catbox-redis-5.0.5.tgz",
+      "integrity": "sha512-S1O9yfnuGQYYB6EVXYcmYlXnyN6GJ9jICUvm0nCp5DA3dw0PHbdPN9zmtJzltOnZkhYF5Lzcn+12MA4Ot5N7bw==",
+      "requires": {
+        "@hapi/hoek": "8.x.x",
+        "@hapi/joi": "16.x.x",
+        "ioredis": "4.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "8.5.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+          "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
+        },
+        "@hapi/joi": {
+          "version": "16.1.8",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
+          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        }
+      }
+    },
     "@hapi/content": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
@@ -2840,6 +2885,11 @@
           "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
         }
       }
+    },
+    "cluster-key-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+      "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw=="
     },
     "coa": {
       "version": "2.0.2",
@@ -5303,6 +5353,32 @@
         }
       }
     },
+    "ioredis": {
+      "version": "4.17.3",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.17.3.tgz",
+      "integrity": "sha512-iRvq4BOYzNFkDnSyhx7cmJNOi1x/HWYe+A4VXHBu4qpwJaGT1Mp+D2bVGJntH9K/Z/GeOM/Nprb8gB3bmitz1Q==",
+      "requires": {
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.1.1",
+        "denque": "^1.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.flatten": "^4.4.0",
+        "redis-commands": "1.5.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "irregular-plurals": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.2.0.tgz",
@@ -6242,10 +6318,20 @@
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+    },
     "lodash.escaperegexp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
@@ -8617,6 +8703,24 @@
         "picomatch": "^2.0.7"
       }
     },
+    "redis-commands": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.5.0.tgz",
+      "integrity": "sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg=="
+    },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
+    },
+    "redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+      "requires": {
+        "redis-errors": "^1.0.0"
+      }
+    },
     "regenerator-runtime": {
       "version": "0.13.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
@@ -9286,6 +9390,11 @@
           "dev": true
         }
       }
+    },
+    "standard-as-callback": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.0.1.tgz",
+      "integrity": "sha512-NQOxSeB8gOI5WjSaxjBgog2QFw55FV8TkS6Y07BiB3VJ8xNTvUYm0wl0s8ObgQ5NhdpnNfigMIKjgPESzgr4tg=="
     },
     "standard-engine": {
       "version": "12.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -264,9 +264,9 @@
       "integrity": "sha512-ITYtqMxat9EoOPgGapHIFwSCr9aQBNgU38Rt+G2FgVgcBh2BFoe2sOUMSHyAY/iKmJMQa8RE1bNIRCUIp+stGA=="
     },
     "@datawrapper/schemas": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@datawrapper/schemas/-/schemas-1.5.1.tgz",
-      "integrity": "sha512-+re2QIGC13++KhhBL1cd6VyZz61wzh/yn+Kc8TMmal/3+gm9+lYqoZRDceRwWyaxAoP4EKLMzHhb0OerRhN7RQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@datawrapper/schemas/-/schemas-1.5.2.tgz",
+      "integrity": "sha512-46taw+WSeu80r5xEZwKH4rV8yYzLFjxDbS5mh8t8BgUJK++zMdYUSwloNNexdRW9JMVGXCtIpEidpHjM5r6cnQ==",
       "requires": {
         "@hapi/joi": "^16.1.7",
         "chalk": "^2.4.2"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "@datawrapper/chart-core": "^8.14.0",
         "@datawrapper/locales": "1.0.2",
         "@datawrapper/orm": "^3.16.0",
-        "@datawrapper/schemas": "^1.5.1",
+        "@datawrapper/schemas": "^1.5.2",
         "@datawrapper/shared": "0.25.3",
         "@hapi/boom": "9.1.0",
         "@hapi/catbox-memory": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
         "@datawrapper/schemas": "^1.5.1",
         "@datawrapper/shared": "0.25.3",
         "@hapi/boom": "9.1.0",
+        "@hapi/catbox-memory": "5.0.0",
+        "@hapi/catbox-redis": "5.0.5",
         "@hapi/hapi": "19.1.1",
         "@hapi/inert": "6.0.1",
         "@hapi/joi": "17.1.1",

--- a/src/routes/admin/plugins.js
+++ b/src/routes/admin/plugins.js
@@ -165,14 +165,25 @@ function register(server, options) {
         }
 
         /* bust visualization css cache */
-        if (server.app.visualizations.has(name)) {
-            const styleCache = server.app.caches.get('style-cache');
-            const themes = await Theme.findAll({ attributes: ['id'] });
+        const visualizations = [];
+        for (const [key, value] of server.app.visualizations) {
+            if (value.__plugin === name) visualizations.push(key);
+        }
 
+        const styleCache = server.app.caches.get('style-cache');
+        const themes = await Theme.findAll({ attributes: ['id'] });
+
+        const dropOperationPromises = [];
+        for (const vis of visualizations) {
             for (const { id } of themes) {
-                await styleCache.drop(`${id}__${name}`);
+                const promise = styleCache.drop(`${id}__${vis}`).catch(() => {
+                    server.logger().info(`Unable to drop cache key [${id}__${vis}]`);
+                });
+                dropOperationPromises.push(promise);
             }
         }
+
+        await Promise.all(dropOperationPromises);
 
         log.info('[Done] Update plugin', payload.name);
         return h.response().code(204);

--- a/src/routes/admin/plugins.js
+++ b/src/routes/admin/plugins.js
@@ -27,6 +27,8 @@ function register(server, options) {
     server.app.adminScopes.add('plugin:read');
     server.app.adminScopes.add('plugin:write');
 
+    const styleCache = server.cache({ segment: 'style_cache', shared: true });
+
     // GET /v3/admin/plugins
     server.route({
         method: 'GET',
@@ -170,7 +172,6 @@ function register(server, options) {
             if (value.__plugin === name) visualizations.push(key);
         }
 
-        const styleCache = server.app.caches.get('style-cache');
         const themes = await Theme.findAll({ attributes: ['id'] });
 
         const dropOperationPromises = [];

--- a/src/routes/admin/plugins.js
+++ b/src/routes/admin/plugins.js
@@ -27,7 +27,7 @@ function register(server, options) {
     server.app.adminScopes.add('plugin:read');
     server.app.adminScopes.add('plugin:write');
 
-    const styleCache = server.cache({ segment: 'style_cache', shared: true });
+    const styleCache = server.cache({ segment: 'vis-styles', shared: true });
 
     // GET /v3/admin/plugins
     server.route({

--- a/src/routes/charts/{id}/assets.js
+++ b/src/routes/charts/{id}/assets.js
@@ -190,9 +190,7 @@ async function writeChartAsset(request, h) {
 async function loadChart(request) {
     const { id } = request.params;
 
-    const chart = await Chart.findByPk(id, {
-        attributes: ['id', 'author_id', 'created_at', 'type', 'guest_session', 'organization_id']
-    });
+    const chart = await Chart.findByPk(id);
 
     if (!chart) {
         throw Boom.notFound();

--- a/src/routes/visualizations.js
+++ b/src/routes/visualizations.js
@@ -15,12 +15,10 @@ async function register(server, options) {
     server.app.scopes.add('visualization:read');
 
     const styleCache = server.cache({
-        cache: 'dw_cache',
         segment: 'style_cache',
-        expiresIn: 86_400_000 /* 1 day */
+        expiresIn: 86_400_000 /* 1 day */,
+        shared: true
     });
-
-    server.app.caches.set('style-cache', styleCache);
 
     server.route({
         method: 'GET',

--- a/src/routes/visualizations.js
+++ b/src/routes/visualizations.js
@@ -16,7 +16,7 @@ async function register(server, options) {
 
     const styleCache = server.cache({
         segment: 'vis-styles',
-        expiresIn: 86_400_000 /* 1 day */,
+        expiresIn: 86400000 * 365 /* 1 year */,
         shared: true
     });
 

--- a/src/routes/visualizations.js
+++ b/src/routes/visualizations.js
@@ -15,7 +15,7 @@ async function register(server, options) {
     server.app.scopes.add('visualization:read');
 
     const styleCache = server.cache({
-        segment: 'style_cache',
+        segment: 'vis-styles',
         expiresIn: 86_400_000 /* 1 day */,
         shared: true
     });

--- a/src/server.js
+++ b/src/server.js
@@ -79,13 +79,12 @@ const server = Hapi.server({
     /* https://hapijs.com/api#-serveroptionsdebug */
     debug: DW_DEV_MODE ? { request: ['implementation'] } : false,
     cache: {
-        name: 'dw_cache',
         provider: useRedis
             ? {
                   constructor: require('@hapi/catbox-redis'),
                   options: {
                       ...config.redis,
-                      partition: 'dw_api_cache'
+                      partition: 'api'
                   }
               }
             : {
@@ -197,7 +196,6 @@ async function configure(options = { usePlugins: true, useOpenAPI: true }) {
     server.app.exportFormats = new Set();
     server.app.scopes = new Set();
     server.app.adminScopes = new Set();
-    server.app.caches = new Map();
 
     server.method('getModel', name => ORM.db.models[name]);
     server.method('config', key => (key ? config[key] : config));

--- a/src/server.js
+++ b/src/server.js
@@ -78,22 +78,23 @@ const server = Hapi.server({
     router: { stripTrailingSlash: true },
     /* https://hapijs.com/api#-serveroptionsdebug */
     debug: DW_DEV_MODE ? { request: ['implementation'] } : false,
-    cache: [
-        {
-            name: 'dw_cache',
-            provider: useRedis
-                ? {
-                      constructor: require('@hapi/catbox-redis'),
-                      options: config.redis
+    cache: {
+        name: 'dw_cache',
+        provider: useRedis
+            ? {
+                  constructor: require('@hapi/catbox-redis'),
+                  options: {
+                      ...config.redis,
+                      partition: 'dw_api_cache'
                   }
-                : {
-                      constructor: require('@hapi/catbox-memory'),
-                      options: {
-                          maxByteSize: 52_480_000
-                      }
+              }
+            : {
+                  constructor: require('@hapi/catbox-memory'),
+                  options: {
+                      maxByteSize: 52_480_000
                   }
-        }
-    ],
+              }
+    },
     routes: {
         cors: {
             origin: config.api.cors,

--- a/src/server.js
+++ b/src/server.js
@@ -241,11 +241,7 @@ async function configure(options = { usePlugins: true, useOpenAPI: true }) {
 
     if (!hasRegisteredDataPlugins) {
         events.on(event.GET_CHART_ASSET, async function({ chart, filename }) {
-            const filePath = path.join(
-                localChartAssetRoot,
-                getDataPath(chart.dataValues.created_at),
-                filename
-            );
+            const filePath = path.join(localChartAssetRoot, getDataPath(chart.createdAt), filename);
             try {
                 await fs.access(filePath, fs.constants.R_OK);
             } catch (e) {
@@ -255,10 +251,7 @@ async function configure(options = { usePlugins: true, useOpenAPI: true }) {
         });
 
         events.on(event.PUT_CHART_ASSET, async function({ chart, data, filename }) {
-            const outPath = path.join(
-                localChartAssetRoot,
-                getDataPath(chart.dataValues.created_at)
-            );
+            const outPath = path.join(localChartAssetRoot, getDataPath(chart.createdAt));
 
             await fs.mkdir(outPath, { recursive: true });
             await fs.writeFile(path.join(outPath, filename), data);

--- a/src/server.js
+++ b/src/server.js
@@ -33,7 +33,7 @@ validateFrontend(config.frontend);
 
 let useRedis = false;
 try {
-    validateRedis(config.redis);
+    validateRedis(config.redis || {});
     useRedis = true;
 } catch (error) {
     console.warn('[Cache] Invalid Redis configuration, falling back to in memory cache.');


### PR DESCRIPTION
Compiling visualization CSS is a relatively CPU intensive operation and takes a little bit of time. It happens every time a chart is previewed and should therefore be done quickly.

By adding a cache the API has do do less work and an serve the styles in around ~16ms (when cached). Compare this to a compilation time of sometimes around 2s this is a huge improvement. Still, this is very dependent on themes and we don't want to wait long for new styles when a theme changes. That's why I added a relatively short ttl of 10 seconds. Chart previewing happens basically all the which means we still hit the cache a lot and reduce response times and CPU work.

Let me know what you think about this! If I should I increase the cache duration or if you have other cool ideas.

This change also means that every API instance has it's own visualization style cache. If we don't want this behaviour we need to look into something like Redis or Memcached. The implementations for Hapi are pretty much the same.

This PR is like a starting point for a discussion about what strategy we want to use.