### PR TITLE
fix: use server logger for better error logs

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -346,7 +346,7 @@ async function configure(options = { usePlugins: true, useOpenAPI: true }) {
 }
 
 process.on('unhandledRejection', err => {
-    console.error(err);
+    server.logger().error(err);
     process.exit(1);
 });
 


### PR DESCRIPTION
This changes gives us better error logs for unhandled errors with timestamps and everything else the normal logs have.

Example:

```
api_1            | ["2020-07-22T11:45:52.254Z"] ERROR (2.9.0): BOOM
api_1            |     Error: BOOM
api_1            |         at p (/app/src/server.js:332:15)
api_1            |         at configure (/app/src/server.js:335:11)
api_1            |         at async start (/app/src/server.js:367:5)
```