### PR TITLE
Write external metadata to chart asset

### DIFF
--- a/src/routes/charts/{id}/assets.js
+++ b/src/routes/charts/{id}/assets.js
@@ -135,6 +135,7 @@ function getAssetWhitelist(id) {
     return [
         '{id}.csv',
         '{id}.public.csv',
+        '{id}.metadata.json',
         '{id}.map.json',
         '{id}.minimap.json',
         '{id}.highlight.json'

--- a/src/routes/charts/{id}/data.js
+++ b/src/routes/charts/{id}/data.js
@@ -129,11 +129,16 @@ module.exports = (server, options) => {
                         if (checkUrl(metadataUrl)) {
                             const metadata = (await got(metadataUrl)).body;
 
-                            await events.emit(event.PUT_CHART_ASSET, {
-                                chart,
-                                data: metadata,
-                                filename: `${chart.id}.metadata.json`
-                            });
+                            try {
+                                JSON.parse(metadata);
+
+                                // @todo: validate against metadata schema
+                                await events.emit(event.PUT_CHART_ASSET, {
+                                    chart,
+                                    data: metadata,
+                                    filename: `${chart.id}.metadata.json`
+                                });
+                            } catch (ex) {}
                         }
                     } catch (ex) {}
                 }


### PR DESCRIPTION
When refreshing external data, also load data.external-metadata URL and save it to chart asset `{id}.metadata.json` for use in step 3 UI.

Related:
- datawrapper/datawrapper#454
- datawrapper/controls#158
