### PR TITLE
Remove a condition that can never be true

### DIFF
--- a/src/routes/charts/{id}/data.js
+++ b/src/routes/charts/{id}/data.js
@@ -103,9 +103,6 @@ module.exports = (server, options) => {
             }
 
             if (chart.external_data && checkUrl(chart.external_data)) {
-                if (!checkUrl(chart.external_data))
-                    throw new Error('Unsupported external data URL');
-
                 try {
                     const data = (await got(chart.external_data)).body;
 


### PR DESCRIPTION
Look at the line above, it tests that `chartUrl(chart.external_data)` is truthy, so it can't be falsy again, if I'm not mistaken.