### PR TITLE
Include image thumbnails in chart response

### DIFF
--- a/src/routes/charts/{id}/index.js
+++ b/src/routes/charts/{id}/index.js
@@ -1,5 +1,6 @@
 const Joi = require('@hapi/joi');
 const Boom = require('@hapi/boom');
+const crypto = require('crypto');
 const { Op } = require('@datawrapper/orm').db;
 const { Chart, ChartPublic, User, Folder } = require('@datawrapper/orm/models');
 const get = require('lodash/get');
@@ -184,6 +185,18 @@ async function getChart(request, h) {
     }
 
     const additionalData = await getAdditionalMetadata(chart, { server });
+
+    if (server.methods.config('general').imageDomain) {
+        const hash = crypto
+            .createHash('md5')
+            .update(`${chart.id}--${chart.createdAt.getTime() / 1000}`)
+            .digest('hex');
+
+        additionalData.thumbnails = {
+            full: `//${server.methods.config('general').imageDomain}/${chart.id}/${hash}/full.png`,
+            plain: `//${server.methods.config('general').imageDomain}/${chart.id}/${hash}/plain.png`
+        };
+    }
 
     return {
         ...(await prepareChart(chart, additionalData)),


### PR DESCRIPTION
As our [PHP implementation](https://github.com/datawrapper/datawrapper/blob/61e3f1835f6e73235cdca5f2d585d90b7c2bce4d/lib/api/charts.php#L31-L38) does