### PR TITLE
Make metadata.custom props available for the custom embed template

### DIFF
--- a/src/routes/charts/{id}/embed-codes.js
+++ b/src/routes/charts/{id}/embed-codes.js
@@ -149,6 +149,7 @@ module.exports = async (server, options) => {
                             /%chart_height%/g,
                             clean(get(chart, 'metadata.publish.embed-height'))
                         )
+                        .replace(/%(.*?)%/g, (match, path) => clean(get(chart, path)))
                 };
             }
         }

--- a/src/routes/charts/{id}/embed-codes.js
+++ b/src/routes/charts/{id}/embed-codes.js
@@ -149,7 +149,9 @@ module.exports = async (server, options) => {
                             /%chart_height%/g,
                             clean(get(chart, 'metadata.publish.embed-height'))
                         )
-                        .replace(/%(.*?)%/g, (match, path) => clean(get(chart, path)))
+                        .replace(/%custom_(.*?)%/g, (match, key) => {
+                            return clean(get(chart, `metadata.custom.${key}`, ''));
+                        })
                 };
             }
         }


### PR DESCRIPTION
So that other properties are available for use. One primary use case being the possibility to define **custom fields** that can then be included in the embed code.

It might be overkill to have literally everything available to the template, but I'm not sure if it's actually a problem.