### PR TITLE
Expose chart display URLs

### DIFF
--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -831,5 +831,6 @@
   "describe / column-format / million": "1 Million",
   "describe / column-format / billion": "1 Milliarde",
   "describe / column-format / trillion": "1 Billion",
-  "controls / annotations / duplicate": "Anmerkung duplizieren"
+  "controls / annotations / duplicate": "Anmerkung duplizieren",
+  "standalone": "Normale Größe"
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -831,5 +831,6 @@
   "describe / column-format / million": "1 million",
   "describe / column-format / billion": "1 billion",
   "describe / column-format / trillion": "1 trillion",
-  "controls / annotations / duplicate": "Duplicate annotation"
+  "controls / annotations / duplicate": "Duplicate annotation",
+  "standalone": "Normal size"
 }


### PR DESCRIPTION
We have a plugin-based architecture to register chart 'display URLs', such as our own `www.datawrapper.de/_/:chart`. This PR adds an endpoint to fetch them from the API, similar to how it's done for embed codes in `/v3/charts/:id/embed-codes`.

This endpoint is used by the PHP frontend in order to show the display URL to the user.