### PR TITLE
Allow transparent preview

### DIFF
--- a/src/routes/charts/{id}/export.js
+++ b/src/routes/charts/{id}/export.js
@@ -32,7 +32,8 @@ module.exports = (server, options) => {
                         width: Joi.number(),
                         color: Joi.string().default('auto')
                     }),
-                    fullVector: Joi.boolean().default(false)
+                    fullVector: Joi.boolean().default(false),
+                    transparent: Joi.boolean().default(false)
                 })
             }
         },


### PR DESCRIPTION
Set `theme.style.body.background` to `transparent` if `?transparent=true` is set on the `/visualizations/:visId/style.css?theme:theme` call