### PR TITLE
Feature/menu icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -190,9 +190,9 @@
             }
         },
         "@datawrapper/chart-core": {
-            "version": "8.22.2",
-            "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-8.22.2.tgz",
-            "integrity": "sha512-phGX1ISVVFcsV2zWoWBNbQcsGimZ4GmJLpkI3EymYLXyOZ2jRfV0wgAw2D+arPzXS4N5W4ge/XQildmvxFnvlA==",
+            "version": "8.23.0",
+            "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-8.23.0.tgz",
+            "integrity": "sha512-3db35hz9Vuh+jeajNa6ztCTXoBamgSFue5n6PoiiFH2DjyEgIBO5Bv/4T7k1ezPREw2XMp+opvBd8cvwn1YRaA==",
             "requires": {
                 "@datawrapper/expr-eval": "^2.0.2-datawrapper.1",
                 "@datawrapper/polyfills": "2.1.0",
@@ -208,6 +208,11 @@
                     "version": "3.6.5",
                     "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
                     "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+                },
+                "svelte2": {
+                    "version": "npm:svelte@2.16.1",
+                    "resolved": "https://registry.npmjs.org/svelte/-/svelte-2.16.1.tgz",
+                    "integrity": "sha512-TpXdfukSkmWkMnH6PPVm7FRW8SSFcTyqBiP+6VN8rtZJ7Lp1Xbf/e3oz73eQBxF0UPZw1aAn1b91lX2XTeD3zg=="
                 }
             }
         },
@@ -9979,11 +9984,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/svelte-extras/-/svelte-extras-2.0.2.tgz",
             "integrity": "sha512-yoxNehbDxGEHxJBTWq2RpIPDTHlNNy6eGR7RPSK7qsh8hoyOXbji8uF//l4+I/l2fLP+E8pQTJYrduPXrW3wsw=="
-        },
-        "svelte2": {
-            "version": "npm:svelte@2.16.1",
-            "resolved": "https://registry.npmjs.org/svelte/-/svelte-2.16.1.tgz",
-            "integrity": "sha512-TpXdfukSkmWkMnH6PPVm7FRW8SSFcTyqBiP+6VN8rtZJ7Lp1Xbf/e3oz73eQBxF0UPZw1aAn1b91lX2XTeD3zg=="
         },
         "svgo": {
             "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "url": "git+https://github.com/datawrapper/datawrapper-api.git"
     },
     "dependencies": {
-        "@datawrapper/chart-core": "^8.22.2",
+        "@datawrapper/chart-core": "^8.23.0",
         "@datawrapper/locales": "^1.0.9",
         "@datawrapper/orm": "^3.20.1",
         "@datawrapper/schemas": "^1.8.0",

--- a/src/publish/compile-css.js
+++ b/src/publish/compile-css.js
@@ -57,6 +57,10 @@ async function compileCSS({ theme, filePaths }) {
         delete theme.data.vis['locator-maps'].markerPresets;
     }
 
+    if (theme.data.options && theme.data.options.menu) {
+        delete theme.data.options.menu.icon;
+    }
+
     let { css } = await less.render(inputLess, {
         paths: paths,
         modifyVars: flatten({


### PR DESCRIPTION
- Bump `@datawrapper/chart-core`
- Don't pass `theme.options.menu.icon` to less compiler

We should eventually find a more elegant solution for the current blacklisting of theme properties that confuse the less compiler