### PR TITLE
folderId and teamId, not in_folder or organization_id

### DIFF
--- a/src/routes/charts/{id}/copy.js
+++ b/src/routes/charts/{id}/copy.js
@@ -65,7 +65,7 @@ module.exports = (server, options) => {
 
             if (isAdmin) {
                 newChart.teamId = null;
-                newChart.folerId = null;
+                newChart.folderId = null;
             }
 
             const chart = await createChart({ server, user, payload: newChart, session });

--- a/src/routes/charts/{id}/copy.js
+++ b/src/routes/charts/{id}/copy.js
@@ -64,8 +64,8 @@ module.exports = (server, options) => {
             };
 
             if (isAdmin) {
-                newChart.organization_id = null;
-                newChart.in_folder = null;
+                newChart.teamId = null;
+                newChart.folerId = null;
             }
 
             const chart = await createChart({ server, user, payload: newChart, session });

--- a/src/routes/charts/{id}/copy.js
+++ b/src/routes/charts/{id}/copy.js
@@ -53,8 +53,8 @@ module.exports = (server, options) => {
                 metadata: clone(srcChart.metadata),
                 theme: srcChart.theme,
                 language: srcChart.language,
-                organization_id: srcChart.organization_id,
-                in_folder: srcChart.in_folder,
+                teamId: srcChart.organization_id,
+                folderId: srcChart.in_folder,
                 external_data: srcChart.external_data,
 
                 forked_from: srcChart.id,
@@ -62,7 +62,6 @@ module.exports = (server, options) => {
 
                 last_edit_step: 3
             };
-
             if (isAdmin) {
                 newChart.organization_id = null;
                 newChart.in_folder = null;

--- a/src/routes/charts/{id}/copy.js
+++ b/src/routes/charts/{id}/copy.js
@@ -62,6 +62,7 @@ module.exports = (server, options) => {
 
                 last_edit_step: 3
             };
+
             if (isAdmin) {
                 newChart.organization_id = null;
                 newChart.in_folder = null;


### PR DESCRIPTION
Set folder id and organization in chart/{id}/copy payload as `createChart` expects, otherwise duplicates created in the app don't end up in the right place.