### PR TITLE
Chart export: Throw `badRequest` when no plugins returns an exported chart

### DIFF
--- a/src/routes/charts/{id}/export.js
+++ b/src/routes/charts/{id}/export.js
@@ -130,7 +130,7 @@ async function exportChart(request, h) {
             })
         ).find(res => res.status === 'success' && res.data);
 
-        if (!result) return Boom.badImplementation();
+        if (!result) return Boom.badRequest();
 
         await request.server.methods.logAction(user.id, `chart/export/${params.format}`, params.id);
 
@@ -151,6 +151,7 @@ async function exportChart(request, h) {
             // this seems to be an orderly error
             return Boom[error.code](error.message);
         }
+
         // this is an unexpected error, so let's log it
         request.logger.error(error);
         return Boom.badImplementation();

--- a/src/routes/charts/{id}/export.test.js
+++ b/src/routes/charts/{id}/export.test.js
@@ -1,0 +1,47 @@
+const test = require('ava');
+const { createUser, destroy, setup } = require('../../../../test/helpers/setup');
+
+test.before(async t => {
+    t.context.server = await setup({ usePlugins: false });
+    t.context.userObj = await createUser(t.context.server, 'admin');
+    t.context.auth = {
+        strategy: 'session',
+        credentials: t.context.userObj.session,
+        artifacts: t.context.userObj.user
+    };
+});
+
+test.after.always(async t => {
+    await destroy(...Object.values(t.context.userObj));
+});
+
+test('Invalid export format returns 400', async t => {
+    // create a new chart
+    let res = await t.context.server.inject({
+        method: 'POST',
+        url: '/v3/charts',
+        headers: {
+            cookie: `DW-SESSION=${t.context.auth.credentials.id}; crumb=abc`,
+            'X-CSRF-Token': 'abc',
+            referer: 'http://localhost'
+        },
+        payload: {}
+    });
+    const chart = res.result;
+    t.is(res.statusCode, 201);
+
+    // lets get a geojson of this
+    res = await t.context.server.inject({
+        method: 'POST',
+        url: `/v3/charts/${chart.id}/export/geojson`,
+        headers: {
+            cookie: `DW-SESSION=${t.context.auth.credentials.id}; crumb=abc`,
+            'X-CSRF-Token': 'abc',
+            referer: 'http://localhost'
+        },
+        payload: {}
+    });
+
+    // this should be a Bad Request
+    t.is(res.statusCode, 400);
+});


### PR DESCRIPTION
When there's no successful response from any plugin, this is because no export plugin supports the requested format for that visualization. For this scenario, a `badRequest` seems to be appropriate. This is considered an 'orderly' error and not explicitly logged. An exception during exporting would still trigger the code path that logs the error.