### PR TITLE
Mitigate CSRF by validation the Origin header

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -45,6 +45,7 @@ if (useRedis) {
 const host = config.api.subdomain
     ? `${config.api.subdomain}.${config.api.domain}`
     : config.api.domain;
+const frontendHost = `${config.frontend.https ? 'https' : 'http'}://${config.frontend.domain}`;
 
 const port = config.api.port || 3000;
 
@@ -103,6 +104,12 @@ const server = Hapi.server({
             credentials: true
         },
         validate: {
+            headers: Joi.object({
+                origin: Joi.any().custom(validateOriginHeader, 'validate origin header')
+            }),
+            options: {
+                allowUnknown: true
+            },
             async failAction(request, h, err) {
                 throw Boom.badRequest('Invalid request payload input: ' + err.message);
             }
@@ -406,6 +413,21 @@ function getDataPath(date) {
     const year = date.getUTCFullYear();
     const month = (date.getUTCMonth() + 1).toString().padStart(2, '0');
     return `${year}${month}`;
+}
+
+/**
+ * Check the request Origin header to prevent CSRF.
+ *
+ * Skip the check when the Origin header is missing, which happens when not making the request from
+ * a browser.
+ *
+ * @see https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#verifying-origin-with-standard-headers
+ */
+function validateOriginHeader(value) {
+    if (value && value !== frontendHost) {
+        throw Error('Invalid Origin header');
+    }
+    return value;
 }
 
 module.exports = { init, start };


### PR DESCRIPTION
#### Motivation

Add additional CSRF mitigation strategy.

Issue: https://www.notion.so/datawrapper/Fix-CSRF-vulnerabilities-320648eba56144bdb914a1448b04f04c

Pentest issue no. 7.

#### Changes

Check the Origin header as described by OWASP: https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#verifying-origin-with-standard-headers

This mitigation strategy relies on the fact that browsers don't allow setting the Origin header when making an XHR request. Hence a malicious party can't send a request on behalf of an authenticated user from a domain that is not the Datawrapper app domain.

This is like the CORS check that browsers do but done on the server because CORS is supposedly not reliable for security. That's what OWASP seems to suggest but I still don't understand what is the exploit. How can CORS be circumvented.
