### PR TITLE
update-translations - take fallback translation from same language alternative if present

### DIFF
--- a/scripts/update-translations.js
+++ b/scripts/update-translations.js
@@ -153,7 +153,18 @@ async function downloadVisualizationTranslations() {
                     typeof plugins[plugin][locale][key] === 'undefined' ||
                     plugins[plugin][locale][key].trim() === ''
                 ) {
-                    plugins[plugin][locale][key] = plugins[plugin]['en-US'][key];
+                    const alternatives = Object.keys(plugins[plugin]).filter(d => {
+                        return (
+                            d !== locale &&
+                            d.split('-')[0] === locale.split('-')[0] &&
+                            plugins[plugin][d][key]
+                        );
+                    });
+                    if (alternatives.length) {
+                        plugins[plugin][locale][key] = plugins[plugin][alternatives[0]][key];
+                    } else {
+                        plugins[plugin][locale][key] = plugins[plugin]['en-US'][key];
+                    }
                 }
             }
         }

--- a/scripts/update-translations.js
+++ b/scripts/update-translations.js
@@ -153,18 +153,11 @@ async function downloadVisualizationTranslations() {
                     typeof plugins[plugin][locale][key] === 'undefined' ||
                     plugins[plugin][locale][key].trim() === ''
                 ) {
-                    const alternatives = Object.keys(plugins[plugin]).filter(d => {
-                        return (
-                            d !== locale &&
-                            d.split('-')[0] === locale.split('-')[0] &&
-                            plugins[plugin][d][key]
-                        );
-                    });
-                    if (alternatives.length) {
-                        plugins[plugin][locale][key] = plugins[plugin][alternatives[0]][key];
-                    } else {
-                        plugins[plugin][locale][key] = plugins[plugin]['en-US'][key];
-                    }
+                    const language = locale.split('-')[0];
+                    const alternative = Object.keys(plugins[plugin]).find(
+                        d => d !== locale && d.split('-')[0] === language && plugins[plugin][d][key]
+                    );
+                    plugins[plugin][locale][key] = plugins[plugin][alternative || 'en-US'][key];
                 }
             }
         }


### PR DESCRIPTION
The current script will populate any missing translations with the `en-US` translation as a fallback.

That's not ideal because some languages have multiple locales, where only one actually has the translations (e.g `pt-PT` & `pt-BR`), if there's a translation available from another locale of the same language, that should be taken preferentially to the english fallback.