### PR TITLE
Allow caller of CHART_EXPORT event to define job key and priority

### DIFF
--- a/src/routes/charts/{id}/export.js
+++ b/src/routes/charts/{id}/export.js
@@ -105,6 +105,8 @@ async function exportChart(request, h) {
             await events.emit(event.CHART_EXPORT, {
                 chart,
                 user,
+                key: `export-${payload.format}`,
+                priority: 5,
                 data: payload,
                 auth,
                 logger


### PR DESCRIPTION
Our export system works through an event called `CHART_EXPORT`. The core endpoint `/chart/:id/export/:format` calls it, and the plugins `export-pdf` and `export-zip` listen to it. The `export-pdf` plugin then creates the jobs for the render network (and waits for their completion). Up until now, the `export-pdf` plugin used a hardcoded job ID of `export-print-{format}`, and a hardcoded job priority of `5`. This worked fine as long as the export API endpoint was the only caller of that event. 

However, we have since migrated the `image-publishing` feature to node, using this event. This results in `image-publishing` exports and API/user-triggered exports being created with the same priority. This is problematic because the latter are actually more important, which leads to us needing to significantly overprovision our render network to achieve acceptable performance.

This PR changes it so that the _caller_ of the `CHART_EXPORT` event can define their own `key` and `priority` to be used. The `key` is not used in any programmatic way but just for human understanding, so I also changed the key identifiers slightly to make more understandable:
- For API-triggered exports, `export-print-png` becomes `export-png` (same for other formats)
- For image-publishing exports, `export-print-png` becomes `image-publishing-png` (same for other formats)
- The Cloudflare invalidation of image publishing exports used to be called `publish-screenshot`, now `image-publishing-invalidation`