### PR TITLE
use util function to check if chart has been deleted

### DIFF
--- a/src/routes/charts/{id}/assets.js
+++ b/src/routes/charts/{id}/assets.js
@@ -3,7 +3,7 @@ const mime = require('mime');
 const Joi = require('@hapi/joi');
 const Boom = require('@hapi/boom');
 const { noContentResponse } = require('../../../schemas/response');
-const { Chart, ChartAccessToken } = require('@datawrapper/orm/models');
+const { ChartAccessToken } = require('@datawrapper/orm/models');
 
 module.exports = (server, options) => {
     // GET /v3/charts/{id}/assets/{asset}
@@ -81,9 +81,9 @@ module.exports = (server, options) => {
 };
 
 async function getChartAsset(request, h) {
-    const { params, auth, query } = request;
-    const { events, event } = request.server.app;
-    const chart = await loadChart(request);
+    const { params, auth, query, server } = request;
+    const { events, event } = server.app;
+    const chart = await server.methods.loadChart(request.params.id);
 
     const filename = params.asset;
 
@@ -146,10 +146,10 @@ function getAssetWhitelist(id) {
 }
 
 async function writeChartAsset(request, h) {
-    const { params, auth } = request;
-    const { events, event } = request.server.app;
+    const { params, auth, server } = request;
+    const { events, event } = server.app;
     const user = auth.artifacts;
-    const chart = await loadChart(request);
+    const chart = await server.methods.loadChart(request.params.id);
 
     const isEditable = await chart.isEditableBy(request.auth.artifacts, auth.credentials.session);
 
@@ -185,16 +185,4 @@ async function writeChartAsset(request, h) {
         request.logger.error(error.message);
         return Boom.notFound();
     }
-}
-
-async function loadChart(request) {
-    const { id } = request.params;
-
-    const chart = await Chart.findByPk(id);
-
-    if (!chart) {
-        throw Boom.notFound();
-    }
-
-    return chart;
 }

--- a/src/routes/charts/{id}/embed-codes.js
+++ b/src/routes/charts/{id}/embed-codes.js
@@ -1,4 +1,3 @@
-const { Chart } = require('@datawrapper/orm/models');
 const { getUserData } = require('@datawrapper/orm/utils/userData');
 const Boom = require('@hapi/boom');
 const Joi = require('@hapi/joi');
@@ -51,9 +50,9 @@ module.exports = async (server, options) => {
             })
         },
         async handler(request, h) {
-            const { params, auth } = request;
+            const { params, auth, server } = request;
 
-            const chart = await Chart.findByPk(params.id);
+            const chart = await server.methods.loadChart(params.id);
 
             if (!chart) {
                 return Boom.notFound();

--- a/src/routes/charts/{id}/export.js
+++ b/src/routes/charts/{id}/export.js
@@ -1,7 +1,5 @@
 const Joi = require('@hapi/joi');
 const Boom = require('@hapi/boom');
-const { Chart } = require('@datawrapper/orm/models');
-const { Op } = require('@datawrapper/orm').db;
 
 module.exports = (server, options) => {
     // POST /v3/charts/{id}/export/{format}
@@ -109,14 +107,8 @@ async function exportChart(request, h) {
     const user = auth.artifacts;
 
     // authorize user
-    const chart = await Chart.findOne({
-        where: {
-            id: params.id,
-            deleted: { [Op.not]: true }
-        }
-    });
+    const chart = await server.methods.loadChart(params.id);
 
-    if (!chart) return Boom.notFound();
     const mayEdit = await user.mayEditChart(chart);
     if (!mayEdit) return Boom.notFound();
 

--- a/src/routes/charts/{id}/publish.js
+++ b/src/routes/charts/{id}/publish.js
@@ -91,7 +91,8 @@ async function publishChart(request, h) {
     const { events, event } = server.app;
     const { createChartWebsite } = server.methods;
     const user = auth.artifacts;
-    const chart = await Chart.findByPk(params.id, { attributes: { include: ['created_at'] } });
+    const chart = await server.methods.loadChart(params.id);
+
     if (!chart || !(await chart.isPublishableBy(user))) {
         throw Boom.unauthorized();
     }
@@ -223,9 +224,9 @@ async function publishChart(request, h) {
 }
 
 async function publishChartStatus(request, h) {
-    const { params, auth } = request;
+    const { params, auth, server } = request;
 
-    const chart = await Chart.findByPk(params.id);
+    const chart = await server.methods.loadChart(params.id);
     if (!(await chart.isEditableBy(auth.artifacts, auth.credentials.session))) {
         return Boom.unauthorized();
     }

--- a/src/server.js
+++ b/src/server.js
@@ -12,7 +12,7 @@ const { findConfigPath } = require('@datawrapper/shared/node/findConfig');
 
 const CodedError = require('@datawrapper/shared/CodedError');
 
-const { generateToken } = require('./utils');
+const { generateToken, loadChart } = require('./utils');
 const { addScope } = require('./utils/l10n');
 const { ApiEventEmitter, eventList } = require('./utils/events');
 
@@ -204,6 +204,7 @@ async function configure(options = { usePlugins: true, useOpenAPI: true }) {
             : undefined
     });
     server.method('validateThemeData', validateThemeData);
+    server.method('loadChart', loadChart);
 
     if (DW_DEV_MODE) {
         server.register([require('@hapi/inert'), require('@hapi/vision')]);

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,6 @@
 const generate = require('nanoid/generate');
 const { camelizeKeys } = require('humps');
+const Boom = require('@hapi/boom');
 const path = require('path');
 const jsesc = require('jsesc');
 const crypto = require('crypto');
@@ -90,5 +91,23 @@ utils.generateToken = (length = 25) => {
 };
 
 utils.noop = () => {};
+
+utils.loadChart = async function(id) {
+    const { Op } = require('@datawrapper/orm').db;
+    const { Chart } = require('@datawrapper/orm/models');
+
+    const chart = await Chart.findOne({
+        where: {
+            id,
+            deleted: { [Op.not]: true }
+        }
+    });
+
+    if (!chart) {
+        throw Boom.notFound();
+    }
+
+    return chart;
+};
 
 module.exports = utils;


### PR DESCRIPTION
we've been a little sloppy with checking for deleted charts. e.g. I think it's even possible to publish deleted charts. This PR changes this by re-using a common `loadChart` server method. Tests are running through, but it would be nice to have more tests checking that deleted charts will return 404 in those routes.