### PR TITLE
Fix Boom call

### DIFF
--- a/src/routes/visualizations.js
+++ b/src/routes/visualizations.js
@@ -133,7 +133,7 @@ async function register(server, options) {
         });
 
         if (statusCode !== 200) {
-            return new Boom(result.message, result);
+            return new Boom.Boom(result.message, result);
         }
 
         const file = result.script;


### PR DESCRIPTION
This constructor method is called `Boom.Boom` (see [Boom API docs](https://hapi.dev/module/boom/api/?v=9.1.1#new-boomboommessage-options)). The current implementation throws a `Boom is not a constructor error`.

Not critical since this is already an 'unhappy code path' but still pollutes error logs needlessly