### PR TITLE
Set robots meta tag 

### DIFF
--- a/src/publish/create-chart-website.js
+++ b/src/publish/create-chart-website.js
@@ -218,6 +218,7 @@ module.exports = async function createChartWebsite(
     const indexHTML = renderHTML({
         __DW_SVELTE_PROPS__: stringify(props),
         CHART_LANGUAGE: locale.split(/_|-/)[0],
+        META_ROBOTS: 'noindex, nofollow',
         CHART_HTML: html,
         CHART_HEAD: head,
         POLYFILL_SCRIPT: getAssetLink(`../../lib/${polyfillScript}`),

--- a/src/publish/index.pug
+++ b/src/publish/index.pug
@@ -2,6 +2,7 @@ doctype html
 html(lang=CHART_LANGUAGE)
   head
     meta(charset="UTF-8")
+    meta(name="robots", content=META_ROBOTS)
     meta(name="viewport", content="width=device-width, initial-scale=1.0")
     style!=CSS
     | !{CHART_HEAD}


### PR DESCRIPTION
Set `noindex, nofollow` robots tag on published charts. In the future, this could also be controlled via (self-hosting) team setting