### PR TITLE
Ensure that theme fonts are included in publishData

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "2.9.0",
             "license": "UNLICENSED",
             "dependencies": {
-                "@datawrapper/chart-core": "^8.36.1",
+                "@datawrapper/chart-core": "^8.36.2",
                 "@datawrapper/locales": "^1.2.6",
                 "@datawrapper/orm": "^3.25.0",
                 "@datawrapper/schemas": "^1.12.0",
@@ -405,9 +405,9 @@
             }
         },
         "node_modules/@datawrapper/chart-core": {
-            "version": "8.36.1",
-            "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-8.36.1.tgz",
-            "integrity": "sha512-bmh8oM4OS2hTvhjWV29m9ExqoH89jbuyqtaP5vYTmMTz6gA/FVzY/t9PpwVj5nJbhv9ejduGTFR7xB0j6mbvuw==",
+            "version": "8.36.2",
+            "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-8.36.2.tgz",
+            "integrity": "sha512-kzFUX+0b4oSro5cqV2gl4KzuMp/F/ehoKsoyDC8R+2qdJT6mz9EJ2CJnmucKnCLz4WFvxutFHGiDriawzanueA==",
             "dependencies": {
                 "@datawrapper/expr-eval": "^2.0.4",
                 "@datawrapper/polyfills": "2.1.1",
@@ -11481,9 +11481,9 @@
             }
         },
         "@datawrapper/chart-core": {
-            "version": "8.36.1",
-            "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-8.36.1.tgz",
-            "integrity": "sha512-bmh8oM4OS2hTvhjWV29m9ExqoH89jbuyqtaP5vYTmMTz6gA/FVzY/t9PpwVj5nJbhv9ejduGTFR7xB0j6mbvuw==",
+            "version": "8.36.2",
+            "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-8.36.2.tgz",
+            "integrity": "sha512-kzFUX+0b4oSro5cqV2gl4KzuMp/F/ehoKsoyDC8R+2qdJT6mz9EJ2CJnmucKnCLz4WFvxutFHGiDriawzanueA==",
             "requires": {
                 "@datawrapper/expr-eval": "^2.0.4",
                 "@datawrapper/polyfills": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "url": "git+https://github.com/datawrapper/datawrapper-api.git"
     },
     "dependencies": {
-        "@datawrapper/chart-core": "^8.36.1",
+        "@datawrapper/chart-core": "^8.36.2",
         "@datawrapper/locales": "^1.2.6",
         "@datawrapper/orm": "^3.25.0",
         "@datawrapper/schemas": "^1.12.0",

--- a/src/routes/charts/{id}/publish.js
+++ b/src/routes/charts/{id}/publish.js
@@ -338,10 +338,11 @@ async function publishData(request, h) {
 
     // the theme
     const theme = await Theme.findByPk(themeId);
+    const themeFonts = await theme.getAssetFonts();
     data.theme = {
         id: theme.id,
         data: await theme.getMergedData(),
-        fonts: theme.fonts
+        fonts: themeFonts
     };
 
     // the styles

--- a/src/routes/charts/{id}/publish.js
+++ b/src/routes/charts/{id}/publish.js
@@ -341,7 +341,7 @@ async function publishData(request, h) {
     data.theme = {
         id: theme.id,
         data: await theme.getMergedData(),
-        fonts: await theme.getAssetFonts()
+        fonts: await theme.getMergedAssets()
     };
 
     // the styles

--- a/src/routes/charts/{id}/publish.js
+++ b/src/routes/charts/{id}/publish.js
@@ -338,11 +338,10 @@ async function publishData(request, h) {
 
     // the theme
     const theme = await Theme.findByPk(themeId);
-    const themeFonts = await theme.getAssetFonts();
     data.theme = {
         id: theme.id,
         data: await theme.getMergedData(),
-        fonts: themeFonts
+        fonts: await theme.getAssetFonts()
     };
 
     // the styles


### PR DESCRIPTION
I'm not sure how this was implemented before, but in any case `theme.fonts` is not included in the theme data. This means that later on in `chart-core`, we don't actually have the fonts for `observeFonts`, or for setting on the `window`, to later be used in pdf export.

https://github.com/datawrapper/api/blob/a5be32b556153d07aaf1970e176e33f2d71fa8f8/src/routes/charts/%7Bid%7D/publish.js#L340-L345

That ensures that the chart has access to the fonts, although chart-core expects fonts as a top level on the `__DW_SVELTE_PROPS__`. Not sure which was the intended behavior, so I followed what was here and made the corresponding changes in chart-core in [datawrapper/chart-core#146](https://github.com/datawrapper/chart-core/pull/146)