### PR TITLE
Allow empty strings in chart creation route

### DIFF
--- a/src/routes/charts/index.js
+++ b/src/routes/charts/index.js
@@ -74,7 +74,8 @@ module.exports = {
                             .example('My cool chart')
                             .description(
                                 'Title of your visualization. This will be the visualization headline.'
-                            ),
+                            )
+                            .allow(''),
                         theme: Joi.string()
                             .example('datawrapper')
                             .description('Chart theme to use.'),
@@ -111,24 +112,28 @@ module.exports = {
                                 transpose: Joi.boolean()
                             }).unknown(true),
                             describe: Joi.object({
-                                intro: Joi.string().description('The visualization description'),
-                                byline: Joi.string().description(
-                                    'Byline as shown in the visualization footer'
-                                ),
-                                'source-name': Joi.string().description(
-                                    'Source as shown in visualization footer'
-                                ),
-                                'source-url': Joi.string().description(
-                                    'Source URL as shown in visualization footer'
-                                ),
-                                'aria-description': Joi.string().description(
-                                    'Alternative description of visualization shown in screen readers (instead of the visualization)'
-                                )
+                                intro: Joi.string()
+                                    .description('The visualization description')
+                                    .allow(''),
+                                byline: Joi.string()
+                                    .description('Byline as shown in the visualization footer')
+                                    .allow(''),
+                                'source-name': Joi.string()
+                                    .description('Source as shown in visualization footer')
+                                    .allow(''),
+                                'source-url': Joi.string()
+                                    .description('Source URL as shown in visualization footer')
+                                    .allow(''),
+                                'aria-description': Joi.string()
+                                    .description(
+                                        'Alternative description of visualization shown in screen readers (instead of the visualization)'
+                                    )
+                                    .allow('')
                             }).unknown(true),
                             annotate: Joi.object({
-                                notes: Joi.string().description(
-                                    'Notes as shown underneath visualization'
-                                )
+                                notes: Joi.string()
+                                    .description('Notes as shown underneath visualization')
+                                    .allow('')
                             }).unknown(true),
                             publish: Joi.object(),
                             custom: Joi.object()

--- a/src/routes/charts/index.js
+++ b/src/routes/charts/index.js
@@ -105,9 +105,12 @@ module.exports = {
                             .max(4)
                             .description('Current position in chart editor workflow'),
                         metadata: Joi.object({
-                            axes: Joi.object().description(
-                                'Mapping of dataset columns to visualization "axes"'
-                            ),
+                            axes: Joi.alternatives().try(
+                                Joi.object().description(
+                                    'Mapping of dataset columns to visualization "axes"'
+                                ),
+                                Joi.array().length(0)
+                            ), // empty array can happen due to PHP's array->object confusion
                             data: Joi.object({
                                 transpose: Joi.boolean()
                             }).unknown(true),

--- a/src/routes/charts/index.js
+++ b/src/routes/charts/index.js
@@ -139,8 +139,7 @@ module.exports = {
                                     .allow('')
                             }).unknown(true),
                             publish: Joi.object(),
-                            custom: Joi.object(),
-                            authorId: Joi.number().optional()
+                            custom: Joi.object()
                         })
                             .description(
                                 'Metadata that saves all visualization specific settings and options.'
@@ -257,7 +256,7 @@ async function getAllCharts(request, h) {
 async function createChartHandler(request, h) {
     const { url, auth, payload, server } = request;
     const { session } = auth.credentials;
-    const isAdmin = server.methods.isAdmin(request);
+    const user = auth.artifacts;
 
     const newChart = {
         title: '',
@@ -267,11 +266,6 @@ async function createChartHandler(request, h) {
         teamId: payload ? payload.organizationId : undefined,
         metadata: payload && payload.metadata ? payload.metadata : { data: {} }
     };
-
-    let user = auth.artifacts;
-    if (isAdmin && payload.authorId) {
-        user = await User.findByPk(payload.authorId);
-    }
 
     const chart = await createChart({ server, user, payload: newChart, session });
 

--- a/src/routes/charts/index.test.js
+++ b/src/routes/charts/index.test.js
@@ -78,6 +78,37 @@ test('Users can create charts in a team they have access to', async t => {
     t.is(chart.statusCode, 201);
 });
 
+test('Users can create charts with settings set', async t => {
+    const { team, session } = await t.context.getTeamWithUser('member');
+
+    const chart = await t.context.server.inject({
+        method: 'POST',
+        url: '/v3/charts',
+        headers: {
+            cookie: `DW-SESSION=${session.id}; crumb=abc`,
+            'X-CSRF-Token': 'abc',
+            referer: 'http://localhost'
+        },
+        payload: {
+            organizationId: team.id,
+            title: 'My new visualization',
+            type: 'd3-bars',
+            metadata: {
+                describe: {
+                    intro: 'A description',
+                    byline: ''
+                }
+            }
+        }
+    });
+
+    t.is(chart.statusCode, 201);
+    t.is(chart.result.type, 'd3-bars');
+    t.is(chart.result.title, 'My new visualization');
+    t.is(chart.result.metadata.describe.intro, 'A description');
+    t.is(chart.result.metadata.describe.byline, '');
+});
+
 test('Users cannot create chart in a team they dont have access to', async t => {
     const { session } = await t.context.getUser();
     const { team } = await t.context.getTeamWithUser('member');

--- a/src/routes/charts/index.test.js
+++ b/src/routes/charts/index.test.js
@@ -94,6 +94,7 @@ test('Users can create charts with settings set', async t => {
             title: 'My new visualization',
             type: 'd3-bars',
             metadata: {
+                axes: [],
                 describe: {
                     intro: 'A description',
                     byline: ''

--- a/src/routes/charts/{id}/copy.test.js
+++ b/src/routes/charts/{id}/copy.test.js
@@ -72,9 +72,11 @@ test('User can copy chart, attributes match', async t => {
     t.is(allMetadata.result.externalData, attributes.externalData);
 
     // compare attributes
-    for (var attr in expectedAttributes) {
+    for (var attr in attributes) {
         if (attr === 'title') {
             t.is(copiedChart.result[attr], `${expectedAttributes[attr]} (Copy)`);
+        } else if (attr === 'metadata') {
+            t.is(copiedChart.result.metadata.visualize.basemap, 'us-counties');
         } else {
             t.deepEqual(copiedChart.result[attr], expectedAttributes[attr]);
         }


### PR DESCRIPTION
Otherwise, lots of chart tests can't be run (and of course, users might also want to do this)