### PR TITLE
Configure CORS to accept CSRF header

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -98,7 +98,7 @@ const server = Hapi.server({
     routes: {
         cors: {
             origin: config.api.cors,
-            headers: ['Accept', 'Authorization', 'Content-Type', 'X-CSRF-Token'],
+            additionalHeaders: ['X-CSRF-Token'],
             credentials: true
         },
         validate: {

--- a/src/server.js
+++ b/src/server.js
@@ -98,6 +98,7 @@ const server = Hapi.server({
     routes: {
         cors: {
             origin: config.api.cors,
+            headers: ['Accept', 'Authorization', 'Content-Type', 'X-CSRF-Token'],
             credentials: true
         },
         validate: {


### PR DESCRIPTION
#### Motivation

To deploy CSRF protection incrementally, we should first make the API accept the new CSRF protection HTTP header. This will allow to start deploying various modules (frontend, plugins...) with CSRF protection and only once everything is deployed, make the CSRF protection a requirement.

#### Changes

- Add `X-CSRF-Token` to the list of accepted CORS headers.

    See https://hapi.dev/api/?v=19.2.0#-routeoptionscors