### PR TITLE
Change authentication mode for asset endpoint

### DIFF
--- a/src/routes/charts/{id}/assets.js
+++ b/src/routes/charts/{id}/assets.js
@@ -14,7 +14,7 @@ module.exports = (server, options) => {
             tags: ['api'],
             description: 'Fetch chart asset',
             auth: {
-                access: { scope: ['chart:read'] }
+                mode: 'try'
             },
             notes: `Request an asset associated with a chart. Requires scope \`chart:read\`.`,
             plugins: {
@@ -79,26 +79,32 @@ async function getChartAsset(request, h) {
 
     const filename = params.asset;
 
-    let isEditable = await chart.isEditableBy(request.auth.artifacts, auth.credentials.session);
+    if (auth.isAuthenticated) {
+        let isEditable = await chart.isEditableBy(auth.artifacts, auth.credentials.session);
 
-    if (!isEditable && query.ott) {
-        // we do not destroy the access token here, because this request might
-        // have been internally injected from the /chart/:id/publish/data endpoint
-        const count = await ChartAccessToken.count({
-            where: {
-                chart_id: params.id,
-                token: query.ott
-            },
-            limit: 1
-        });
+        if (!isEditable && query.ott) {
+            // we do not destroy the access token here, because this request might
+            // have been internally injected from the /chart/:id/publish/data endpoint
+            const count = await ChartAccessToken.count({
+                where: {
+                    chart_id: params.id,
+                    token: query.ott
+                },
+                limit: 1
+            });
 
-        if (count === 1) {
-            isEditable = true;
+            if (count === 1) {
+                isEditable = true;
+            }
         }
-    }
 
-    if (filename !== `${chart.id}.public.csv` && !isEditable) {
-        return Boom.forbidden();
+        if (!isEditable || auth.credentials.scope.indexOf('chart:read') === -1) {
+            return Boom.forbidden();
+        }
+    } else {
+        if (filename !== `${chart.id}.public.csv`) {
+            return Boom.forbidden();
+        }
     }
 
     if (!getAssetWhitelist(params.id).includes(params.asset)) {

--- a/src/routes/charts/{id}/assets.js
+++ b/src/routes/charts/{id}/assets.js
@@ -98,7 +98,10 @@ async function getChartAsset(request, h) {
             }
         }
 
-        if (!isEditable || auth.credentials.scope.indexOf('chart:read') === -1) {
+        if (
+            filename !== `${chart.id}.public.csv` &&
+            (!isEditable || auth.credentials.scope.indexOf('chart:read') === -1)
+        ) {
             return Boom.forbidden();
         }
     } else {

--- a/src/routes/charts/{id}/assets.test.js
+++ b/src/routes/charts/{id}/assets.test.js
@@ -64,3 +64,79 @@ test('User can write chart asset with almost 2MB', async t => {
         });
     }
 });
+
+test('Public asset can be read', async t => {
+    const { session } = await t.context.getUser();
+
+    const headers = {
+        cookie: `DW-SESSION=${session.id}; crumb=abc`,
+        'X-CSRF-Token': 'abc',
+        referer: 'http://localhost'
+    };
+    // create a new chart
+    const chart = await t.context.server.inject({
+        method: 'POST',
+        url: '/v3/charts',
+        headers,
+        payload: {}
+    });
+
+    const asset = `X1,X2
+10,20`;
+
+    let res = await putAsset(`${chart.result.id}.csv`, { data: asset });
+    t.is(res.statusCode, 204);
+
+    // see if that worked
+    res = await getAsset(`${chart.result.id}.csv`);
+    t.is(res.statusCode, 200);
+    t.is(JSON.parse(res.result).data, asset);
+
+    // publish chart
+    t.context.server.inject({
+        method: 'POST',
+        headers,
+        url: `/v3/charts/${chart.result.id}/publish`
+    });
+
+    // unauthenticated user can read public asset
+    const unauthenticatedHeaders = {
+        cookie: `crumb=abc`,
+        'X-CSRF-Token': 'abc',
+        referer: 'http://localhost'
+    };
+
+    const publicAsset = await t.context.server.inject({
+        method: 'GET',
+        headers: unauthenticatedHeaders,
+        url: `/v3/charts/${chart.result.id}/assets/${chart.result.id}.public.csv`
+    });
+    t.is(publicAsset.statusCode, 200);
+
+    const nonPublicAsset = await t.context.server.inject({
+        method: 'GET',
+        headers: unauthenticatedHeaders,
+        url: `/v3/charts/${chart.result.id}/assets/${chart.result.id}.csv`
+    });
+    t.is(nonPublicAsset.statusCode, 403);
+
+    async function getAsset(asset) {
+        return t.context.server.inject({
+            method: 'GET',
+            headers,
+            url: `/v3/charts/${chart.result.id}/assets/${asset}`
+        });
+    }
+
+    async function putAsset(asset, data, contentType = 'text/csv') {
+        return t.context.server.inject({
+            method: 'PUT',
+            headers: {
+                ...headers,
+                'Content-Type': contentType
+            },
+            url: `/v3/charts/${chart.result.id}/assets/${asset}`,
+            payload: data
+        });
+    }
+});


### PR DESCRIPTION
Change authentication mode for `/charts/:id/assets/:asset` endpoint. 

Specifically, allow unauthenticated requests to the `:id.public.csv` asset. This asset is supposed to be publicly accessible, but at the moment, requires a valid session (regardless of to whom the session belongs). This breaks the 'Edit this chart' feature when somebody without _any_ Datawrapper session (e.g. incognito mode or guest) uses it from blog.datawrapper.de or our homepage.