### PR TITLE
Log some more details about requests without valid CSRF token

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -140,7 +140,13 @@ function checkReferer(request) {
         return;
     }
     if (!acceptedOrigins.has(url.origin)) {
-        server.logger().warn("Referer header doesn't match any trusted origins");
+        server
+            .logger()
+            .warn(
+                `Referer header doesn't match any trusted origins for request ${request.method.toUpperCase()} ${
+                    request.url
+                } from ${request.headers.referer}`
+            );
     }
 }
 

--- a/src/server.js
+++ b/src/server.js
@@ -145,11 +145,19 @@ function checkReferer(request) {
 }
 
 function checkCSRFHeader(request) {
-    if (
-        !request.state[CSRF_COOKIE_NAME] ||
-        request.state[CSRF_COOKIE_NAME] !== request.headers[CSRF_TOKEN_HEADER.toLowerCase()]
-    ) {
-        server.logger().warn('CSRF token header is not set');
+    const csrfCrumb =
+        typeof request.state[CSRF_COOKIE_NAME] === 'object'
+            ? request.state[CSRF_COOKIE_NAME][0]
+            : request.state[CSRF_COOKIE_NAME];
+
+    if (!csrfCrumb || csrfCrumb !== request.headers[CSRF_TOKEN_HEADER.toLowerCase()]) {
+        server
+            .logger()
+            .warn(
+                `CSRF token header is not set for request ${request.method.toUpperCase()} ${
+                    request.url
+                } from ${request.headers.referer}`
+            );
     }
 }
 


### PR DESCRIPTION
This PR contains two changes:
- for requests without valid CSRF token, log the request method, URL and referer, to help determine which part of the application caused the request
- add a special case for when `request.state[CSRF_COOKIE_NAME]` is an array, which can happen if there are two cookies set with the same key. This specifically happens on our staging environment because it lives at a subdomain of our production environment, which causes two cookies to be sent by the browser.

This branch is deployed on staging already.