### PR TITLE
update plugins using git reset --hard instead of complicated tar download

### DIFF
--- a/src/routes/admin/plugins.js
+++ b/src/routes/admin/plugins.js
@@ -92,7 +92,13 @@ function register(server, options) {
         // if the plugin is a git repo we update it using git pull
         // get current branch
         const branch = payload.branch;
-        const result = [`Updating plugin ${name} from branch origin/${branch}`, 'git fetch origin'];
+        const result = [`Updating plugin ${name} from branch origin/${branch}`];
+        const { stdout: oldCommit } = await exec(
+            'git log --pretty=format:"#%h: %s (%an, %ar)" -1',
+            { cwd: pluginLocation }
+        );
+        result.push(`Plugin is at commit:\n${oldCommit}`);
+        result.push('git fetch origin');
         // fetch all updates from origin
         await exec('git fetch origin', { cwd: pluginLocation });
         // reset local repo to latest origin branch

--- a/src/routes/admin/plugins.js
+++ b/src/routes/admin/plugins.js
@@ -110,17 +110,24 @@ function register(server, options) {
         const themes = await Theme.findAll({ attributes: ['id'] });
 
         const dropOperationPromises = [];
+        const droppedCacheKeys = [];
         for (const vis of visualizations) {
             for (const { id } of themes) {
                 const promise = styleCache.drop(`${id}__${vis}`).catch(() => {
                     server.logger().info(`Unable to drop cache key [${id}__${vis}]`);
                 });
-                result.push(`Dropping cache key ${id}__${vis}`);
+                droppedCacheKeys.push(`${id}__${vis}`);
                 dropOperationPromises.push(promise);
             }
         }
 
         await Promise.all(dropOperationPromises);
+
+        result.push(
+            `Dropped ${droppedCacheKeys.length} cache keys (e.g., ${droppedCacheKeys
+                .slice(0, 2)
+                .join(', ')})`
+        );
 
         log.info('[Done] Update plugin', payload.name);
         return { log: result };

--- a/src/routes/admin/plugins.js
+++ b/src/routes/admin/plugins.js
@@ -89,11 +89,14 @@ function register(server, options) {
         }
         // if the plugin is a git repo we update it using git pull
         // get current branch
-        const { stdout: branch } = await exec('git rev-parse --abbrev-ref HEAD');
+        const { stdout: branch } = await exec('git rev-parse --abbrev-ref HEAD', {
+            cwd: pluginLocation
+        });
+        log.info(`update plugin from branch origin/${branch}`);
         // fetch all updates from origin
-        await exec('git fetch origin');
+        await exec('git fetch origin', { cwd: pluginLocation });
         // reset local repo to latest origin branch
-        await exec(`git reset --hard origin/${branch}`);
+        await exec(`git reset --hard origin/${branch}`, { cwd: pluginLocation });
 
         /* bust visualization css cache */
         const visualizations = [];

--- a/src/routes/admin/plugins.js
+++ b/src/routes/admin/plugins.js
@@ -97,7 +97,7 @@ function register(server, options) {
             'git log --pretty=format:"#%h: %s (%an, %ar)" -1',
             { cwd: pluginLocation }
         );
-        result.push(`Plugin is at commit:\n${oldCommit}`);
+        result.push(`Plugin is at commit:\n${oldCommit}\n`);
         result.push('git fetch origin');
         // fetch all updates from origin
         await exec('git fetch origin', { cwd: pluginLocation });

--- a/src/routes/admin/plugins.js
+++ b/src/routes/admin/plugins.js
@@ -106,8 +106,19 @@ function register(server, options) {
         const changedFiles = (
             await exec(`git diff --name-only origin/${branch} ${branch}`, { cwd })
         ).stdout.split('\n');
-        let needsPm2Reload = some(['api.js', 'crons.js', 'frontend.js'], file =>
-            changedFiles.includes(file)
+        let needsPm2Reload = some(
+            [
+                'api.js',
+                'crons.js',
+                'frontend.js',
+                /^src\/api\//,
+                /^src\/crons\//,
+                /^src\/frontend\/$/
+            ],
+            file =>
+                typeof file === 'string'
+                    ? changedFiles.includes(file) // exact file name match
+                    : some(changedFiles, f => file.test(f)) // regex pattern match
         );
         if (changedFiles.includes('package.json')) {
             // compare old package.json with new one to see

--- a/src/routes/admin/plugins.js
+++ b/src/routes/admin/plugins.js
@@ -85,13 +85,13 @@ function register(server, options) {
         const pluginLocation = path.join(general.localPluginRoot, name);
         const isGitRepo = await fs.pathExists(path.join(pluginLocation, '.git/index'));
         if (!isGitRepo) {
-            return Boom.notImplemented("Cannot update plugins which aren't git repos");
+            return Boom.notImplemented(
+                "Cannot update plugins which aren't git repos (or not installed yet)"
+            );
         }
         // if the plugin is a git repo we update it using git pull
         // get current branch
-        const { stdout: branch } = await exec('git rev-parse --abbrev-ref HEAD', {
-            cwd: pluginLocation
-        });
+        const branch = payload.branch;
         const result = [`Updating plugin ${name} from branch origin/${branch}`, 'git fetch origin'];
         // fetch all updates from origin
         await exec('git fetch origin', { cwd: pluginLocation });

--- a/src/routes/admin/plugins.js
+++ b/src/routes/admin/plugins.js
@@ -125,11 +125,11 @@ function register(server, options) {
 
         result.push(
             `Dropped ${droppedCacheKeys.length} cache keys (e.g., ${droppedCacheKeys
-                .slice(0, 2)
+                .slice(0, 3)
                 .join(', ')})`
         );
 
         log.info('[Done] Update plugin', payload.name);
-        return { log: result };
+        return { log: result.join('\n') };
     }
 }


### PR DESCRIPTION
deployed on staging api if you want to test.

I also threw in some more logging which will show up in the plugin admin
```
callig v3 api to update plugin there as well...
received 200 response
Updating plugin d3-lines from branch origin/master
Plugin is at commit:
#6d3c5b9: wrap __annotationLayer.() in try catch block to prevent crashing in IE (ilokhov, 5 weeks ago)

git fetch origin
git reset --hard origin/master
HEAD is now at 164fad1 bump xy-grid to get truncation fix (#72)

Dropped 1068 cache keys (e.g., __d3-lines, 058bm7ht9n__d3-lines, 20minuten__d3-lines)
```