### PR TITLE
Check for activated team

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -208,6 +208,11 @@
                     "version": "3.6.5",
                     "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
                     "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+                },
+                "svelte2": {
+                    "version": "npm:svelte@2.16.1",
+                    "resolved": "https://registry.npmjs.org/svelte/-/svelte-2.16.1.tgz",
+                    "integrity": "sha512-TpXdfukSkmWkMnH6PPVm7FRW8SSFcTyqBiP+6VN8rtZJ7Lp1Xbf/e3oz73eQBxF0UPZw1aAn1b91lX2XTeD3zg=="
                 }
             }
         },
@@ -222,9 +227,9 @@
             "integrity": "sha512-02shz5tm4ZQJKvZwjsIYuiAx9MECHJQGp/vFAbnBa1W9cn8N2IIpEERwdkBwqP/Zc8GHf4vjYzLeCpj9f0UatQ=="
         },
         "@datawrapper/orm": {
-            "version": "3.22.0",
-            "resolved": "https://registry.npmjs.org/@datawrapper/orm/-/orm-3.22.0.tgz",
-            "integrity": "sha512-6XbNnBNDtxIwkZ1kYpM8Zudg9PZ2/hSdhzCFg8AH8TT7UhQi76uM1+WF0yu9svkfrgNqVFfUwiE2B9WxyRQrtw==",
+            "version": "3.22.1",
+            "resolved": "https://registry.npmjs.org/@datawrapper/orm/-/orm-3.22.1.tgz",
+            "integrity": "sha512-zM2/LezSxbyzF/usqT0aRRW/UzgG4aeXnKE+45wXSQ0aQjEF9W6sCXF22iPQtYefkwg7DgOYcmMTJ8CBR3FHEw==",
             "requires": {
                 "assign-deep": "^1.0.1",
                 "lodash": "^4.17.20",
@@ -10026,11 +10031,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/svelte-extras/-/svelte-extras-2.0.2.tgz",
             "integrity": "sha512-yoxNehbDxGEHxJBTWq2RpIPDTHlNNy6eGR7RPSK7qsh8hoyOXbji8uF//l4+I/l2fLP+E8pQTJYrduPXrW3wsw=="
-        },
-        "svelte2": {
-            "version": "npm:svelte@2.16.1",
-            "resolved": "https://registry.npmjs.org/svelte/-/svelte-2.16.1.tgz",
-            "integrity": "sha512-TpXdfukSkmWkMnH6PPVm7FRW8SSFcTyqBiP+6VN8rtZJ7Lp1Xbf/e3oz73eQBxF0UPZw1aAn1b91lX2XTeD3zg=="
         },
         "svgo": {
             "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "dependencies": {
         "@datawrapper/chart-core": "^8.24.2",
         "@datawrapper/locales": "^1.1.2",
-        "@datawrapper/orm": "^3.22.0",
+        "@datawrapper/orm": "^3.22.1",
         "@datawrapper/schemas": "^1.11.0",
         "@datawrapper/service-utils": "^0.3.0",
         "@hapi/boom": "9.1.0",

--- a/src/routes/charts/index.js
+++ b/src/routes/charts/index.js
@@ -214,7 +214,7 @@ async function createChart(request, h) {
         payload &&
         payload.organizationId &&
         !isAdmin &&
-        !(await user.hasTeam(payload.organizationId))
+        !(await user.hasActivatedTeam(payload.organizationId))
     ) {
         return Boom.unauthorized('User is not allowed to create a chart in that team.');
     }
@@ -234,7 +234,7 @@ async function createChart(request, h) {
             !folder ||
             (!isAdmin &&
                 folder.user_id !== auth.artifacts.id &&
-                !(await user.hasTeam(folder.org_id)))
+                !(await user.hasActivatedTeam(folder.org_id)))
         ) {
             payload.folderId = undefined;
             request.logger.info('Invalid folder id. User does not have access to this folder');

--- a/src/routes/charts/{id}/index.js
+++ b/src/routes/charts/{id}/index.js
@@ -227,7 +227,11 @@ async function editChart(request, h) {
         return Boom.unauthorized();
     }
 
-    if (payload.organizationId && !isAdmin && !(await user.hasTeam(payload.organizationId))) {
+    if (
+        payload.organizationId &&
+        !isAdmin &&
+        !(await user.hasActivatedTeam(payload.organizationId))
+    ) {
         return Boom.unauthorized('User does not have access to the specified team.');
     }
 
@@ -246,7 +250,7 @@ async function editChart(request, h) {
             !folder ||
             (!isAdmin &&
                 folder.user_id !== auth.artifacts.id &&
-                !(await user.hasTeam(folder.org_id)))
+                !(await user.hasActivatedTeam(folder.org_id)))
         ) {
             throw Boom.unauthorized(
                 'User does not have access to the specified folder, or it does not exist.'

--- a/src/routes/folders.js
+++ b/src/routes/folders.js
@@ -114,7 +114,7 @@ const routes = [
             };
 
             if (payload.organizationId) {
-                if (!isAdmin && !(await user.hasTeam(payload.organizationId))) {
+                if (!isAdmin && !(await user.hasActivatedTeam(payload.organizationId))) {
                     return Boom.unauthorized('User does not have access to the specified team.');
                 }
 
@@ -131,7 +131,7 @@ const routes = [
                     !folder ||
                     (!isAdmin &&
                         folder.user_id !== auth.artifacts.id &&
-                        !(await user.hasTeam(folder.org_id)))
+                        !(await user.hasActivatedTeam(folder.org_id)))
                 ) {
                     return Boom.unauthorized(
                         'User does not have access to the specified parent folder, or it does not exist.'

--- a/src/routes/teams/{id}/index.js
+++ b/src/routes/teams/{id}/index.js
@@ -97,12 +97,8 @@ async function getTeam(request, h) {
     const { url, server, auth, params } = request;
 
     const isAdmin = server.methods.isAdmin(request);
-    const hasTeam = !!(await UserTeam.findOne({
-        where: {
-            user_id: auth.artifacts.id,
-            organization_id: params.id
-        }
-    }));
+    const user = auth.artifacts;
+    const hasTeam = await user.hasActivatedTeam(params.id);
 
     if (!hasTeam && !isAdmin) {
         return Boom.unauthorized();

--- a/src/routes/teams/{id}/members.js
+++ b/src/routes/teams/{id}/members.js
@@ -153,13 +153,9 @@ module.exports = async (server, options) => {
 
 async function getTeamMembers(request, h) {
     const { query, params, auth, server } = request;
+    const user = auth.artifacts;
 
-    const hasTeam = !!(await UserTeam.findOne({
-        where: {
-            user_id: auth.artifacts.id,
-            organization_id: params.id
-        }
-    }));
+    const hasTeam = await user.hasTeam(params.id);
 
     if (!hasTeam && !server.methods.isAdmin(request)) {
         return Boom.unauthorized();

--- a/src/routes/teams/{id}/members.js
+++ b/src/routes/teams/{id}/members.js
@@ -155,7 +155,7 @@ async function getTeamMembers(request, h) {
     const { query, params, auth, server } = request;
     const user = auth.artifacts;
 
-    const hasTeam = await user.hasTeam(params.id);
+    const hasTeam = await user.hasActivatedTeam(params.id);
 
     if (!hasTeam && !server.methods.isAdmin(request)) {
         return Boom.unauthorized();


### PR DESCRIPTION
see https://github.com/datawrapper/orm/pull/46#pullrequestreview-547691611

We use Sequelize's built-in `User.hasTeam` in various places to check whether a user is in a team. This however isn't 100% correct, as that will also return `true` if the user has been invited but hasn't accepted the invitation yet. This PR changes the logic to use the ORM's `User.hasActivatedTeam` instead of `hasTeam` or custom checks.