### PR TITLE
Two-factor authentication using Yubikey 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10701,6 +10701,11 @@
                 }
             }
         },
+        "yub": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/yub/-/yub-0.11.1.tgz",
+            "integrity": "sha1-rG0OplwUa3sJfnNnun6o70hEVi8="
+        },
         "z-schema": {
             "version": "3.25.1",
             "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.25.1.tgz",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
         "postcss-less": "3.1.4",
         "pug": "2.0.4",
         "sanitize-html": "^1.23.0",
-        "tar": "6.0.1"
+        "tar": "6.0.1",
+        "yub": "^0.11.1"
     },
     "devDependencies": {
         "ava": "~3.5.2",

--- a/src/auth/otp/index.js
+++ b/src/auth/otp/index.js
@@ -1,0 +1,1 @@
+module.exports = [require('./yubikey')];

--- a/src/auth/otp/yubikey.js
+++ b/src/auth/otp/yubikey.js
@@ -1,0 +1,70 @@
+const { promisify } = require('util');
+const yub = require('yub');
+const yubVerify = promisify(yub.verify);
+const { getUserData, setUserData, unsetUserData } = require('@datawrapper/orm/utils/userData');
+const Boom = require('@hapi/boom');
+const get = require('lodash/get');
+
+const USER_DATA_KEY = '.otp_yubikey';
+
+module.exports = {
+    id: 'yubikey',
+    title: 'YubiKey',
+    /*
+     * Returns true if Yubikey client has been configured
+     * in config.api.otp.yubikey
+     */
+    isEnabled({ config }) {
+        const api = config('api');
+        return get(api, 'otp.yubikey.clientId') && get(api, 'otp.yubikey.secretKey');
+    },
+
+    async isEnabledForUser({ user }) {
+        return getUserData(user.id, USER_DATA_KEY);
+    },
+
+    /*
+     * Check if the authenticated user has enabled OTP
+     * and if they do, require a valid OTP for login
+     */
+    async verify({ user, otp, config }) {
+        const api = config('api');
+
+        yub.init(api.otp.yubikey.clientId, api.otp.yubikey.secretKey);
+        // check if the user has configured an OTP
+        const userOTP = await getUserData(user.id, USER_DATA_KEY);
+        if (userOTP) {
+            // user has enabled OTP, so we require it
+            if (!otp) {
+                // no OTP in payload, return error
+                throw Boom.unauthorized('Need OTP');
+            }
+            const otpRes = await yubVerify(otp);
+            if (!otpRes.valid || otpRes.identity !== userOTP) {
+                throw Boom.unauthorized('Invalid OTP');
+            }
+        }
+    },
+
+    /*
+     * Enable OTP for a user (or reset the otp)
+     */
+    async enable({ user, config, otp }) {
+        const api = config('api');
+        if (!otp) throw Boom.unauthorized('Need OTP');
+        yub.init(api.otp.yubikey.clientId, api.otp.yubikey.secretKey);
+        const otpRes = await yubVerify(otp);
+        if (!otpRes.valid) {
+            throw Boom.unauthorized('Invalid OTP');
+        }
+        // otp is valid, store device identity
+        await setUserData(user.id, USER_DATA_KEY, otpRes.identity);
+    },
+
+    /*
+     * Disable OTP login for a given user
+     */
+    async disable({ user }) {
+        await unsetUserData(user.id, USER_DATA_KEY);
+    }
+};

--- a/src/routes/me/index.js
+++ b/src/routes/me/index.js
@@ -73,6 +73,7 @@ module.exports = {
 
         require('./settings')(server, options);
         require('./data')(server, options);
+        require('./otp')(server, options);
 
         // DELETE /v3/me
         server.route({

--- a/src/routes/me/otp.js
+++ b/src/routes/me/otp.js
@@ -1,0 +1,112 @@
+const Boom = require('@hapi/boom');
+const Joi = require('@hapi/joi');
+const otpProviders = require('../../auth/otp');
+
+const { noContentResponse } = require('../../schemas/response');
+
+module.exports = async (server, options) => {
+    server.route({
+        method: 'GET',
+        path: '/otp',
+        options: {
+            description: 'Get list of supported OTP providers',
+            auth: {
+                access: { scope: ['user:read'] }
+            },
+            validate: {}
+        },
+        async handler(request, h) {
+            const { auth } = request;
+            const { config } = request.server.methods;
+
+            const res = [];
+            for (var i = 0; i < otpProviders.length; i++) {
+                const otpProvider = otpProviders[i];
+                const installed = !!otpProvider.isEnabled({ config });
+                const enabled = !!(await otpProvider.isEnabledForUser({ user: auth.artifacts }));
+                if (installed || auth.artifacts.isAdmin()) {
+                    res.push({
+                        id: otpProvider.id,
+                        title: otpProvider.title,
+                        installed,
+                        enabled
+                    });
+                }
+            }
+
+            return res;
+        }
+    });
+    // POST /v3/me/otp/{provider}
+    server.route({
+        method: 'POST',
+        path: '/otp/{provider}',
+        options: {
+            description: 'Enable OTP for user login',
+            auth: {
+                access: { scope: ['user:write'] }
+            },
+            validate: {
+                params: {
+                    provider: Joi.string()
+                        .required()
+                        .valid(...otpProviders.map(p => p.id))
+                        .description('Valid OTP provider id (e.g., `yubikey`')
+                },
+                payload: Joi.object({
+                    otp: Joi.string().required().description('A valid OTP')
+                })
+            },
+            response: noContentResponse
+        },
+        async handler(request, h) {
+            const { auth, params } = request;
+            const { config } = request.server.methods;
+            const { otp } = request.payload;
+
+            const otpProvider = otpProviders.find(p => p.id === params.provider);
+            if (!otpProvider) return Boom.badRequest('Unkown OTP provider');
+
+            if (!otpProvider.isEnabled({ config })) {
+                return Boom.badRequest('This OTP provider is not configured');
+            }
+
+            await otpProvider.enable({ user: auth.artifacts, config, otp });
+            return h.response().code(204);
+        }
+    });
+    // DELETE /v3/me/otp/{provider}
+    server.route({
+        method: 'DELETE',
+        path: '/otp/{provider}',
+        options: {
+            description: 'Disable OTP for user login',
+            auth: {
+                access: { scope: ['user:write'] }
+            },
+            validate: {
+                params: {
+                    provider: Joi.string()
+                        .required()
+                        .valid(...otpProviders.map(p => p.id))
+                        .description('Valid OTP provider id (e.g., `yubikey`')
+                }
+            },
+            response: noContentResponse
+        },
+        async handler(request, h) {
+            const { auth, params } = request;
+            const { config } = request.server.methods;
+
+            const otpProvider = otpProviders.find(p => p.id === params.provider);
+            if (!otpProvider) return Boom.badRequest('Unkown OTP provider');
+
+            if (!otpProvider.isEnabled({ config })) {
+                return Boom.badRequest('This OTP provider is not configured');
+            }
+
+            await otpProvider.disable({ user: auth.artifacts });
+            return h.response().code(204);
+        }
+    });
+};


### PR DESCRIPTION
This PR adds a two-factor authentication using YubiKey devices (see https://github.com/datawrapper/datawrapper/pull/430) 

I decided to put the code into the core api repo, because it's authentication. The code is structured to allow multiple OTP providers at some point, but as of now, only YubiKey is implemented. The verification of the second factor happens in the `login` route. We're going through all OTP providers we know, check if any of them has been configured in the config. If they are configured, we check if the user has enabled the provider. For that I'm using the `user_data` relation (more on that later).

For setting up the OTP providers I added three new routes:

* `GET /v3/me/otp` returns a list of existing OTP providers and the `installed` and `enabled` status.
* `POST /v3/me/otp/{provider}` enabled a given provider. The request payload needs to include a valid `otp` token. The request handler then calls the YubiKey api (using the [yub](https://www.npmjs.com/package/yub) package) to confirm if the OTP token is valid. This call also returns a device **identity** which we're storing under the `.otp_yubikey` key in `user_data`. The login request will perform the same request, but will only pass if the returned identity matches the one we stored in `user_data`.
* `DELETE /v3/me/otp/{provider}` disabes a provider. Currently this does not require entering another `otp` token, but we could change this. This endpoint simply removes the row in `user_data`.

I assume the OTP device **identity** is scoped to our app (I had to create a Yubikey clientID + secretKey [here](https://upgrade.yubico.com/getapikey/)), but I still don't want to expose the identity value on our page. We're currently passing all user data keys to the client under `dw.backend.__user_data`. To prevent this I decided to let the `.otp_yubikey` key start with a `.` and I added some code that [filters out keys starting with `.` here](https://github.com/datawrapper/datawrapper/pull/430/commits/4292cbfc84dc85f5fdc65d9b32dc0133a4a08f39).