### PR TITLE
Fix error & error logging

### DIFF
--- a/src/plugin-loader.js
+++ b/src/plugin-loader.js
@@ -43,7 +43,8 @@ module.exports = {
         if (plugins.length) {
             for (const [{ plugin, options, error, name }, pluginOptions] of plugins) {
                 if (error) {
-                    server.logger.warn(`[Plugin] ${name}`, logError(root, name, error));
+                    server.logger.warn(`[Plugin] ${name}\n\n${logError(root, name, error)}`);
+                    server.logger.warn(error);
                 } else {
                     const version = get(plugin, ['pkg', 'version'], plugin.version);
                     server.logger.info(`[Plugin] ${name}@${version}`);

--- a/src/routes/folders.js
+++ b/src/routes/folders.js
@@ -72,9 +72,11 @@ const routes = [
                     arr.push({
                         id: folder.id,
                         name: folder.name,
-                        charts: await Chart.findAll({
-                            where: { in_folder: folder.id, deleted: false }
-                        }).map(cleanChart),
+                        charts: (
+                            await Chart.findAll({
+                                where: { in_folder: folder.id, deleted: false }
+                            })
+                        ).map(cleanChart),
                         folders: await getFolders(by, owner, folder.id)
                     });
                 }


### PR DESCRIPTION
Following the recent `hapi` upgrade, `server.logger` functions only accept a single parameter, so we need to change our plugin error logging a bit

Also fixing a bug where a `map` function was applied on a promise rather than its return value.