### PR TITLE
pass the token to createChart, add test for this case

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@datawrapper/locales": "^1.2.4",
                 "@datawrapper/orm": "^3.22.4",
                 "@datawrapper/schemas": "^1.12.0",
-                "@datawrapper/service-utils": "^1.0.1",
+                "@datawrapper/service-utils": "^1.0.2",
                 "@hapi/boom": "^9.1.2",
                 "@hapi/catbox-memory": "^5.0.1",
                 "@hapi/catbox-redis": "^6.0.2",
@@ -537,9 +537,9 @@
             }
         },
         "node_modules/@datawrapper/service-utils": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@datawrapper/service-utils/-/service-utils-1.0.1.tgz",
-            "integrity": "sha512-onkLzFxlUxlkueQ+9/202KWHrd/eD6+UV2/NcSesdhH+mrKPSdGbTpYHOsBxTJ7gOFYGXdGZ/vyfNsemGIbyZA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@datawrapper/service-utils/-/service-utils-1.0.2.tgz",
+            "integrity": "sha512-T1lhRUtHC4NUTm1lM52WeeytJl8BLD9yv8ZXZ9I9MhF0xdht0X8ptlxmAJaAFK1p1kvv4tMWQyz+i5youSzW3Q==",
             "dependencies": {
                 "@hapi/boom": "^9.1.0",
                 "assign-deep": "^1.0.1",
@@ -10672,9 +10672,9 @@
             }
         },
         "@datawrapper/service-utils": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@datawrapper/service-utils/-/service-utils-1.0.1.tgz",
-            "integrity": "sha512-onkLzFxlUxlkueQ+9/202KWHrd/eD6+UV2/NcSesdhH+mrKPSdGbTpYHOsBxTJ7gOFYGXdGZ/vyfNsemGIbyZA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@datawrapper/service-utils/-/service-utils-1.0.2.tgz",
+            "integrity": "sha512-T1lhRUtHC4NUTm1lM52WeeytJl8BLD9yv8ZXZ9I9MhF0xdht0X8ptlxmAJaAFK1p1kvv4tMWQyz+i5youSzW3Q==",
             "requires": {
                 "@hapi/boom": "^9.1.0",
                 "assign-deep": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
         "@datawrapper/locales": "^1.2.4",
         "@datawrapper/orm": "^3.22.4",
         "@datawrapper/schemas": "^1.12.0",
-        "@datawrapper/service-utils": "^1.0.1",
+        "@datawrapper/service-utils": "^1.0.2",
         "@hapi/boom": "^9.1.2",
         "@hapi/catbox-memory": "^5.0.1",
         "@hapi/catbox-redis": "^6.0.2",

--- a/src/routes/charts/index.js
+++ b/src/routes/charts/index.js
@@ -255,7 +255,7 @@ async function getAllCharts(request, h) {
 
 async function createChartHandler(request, h) {
     const { url, auth, payload, server } = request;
-    const { session } = auth.credentials;
+    const { session, token } = auth.credentials;
     const user = auth.artifacts;
 
     const newChart = {
@@ -266,8 +266,7 @@ async function createChartHandler(request, h) {
         teamId: payload ? payload.organizationId : undefined,
         metadata: payload && payload.metadata ? payload.metadata : { data: {} }
     };
-
-    const chart = await createChart({ server, user, payload: newChart, session });
+    const chart = await createChart({ server, user, payload: newChart, session, token });
 
     // log chart/edit
     await request.server.methods.logAction(auth.artifacts.id, `chart/edit`, chart.id);

--- a/src/routes/charts/index.test.js
+++ b/src/routes/charts/index.test.js
@@ -111,6 +111,27 @@ test('Users can create charts with settings set', async t => {
     t.is(chart.result.metadata.describe.byline, '');
 });
 
+test('Users can create a chart in a team when authenticating with a token', async t => {
+    const { team, token } = await t.context.getTeamWithUser('member');
+
+    const chart = await t.context.server.inject({
+        method: 'POST',
+        url: '/v3/charts',
+        headers: {
+            Authorization: `Bearer ${token}`
+        },
+        payload: {
+            organizationId: team.id,
+            title: 'My new visualization',
+            type: 'd3-bars'
+        }
+    });
+    t.is(chart.statusCode, 201);
+    t.is(chart.result.type, 'd3-bars');
+    t.is(chart.result.title, 'My new visualization');
+    t.is(chart.result.organizationId, team.id);
+});
+
 test('Users cannot create chart in a team they dont have access to', async t => {
     const { session } = await t.context.getUser();
     const { team } = await t.context.getTeamWithUser('member');

--- a/src/routes/charts/index.test.js
+++ b/src/routes/charts/index.test.js
@@ -132,6 +132,24 @@ test('Users can create a chart in a team when authenticating with a token', asyn
     t.is(chart.result.organizationId, team.id);
 });
 
+test('Users cannot create a chart with an invalid token', async t => {
+    const { team } = await t.context.getTeamWithUser('member');
+
+    const chart = await t.context.server.inject({
+        method: 'POST',
+        url: '/v3/charts',
+        headers: {
+            Authorization: `Bearer XXXXXXXXX`
+        },
+        payload: {
+            organizationId: team.id,
+            title: 'My new visualization',
+            type: 'd3-bars'
+        }
+    });
+    t.is(chart.statusCode, 401);
+});
+
 test('Users cannot create chart in a team they dont have access to', async t => {
     const { session } = await t.context.getUser();
     const { team } = await t.context.getTeamWithUser('member');

--- a/src/routes/charts/index.test.js
+++ b/src/routes/charts/index.test.js
@@ -150,7 +150,25 @@ test('Users cannot create a chart with an invalid token', async t => {
     t.is(chart.statusCode, 401);
 });
 
-test('Users cannot create chart in a team they dont have access to', async t => {
+test('Users cannot create chart in a team they dont have access to (token auth)', async t => {
+    const { token } = await t.context.getUser();
+    const { team } = await t.context.getTeamWithUser('member');
+
+    const chart = await t.context.server.inject({
+        method: 'POST',
+        url: '/v3/charts',
+        headers: {
+            Authorization: `Bearer ${token}`
+        },
+        payload: {
+            organizationId: team.id
+        }
+    });
+
+    t.is(chart.statusCode, 403);
+});
+
+test('Users cannot create chart in a team they dont have access to (session auth)', async t => {
     const { session } = await t.context.getUser();
     const { team } = await t.context.getTeamWithUser('member');
 

--- a/test/helpers/setup.js
+++ b/test/helpers/setup.js
@@ -107,7 +107,7 @@ async function setup(options) {
         });
 
         const [team, userData] = await Promise.all([teamPromise, getUser()]);
-        const { user, session } = userData;
+        const { user, session, token } = userData;
 
         await models.UserTeam.create({
             user_id: user.id,
@@ -134,7 +134,7 @@ async function setup(options) {
 
         session.scope = allScopes;
 
-        return { team, user, session, addUser };
+        return { team, user, session, token, addUser };
     }
 
     async function createTheme(themeData) {


### PR DESCRIPTION
Currently `createChart` uses the `session` to determine if/what `organizationId` and `folderId` should be applied to the newly created chart. That logic should also hold when there's a token, so that also needs to be passed to the createChart function.

Also added a test for the case of a user creating a chart in a team via API

Full fix (and test passing) depends on [service-utils PR](https://github.com/datawrapper/service-utils/pull/19)