### PR TITLE
improve update-translation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,3 +212,23 @@ Some plugins register visualizations and provide static assets like JS and CSS t
 > **Note**: The process of updating only static files is not ideal and could cause inconsistent states in the API server. In practice this should not be a problem. 
 >
 > With our implementation of zero downtime API reloads, thanks to PM2, we should be able to programmatically trigger full plugin updates in the future. So far our special case for visualizations solves the problem.
+
+### Updating translations
+
+You can update the translations in `api` (and other services and plugins) by running
+
+```bash
+npm run update-translations
+```
+
+The script will only write translations to repositories which are up to date or ahead of their counterpart on Github. You can bypass this check by adding the `--no-git-check` flag:
+
+```bash
+npm run update-translations -- --no-git-check
+```
+
+If you only want to update translations for a certain part of Datawrapper you can use the `--prefix` flag:
+
+```bash
+npm run update-translations -- --prefix=plugins/d3-bars
+```

--- a/scripts/update-translations.js
+++ b/scripts/update-translations.js
@@ -247,7 +247,7 @@ async function commitNewTranslations() {
         } catch (answer) {
             if (answer && answer.toLowerCase() === 'y') {
                 // commit changes
-                const cmd = `git commit ${files.join(' ')} -m "l10n: update translations"`;
+                const cmd = `git commit -m "l10n: update translations" -- ${files.join(' ')}`;
                 const { stderr } = await exec(cmd, { cwd: repoPath, shell: true });
                 if (stderr) process.stderr.write(stderr);
                 else {

--- a/scripts/update-translations.js
+++ b/scripts/update-translations.js
@@ -204,7 +204,10 @@ async function writeTranslationsIfGitClean(file, translations) {
             cwd: repoPath,
             shell: true
         });
-        if (!gitStatus.includes('Your branch is up to date with')) {
+        if (
+            !gitStatus.includes('Your branch is up to date with') &&
+            !gitStatus.includes('Your branch is ahead of')
+        ) {
             process.stdout.write(chalk`
 {red ${repoName} is not clean, please run git pull before updating translations.}`);
             return;

--- a/scripts/update-translations.js
+++ b/scripts/update-translations.js
@@ -175,7 +175,7 @@ async function go() {
 }
 
 const gitFetchCache = new Set();
-const gitStatusCache = new Set();
+const gitStatusCache = new Map();
 const gitNewChanges = new Map();
 
 async function writeTranslationsIfGitClean(file, translations) {
@@ -204,16 +204,17 @@ async function writeTranslationsIfGitClean(file, translations) {
             cwd: repoPath,
             shell: true
         });
-        if (
-            !gitStatus.includes('Your branch is up to date with') &&
-            !gitStatus.includes('Your branch is ahead of')
-        ) {
-            process.stdout.write(chalk`
-{red ${repoName} is not clean, please run git pull before updating translations.}`);
-            return;
-        }
-        gitStatusCache.add(repoPath);
+        gitStatusCache.set(repoPath, gitStatus);
     }
+    if (
+        !gitStatusCache.get(repoPath).includes('Your branch is up to date with') &&
+        !gitStatusCache.get(repoPath).includes('Your branch is ahead of')
+    ) {
+        process.stdout.write(chalk`
+{red ${repoName} is not clean, please run git pull before updating translations.}`);
+        return;
+    }
+
     await writeFile(file, JSON.stringify(translations, null, 2));
     if (!gitNewChanges.has(repoPath)) {
         gitNewChanges.set(repoPath, []);


### PR DESCRIPTION
* compare remote translation with local translations and only log if something has changed
* if translations have changed check if the corresponding repo is up to date or ahead of `origin` first. If it's not, we don't write the new translations (since they are likely already on `origin`).
* if the repo is clean or ahead, we write the translations (and log the `Updated translations for ...` message)
* at the end of the script we ask the user if they want to commit the changed translation files