### PR TITLE
Prevent publicVersion in payload from setting version behind true publicVersion

### DIFF
--- a/src/routes/charts/{id}/index.js
+++ b/src/routes/charts/{id}/index.js
@@ -4,6 +4,7 @@ const ReadonlyChart = require('@datawrapper/orm/models/ReadonlyChart');
 const { Op } = require('@datawrapper/orm').db;
 const { Chart, ChartPublic, User, Folder } = require('@datawrapper/orm/models');
 const set = require('lodash/set');
+const get = require('lodash/get');
 const assignWithEmptyObjects = require('../../../utils/assignWithEmptyObjects');
 const { decamelizeKeys } = require('humps');
 const { getAdditionalMetadata, prepareChart } = require('../../../utils/index.js');
@@ -279,6 +280,11 @@ async function editChart(request, h) {
         payload.publicUrl = chart.public_url;
         payload.publishedAt = chart.published_at;
         payload.lastEditStep = chart.last_edit_step;
+        set(
+            payload,
+            'metadata.publish.embed-codes',
+            get(chart, 'metadata.publish.embed-codes', {})
+        );
     }
 
     const newData = assignWithEmptyObjects(await prepareChart(chart), payload);

--- a/src/routes/charts/{id}/index.js
+++ b/src/routes/charts/{id}/index.js
@@ -273,6 +273,11 @@ async function editChart(request, h) {
         delete payload.isFork;
     }
 
+    // prevent publicVersion from being 'reverted back' from true publicVersion
+    if (!isNaN(payload.publicVersion) && payload.publicVersion < chart.public_version) {
+        payload.publicVersion = chart.public_version;
+    }
+
     const newData = assignWithEmptyObjects(await prepareChart(chart), payload);
 
     if (request.method === 'put' && payload.metadata) {

--- a/src/routes/charts/{id}/index.js
+++ b/src/routes/charts/{id}/index.js
@@ -273,9 +273,12 @@ async function editChart(request, h) {
         delete payload.isFork;
     }
 
-    // prevent publicVersion from being 'reverted back' from true publicVersion
+    // prevent information about earlier publish from being reverted
     if (!isNaN(payload.publicVersion) && payload.publicVersion < chart.public_version) {
         payload.publicVersion = chart.public_version;
+        payload.publicUrl = chart.public_url;
+        payload.publishedAt = chart.published_at;
+        payload.lastEditStep = chart.last_edit_step;
     }
 
     const newData = assignWithEmptyObjects(await prepareChart(chart), payload);


### PR DESCRIPTION
### Motivation
**Fix for this scenario:**
- You're working on a chart
- You open the publish step in a new tab
- You publish, the publicVersion gets incremented (e.g from 2->3)
- You go back to your other tab, that's still in the visualize step - this page hasn't been reloaded so it doesn't 'know' about the true publicVersion, and still 'thinks' it's 2
- You make a change
- A PUT request overwrites the true publicVersion (3), with the former one (2)
- You go to the publish step, and republish, effectively publishing to /3 again
- Because /3 was already published, caching logic doesn't work, and you don't see your changes in the published chart

### Changes
If publicVersion is included in the payload, don't let it be lower than the true current publicVersion