### PR TITLE
Fix cache invalidation script

### DIFF
--- a/scripts/drop-vis-cache.js
+++ b/scripts/drop-vis-cache.js
@@ -48,7 +48,7 @@ process.stdout.write(chalk`
 
 stream.on('data', keys => {
     const filteredKeys = keys.filter(key => {
-        key = key.split('__').pop();
+        key = key.split('__')[1];
         return visualizations.includes(key);
     });
 


### PR DESCRIPTION
We store cached visualization styles as `themeId__visualizationType__commitHash` now, so in order for our script to do its job of deleting all cached styles for a given visualizationType, we need to check for the middle value, not the last.