### PR TITLE
Inject CSRF headers into internal API calls

### DIFF
--- a/src/publish/create-chart-website.js
+++ b/src/publish/create-chart-website.js
@@ -43,6 +43,7 @@ module.exports = async function createChartWebsite(
     chart,
     {
         auth,
+        headers,
         server,
         log = noop,
         includePolyfills = true,
@@ -58,7 +59,8 @@ module.exports = async function createChartWebsite(
      */
     const { result: publishData } = await server.inject({
         url: `/v3/charts/${chart.id}/publish/data${publish ? '?publish=true' : ''}`,
-        auth
+        auth,
+        headers
     });
 
     if (chart.error) {

--- a/src/routes/auth/signup.js
+++ b/src/routes/auth/signup.js
@@ -40,6 +40,7 @@ async function signup(request, h) {
     const res = await request.server.inject({
         method: 'POST',
         url: '/v3/users',
+        headers: request.headers,
         payload: request.payload
     });
 

--- a/src/routes/charts/{id}/copy.js
+++ b/src/routes/charts/{id}/copy.js
@@ -64,7 +64,7 @@ module.exports = (server, options) => {
             }
         },
         handler: async (request, h) => {
-            const { server, params, auth } = request;
+            const { server, params, auth, headers } = request;
             const srcChart = await server.methods.loadChart(params.id);
             const isAdmin = server.methods.isAdmin(request);
             const user = await User.findByPk(auth.artifacts.id);
@@ -112,7 +112,8 @@ module.exports = (server, options) => {
                 await server.inject({
                     url: `/v3/charts/${chart.id}/data/refresh`,
                     method: 'POST',
-                    auth
+                    auth,
+                    headers
                 });
             } catch (ex) {}
 
@@ -139,7 +140,7 @@ module.exports = (server, options) => {
             }
         },
         handler: async (request, h) => {
-            const { server, params, auth } = request;
+            const { server, params, auth, headers } = request;
             const user = auth.artifacts;
             const srcChart = await server.methods.loadChart(params.id);
 
@@ -185,7 +186,8 @@ module.exports = (server, options) => {
                 await server.inject({
                     url: `/v3/charts/${chart.id}/data/refresh`,
                     method: 'POST',
-                    auth
+                    auth,
+                    headers
                 });
             } catch (ex) {}
 

--- a/src/routes/charts/{id}/data.js
+++ b/src/routes/charts/{id}/data.js
@@ -164,6 +164,7 @@ async function writeChartData(request, h) {
         method: 'PUT',
         url: `/v3/charts/${params.id}/assets/${params.id}.csv`,
         auth: request.auth,
+        headers: request.headers,
         payload: request.payload
     });
 

--- a/src/routes/charts/{id}/publish.js
+++ b/src/routes/charts/{id}/publish.js
@@ -79,7 +79,7 @@ module.exports = (server, options) => {
 };
 
 async function publishChart(request, h) {
-    const { params, auth, server } = request;
+    const { params, auth, headers, server } = request;
     const { events, event } = server.app;
     const { createChartWebsite } = server.methods;
     const user = auth.artifacts;
@@ -103,7 +103,7 @@ async function publishChart(request, h) {
         });
     }
 
-    const options = { auth, server, log: logPublishStatus, publish: true };
+    const options = { auth, headers, server, log: logPublishStatus, publish: true };
     const { data, outDir, fileMap, cleanup } = await createChartWebsite(chart, options);
 
     /**
@@ -167,7 +167,8 @@ async function publishChart(request, h) {
     const embedCodes = {};
     const res = await request.server.inject({
         url: `/v3/charts/${params.id}/embed-codes`,
-        auth
+        auth,
+        headers
     });
     res.result.forEach(embed => {
         embedCodes[`embed-method-${embed.id}`] = embed.code;
@@ -246,7 +247,7 @@ async function publishChartStatus(request, h) {
 }
 
 async function publishData(request, h) {
-    const { query, params, server, auth } = request;
+    const { query, params, server, auth, headers } = request;
 
     let chart;
 
@@ -302,7 +303,8 @@ async function publishData(request, h) {
         url: `/v3/charts/${params.id}/data${
             query.published ? '?published=1' : query.ott ? `?ott=${query.ott}` : ''
         }`,
-        auth
+        auth,
+        headers
     });
 
     const additionalData = await getAdditionalMetadata(chart, { server });

--- a/src/routes/me/data.js
+++ b/src/routes/me/data.js
@@ -25,6 +25,7 @@ module.exports = async (server, options) => {
                 method: 'PATCH',
                 url: `/v3/users/${request.auth.artifacts.id}/data`,
                 auth: request.auth,
+                headers: request.headers,
                 payload: request.payload
             });
 

--- a/src/routes/me/index.js
+++ b/src/routes/me/index.js
@@ -131,6 +131,7 @@ async function updateMe(request, h) {
         method: 'PATCH',
         url: `/v3/users/${request.auth.artifacts.id}`,
         auth: request.auth,
+        headers: request.headers,
         payload: request.payload
     });
 
@@ -142,6 +143,7 @@ async function deleteMe(request, h) {
         method: 'DELETE',
         url: `/v3/users/${request.auth.artifacts.id}`,
         auth: request.auth,
+        headers: request.headers,
         payload: request.payload
     });
 

--- a/src/routes/me/settings.js
+++ b/src/routes/me/settings.js
@@ -32,6 +32,7 @@ module.exports = async (server, options) => {
                 method: 'PATCH',
                 url: `/v3/users/${request.auth.artifacts.id}/settings`,
                 auth: request.auth,
+                headers: request.headers,
                 payload: request.payload
             });
 


### PR DESCRIPTION
#### Motivation

We need to pass the CSRF headers everywhere.

#### Testing

I tried:

- uploading chart data
- zip export

Other than that this PR isn't really tested. Unit tests pass.