### PR TITLE
Refresh external data before calling CHART_PUBLISHED hook

### DIFF
--- a/src/routes/charts/{id}/publish.js
+++ b/src/routes/charts/{id}/publish.js
@@ -7,7 +7,11 @@ const set = require('lodash/set');
 const { prepareChart } = require('../../../utils/index.js');
 const { Op } = require('@datawrapper/orm').db;
 const { getScope } = require('@datawrapper/service-utils/l10n');
+const { findConfigPath } = require('@datawrapper/service-utils/findConfig');
 const { getEmbedCodes } = require('./utils');
+
+const configPath = findConfigPath();
+const config = require(configPath);
 
 module.exports = (server, options) => {
     // POST /v3/charts/{id}/publish
@@ -204,8 +208,8 @@ async function publishChart(request, h) {
     // log action that chart has been published
     await request.server.methods.logAction(user.id, `chart/publish`, chart.id);
 
-    // refresh external data
-    if (!headers.origin) {
+    // refresh external data if request isn't coming from the app
+    if (headers.origin !== `http${config.frontend.https ? 's' : ''}://${config.frontend.domain}`) {
         try {
             await server.inject({
                 url: `/v3/charts/${chart.id}/data/refresh`,

--- a/src/routes/charts/{id}/publish.js
+++ b/src/routes/charts/{id}/publish.js
@@ -204,6 +204,18 @@ async function publishChart(request, h) {
     // log action that chart has been published
     await request.server.methods.logAction(user.id, `chart/publish`, chart.id);
 
+    // refresh external data
+    if (!headers.origin) {
+        try {
+            await server.inject({
+                url: `/v3/charts/${chart.id}/data/refresh`,
+                method: 'POST',
+                auth,
+                headers
+            });
+        } catch (ex) {}
+    }
+
     // for image publishing and things that we want to (optionally)
     // make the user wait for and/or inform about in publish UI
     await server.app.events.emit(server.app.event.CHART_PUBLISHED, {


### PR DESCRIPTION
This ensures that the the image publishing images have the latest preview data, when publish is done externally via the API (rather than the app, where refreshing happens automatically when in the editor)

This is the analogue of what we do before export in the /export endpoint:

https://github.com/datawrapper/api/blob/0033b1c215cacc54a2d8eda34853a2dbfae19b7f/src/routes/charts/%7Bid%7D/export.js#L108-L118
