### PR TITLE
Provide information if filename contains hash during publication

### DIFF
--- a/src/publish/create-chart-website.js
+++ b/src/publish/create-chart-website.js
@@ -228,14 +228,22 @@ module.exports = async function createChartWebsite(
     );
 
     const fileMap = [
-        ...dependencies,
-        ...polyfillFiles,
-        ...blocksFiles,
-        ...assetsFiles,
-        path.join('lib/', polyfillScript),
-        path.join('lib/', coreScript),
-        'index.html',
-        dataFile
+        ...dependencies.map(path => {
+            return { path, hashed: true };
+        }),
+        ...polyfillFiles.map(path => {
+            return { path, hashed: false };
+        }),
+        ...blocksFiles.map(path => {
+            return { path, hashed: true };
+        }),
+        ...assetsFiles.map(path => {
+            return { path, hashed: true };
+        }),
+        { path: path.join('lib/', polyfillScript), hashed: true },
+        { path: path.join('lib/', coreScript), hashed: true },
+        { path: 'index.html', hashed: false },
+        { path: dataFile, hashed: false }
     ];
 
     async function cleanup() {

--- a/src/server.js
+++ b/src/server.js
@@ -345,8 +345,8 @@ async function configure(options = { usePlugins: true, useOpenAPI: true }) {
                 );
             } else {
                 for (const file of fileMap) {
-                    const basename = path.basename(file);
-                    const dir = path.dirname(file);
+                    const basename = path.basename(file.path);
+                    const dir = path.dirname(file.path);
 
                     const out =
                         dir === '.'


### PR DESCRIPTION
Certain assets (like most JS and CSS files) are provided by us including a hash of the contents in the filename. This is useful, because it ensures that when the content of the asset changes, we load it from a new URL, so we are 100% sure the contents of the file remain unchanged.

This is different from files like `index.html`, which might change (i.e when republishing and they get overwritten with redirects). This PR changes it so that the information about which files are 'hashed' and which aren't is provided in the `PUBLISH_CHART` event, so that plugins can take appropriate measures (such as serving different cache headers)