### PR TITLE
Set SameSite cookie depending on session type

### DIFF
--- a/src/auth/cookie-auth.js
+++ b/src/auth/cookie-auth.js
@@ -22,7 +22,6 @@ async function cookieValidation(request, session, h) {
         strategy: 'Session',
         logger: request.server.logger()
     });
-
     if (auth.isValid) {
         // add all scopes to cookie session
         auth.credentials.scope = request.server.methods.getScopes(auth.artifacts.isAdmin());
@@ -35,7 +34,7 @@ function cookieAuth(server, options) {
     const api = server.methods.config('api');
     const opts = { cookie: api.sessionID, ...options };
 
-    server.state(opts.cookie, getStateOpts(api.domain, 90, 'Strict'));
+    server.state(opts.cookie, getStateOpts(api.domain, 90));
 
     const scheme = {
         authenticate: async (request, h) => {

--- a/src/auth/cookie-auth.js
+++ b/src/auth/cookie-auth.js
@@ -69,7 +69,7 @@ function cookieAuth(server, options) {
                 h.state(
                     opts.cookie,
                     session,
-                    getStateOpts(api.domain, 90, sessionType === 'login-token' ? 'None' : 'Strict')
+                    getStateOpts(api.domain, 90, sessionType === 'token' ? 'None' : 'Strict')
                 );
                 return h.authenticated({ credentials, artifacts });
             }

--- a/src/auth/utils.js
+++ b/src/auth/utils.js
@@ -152,7 +152,7 @@ async function associateChartsWithUser(sessionId, userId) {
     );
 }
 
-async function createSession(id, userId, keepSession = true, type = 'login') {
+async function createSession(id, userId, keepSession = true, type = 'password') {
     return Session.create({
         id,
         user_id: userId,

--- a/src/auth/utils.js
+++ b/src/auth/utils.js
@@ -123,12 +123,12 @@ function createComparePassword(server) {
     };
 }
 
-function getStateOpts(domain, ttl) {
+function getStateOpts(domain, ttl, sameSite = 'Strict') {
     return {
         isSecure: process.env.NODE_ENV === 'production',
         strictHeader: false,
         domain: `.${domain}`,
-        isSameSite: false,
+        isSameSite: sameSite,
         path: '/',
         ttl: cookieTTL(ttl)
     };
@@ -152,7 +152,7 @@ async function associateChartsWithUser(sessionId, userId) {
     );
 }
 
-async function createSession(id, userId, keepSession = true) {
+async function createSession(id, userId, keepSession = true, type = 'login') {
     return Session.create({
         id,
         user_id: userId,
@@ -160,7 +160,8 @@ async function createSession(id, userId, keepSession = true) {
         data: {
             'dw-user-id': userId,
             persistent: keepSession,
-            last_action_time: Math.floor(Date.now() / 1000)
+            last_action_time: Math.floor(Date.now() / 1000),
+            type
         }
     });
 }

--- a/src/routes/auth/login.js
+++ b/src/routes/auth/login.js
@@ -79,13 +79,18 @@ module.exports = async (server, options) => {
             // create a new user session
             const { generateToken, config } = request.server.methods;
             const { api, frontend } = config();
-            const session = await createSession(generateToken(), token.user_id, false);
+            const session = await createSession(
+                generateToken(),
+                token.user_id,
+                false,
+                'login-token'
+            );
 
             return h
                 .response({
                     [api.sessionID]: session.id
                 })
-                .state(api.sessionID, session.id, getStateOpts(api.domain, 30))
+                .state(api.sessionID, session.id, getStateOpts(api.domain, 30, 'None'))
                 .redirect(
                     `${frontend.https ? 'https' : 'http'}://${frontend.domain}${
                         token.data.redirect_url

--- a/src/routes/auth/login.js
+++ b/src/routes/auth/login.js
@@ -79,12 +79,7 @@ module.exports = async (server, options) => {
             // create a new user session
             const { generateToken, config } = request.server.methods;
             const { api, frontend } = config();
-            const session = await createSession(
-                generateToken(),
-                token.user_id,
-                false,
-                'login-token'
-            );
+            const session = await createSession(generateToken(), token.user_id, false, 'token');
 
             return h
                 .response({

--- a/src/routes/auth/login.test.js
+++ b/src/routes/auth/login.test.js
@@ -88,6 +88,7 @@ test("Login set's correct cookie", async t => {
 
     t.true(cookie.HttpOnly);
     t.is(maxAge, 90);
+    t.is(cookie.SameSite, 'Strict');
 
     res = await t.context.server.inject({
         method: 'POST',


### PR DESCRIPTION
This PR adds two things:
- it saves the `type` of the user session to `session.data` on login, which can be either `password` (for password-based sessions) or `token` (for login-token authenticated sessions)
- when a session is of the type `token`, it sets `SameSite=None` for the cookie. Otherwise, it sets `SameSite=Strict`.