### PR TITLE
Fix copy of externalData

### DIFF
--- a/src/routes/charts/{id}/copy.js
+++ b/src/routes/charts/{id}/copy.js
@@ -90,7 +90,7 @@ module.exports = (server, options) => {
                 language: srcChart.language,
                 organization_id: srcChart.organization_id,
                 in_folder: srcChart.in_folder,
-                externalData: srcChart.externalData,
+                externalData: srcChart.external_data,
 
                 forked_from: srcChart.id,
                 author_id: user.id,
@@ -161,7 +161,7 @@ module.exports = (server, options) => {
                 type: publicChart.type,
                 title: publicChart.title,
                 metadata: newMeta,
-                externalData: publicChart.externalData,
+                externalData: publicChart.external_data,
                 forked_from: publicChart.id,
                 is_fork: true,
                 theme: 'default',

--- a/src/routes/charts/{id}/copy.js
+++ b/src/routes/charts/{id}/copy.js
@@ -90,7 +90,7 @@ module.exports = (server, options) => {
                 language: srcChart.language,
                 organization_id: srcChart.organization_id,
                 in_folder: srcChart.in_folder,
-                externalData: srcChart.external_data,
+                external_data: srcChart.external_data,
 
                 forked_from: srcChart.id,
                 author_id: user.id,
@@ -161,7 +161,7 @@ module.exports = (server, options) => {
                 type: publicChart.type,
                 title: publicChart.title,
                 metadata: newMeta,
-                externalData: publicChart.external_data,
+                external_data: publicChart.external_data,
                 forked_from: publicChart.id,
                 is_fork: true,
                 theme: 'default',

--- a/src/routes/charts/{id}/copy.test.js
+++ b/src/routes/charts/{id}/copy.test.js
@@ -19,6 +19,7 @@ test('User can copy chart, attributes match', async t => {
         title: 'This is my chart',
         theme: 'datawrapper-data',
         language: 'en-IE',
+        externalData: 'https://static.dwcdn.net/data/12345.csv',
         metadata: {
             visualize: {
                 basemap: 'us-counties'
@@ -41,9 +42,16 @@ test('User can copy chart, attributes match', async t => {
         headers
     });
 
+    const allMetadata = await t.context.server.inject({
+        method: 'GET',
+        url: `/v3/charts/${copiedChart.result.id}`,
+        headers
+    });
+
     t.is(copiedChart.statusCode, 201);
     t.is(copiedChart.result.authorId, user.id);
     t.is(copiedChart.result.forkedFrom, srcChart.result.id);
+    t.is(allMetadata.result.externalData, attributes.externalData);
 
     // compare attributes
     for (var attr in attributes) {


### PR DESCRIPTION
### Motivation
Copy / Fork of charts with not datawrapper-cdn external data ended up with `externalData` as `null`.

This PR fixes that and adds a check for externalData to the `copy.test`, although this is a primitive version of the test that doesn't really reflect the app's behaviour due to the external-data plugin not being included.