### PR TITLE
Fix empty data

### DIFF
--- a/src/routes/charts/{id}/data.test.js
+++ b/src/routes/charts/{id}/data.test.js
@@ -31,7 +31,8 @@ test('User can read and write chart data', async t => {
 
     // chart data is missing by default
     let res = await getData();
-    t.is(res.statusCode, 404);
+    t.is(res.statusCode, 200);
+    t.is(res.result, ' ');
     // set chart data
     res = await putData('hello world');
     t.is(res.statusCode, 204);

--- a/src/server.js
+++ b/src/server.js
@@ -15,8 +15,6 @@ const {
 const schemas = require('@datawrapper/schemas');
 const { findConfigPath } = require('@datawrapper/shared/node/findConfig');
 
-const CodedError = require('@datawrapper/shared/CodedError');
-
 const { generateToken, loadChart } = require('./utils');
 const { addScope } = require('./utils/l10n');
 const { ApiEventEmitter, eventList } = require('./utils/events');
@@ -280,7 +278,8 @@ async function configure(options = { usePlugins: true, useOpenAPI: true }) {
             try {
                 await fs.access(filePath, fs.constants.R_OK);
             } catch (e) {
-                throw new CodedError('notFound', 'chart asset not found');
+                // file does not exist, return "empty" data
+                return filename.endsWith('.json') ? '{}' : ' ';
             }
             return fs.createReadStream(filePath);
         });


### PR DESCRIPTION
This PR aligns the behavior of the core local asset storage system with the behavior on production in the [`chart-data-s3` plugin](https://github.com/datawrapper/plugin-chart-data-s3/blob/master/api.js#L27-L28).

Fixes the problem of new maps failing to render on local