### PR TITLE
Use orm for thumbnail hash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -208,6 +208,11 @@
                     "version": "3.6.5",
                     "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
                     "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+                },
+                "svelte2": {
+                    "version": "npm:svelte@2.16.1",
+                    "resolved": "https://registry.npmjs.org/svelte/-/svelte-2.16.1.tgz",
+                    "integrity": "sha512-TpXdfukSkmWkMnH6PPVm7FRW8SSFcTyqBiP+6VN8rtZJ7Lp1Xbf/e3oz73eQBxF0UPZw1aAn1b91lX2XTeD3zg=="
                 }
             }
         },
@@ -222,9 +227,9 @@
             "integrity": "sha512-8tyOA+6fDfKfrVBs/Etyi4Ee3W0I1mqOuTJRabIUw+IFvQRbm/d//8ZvOEPw+2WKP9jqK38Cpwvi/3l/a7RtSw=="
         },
         "@datawrapper/orm": {
-            "version": "3.19.0",
-            "resolved": "https://registry.npmjs.org/@datawrapper/orm/-/orm-3.19.0.tgz",
-            "integrity": "sha512-zqvO84tYX+isn52EhJj21VDuhbG1uOgFD/78tsnRoR+CsEfgXZOrP3wiB4CpPwjeOJNr1rwPPLwcDRNcKlwWDA==",
+            "version": "3.20.0",
+            "resolved": "https://registry.npmjs.org/@datawrapper/orm/-/orm-3.20.0.tgz",
+            "integrity": "sha512-apaVtEfkjghl7bZRsc7N2Y3bzc3Cx1avvxw8h9AxBVJ3UdrCCt/5+mxpnIQExCNRVszCFUDLQkFNFblb9+eRuw==",
             "requires": {
                 "assign-deep": "^1.0.1",
                 "lodash": "^4.17.20",
@@ -9927,11 +9932,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/svelte-extras/-/svelte-extras-2.0.2.tgz",
             "integrity": "sha512-yoxNehbDxGEHxJBTWq2RpIPDTHlNNy6eGR7RPSK7qsh8hoyOXbji8uF//l4+I/l2fLP+E8pQTJYrduPXrW3wsw=="
-        },
-        "svelte2": {
-            "version": "npm:svelte@2.16.1",
-            "resolved": "https://registry.npmjs.org/svelte/-/svelte-2.16.1.tgz",
-            "integrity": "sha512-TpXdfukSkmWkMnH6PPVm7FRW8SSFcTyqBiP+6VN8rtZJ7Lp1Xbf/e3oz73eQBxF0UPZw1aAn1b91lX2XTeD3zg=="
         },
         "svgo": {
             "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "dependencies": {
         "@datawrapper/chart-core": "^8.19.5",
         "@datawrapper/locales": "^1.0.6",
-        "@datawrapper/orm": "^3.19.0",
+        "@datawrapper/orm": "^3.20.0",
         "@datawrapper/schemas": "^1.6.0",
         "@datawrapper/service-utils": "0.2.0",
         "@hapi/boom": "9.1.0",

--- a/src/routes/charts/index.js
+++ b/src/routes/charts/index.js
@@ -109,10 +109,11 @@ module.exports = {
 async function getAllCharts(request, h) {
     const { query, url, auth } = request;
     const isAdmin = request.server.methods.isAdmin(request);
+    const general = request.server.methods.config('general');
 
     const options = {
         order: [[decamelize(query.orderBy), query.order]],
-        attributes: ['id', 'title', 'type', 'created_at', 'last_modified_at', 'public_version'],
+        attributes: ['id', 'title', 'type', 'createdAt', 'last_modified_at', 'public_version'],
         where: {
             deleted: {
                 [Op.not]: true
@@ -166,6 +167,16 @@ async function getAllCharts(request, h) {
     for (const chart of rows) {
         charts.push({
             ...(await prepareChart(chart)),
+            thumbnails: general.imageDomain
+                ? {
+                      full: `//${general.imageDomain}/${
+                          chart.id
+                      }/${chart.getThumbnailHash()}/full.png`,
+                      plain: `//${general.imageDomain}/${
+                          chart.id
+                      }/${chart.getThumbnailHash()}/plain.png`
+                  }
+                : undefined,
             url: `${url.pathname}/${chart.id}`
         });
     }

--- a/src/routes/charts/{id}/index.js
+++ b/src/routes/charts/{id}/index.js
@@ -1,6 +1,5 @@
 const Joi = require('@hapi/joi');
 const Boom = require('@hapi/boom');
-const crypto = require('crypto');
 const { Op } = require('@datawrapper/orm').db;
 const { Chart, ChartPublic, User, Folder } = require('@datawrapper/orm/models');
 const get = require('lodash/get');
@@ -187,14 +186,13 @@ async function getChart(request, h) {
     const additionalData = await getAdditionalMetadata(chart, { server });
 
     if (server.methods.config('general').imageDomain) {
-        const hash = crypto
-            .createHash('md5')
-            .update(`${chart.id}--${chart.createdAt.getTime() / 1000}`)
-            .digest('hex');
-
         additionalData.thumbnails = {
-            full: `//${server.methods.config('general').imageDomain}/${chart.id}/${hash}/full.png`,
-            plain: `//${server.methods.config('general').imageDomain}/${chart.id}/${hash}/plain.png`
+            full: `//${server.methods.config('general').imageDomain}/${
+                chart.id
+            }/${chart.getThumbnailHash()}/full.png`,
+            plain: `//${server.methods.config('general').imageDomain}/${
+                chart.id
+            }/${chart.getThumbnailHash()}/plain.png`
         };
     }
 


### PR DESCRIPTION
Two changes:
- use the [orm function](https://github.com/datawrapper/orm/pull/47) to determine the thumbnail hash
- include it in `GET /v3/charts` as well, which is the most common use case for thumbnails (displaying a list of charts)