### PR TITLE
Hotfix: don't require visualization:read for styles.css

### DIFF
--- a/src/routes/visualizations.js
+++ b/src/routes/visualizations.js
@@ -56,8 +56,7 @@ async function register(server, options) {
         path: '/{id}/styles.css',
         options: {
             auth: {
-                mode: 'try',
-                access: { scope: ['visualization:read'] }
+                mode: 'try'
             },
             validate: {
                 query: Joi.object({


### PR DESCRIPTION
Otherwise, it becomes an implicit requirement of `POST chart/:id/publish`, which uses this endpoint under the hood but currently only needs `chart:write`