### PR TITLE
Split out stylesheet into its own file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,12 +83,14 @@
         "node_modules/@babel/compat-data": {
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.4.tgz",
-            "integrity": "sha512-i2wXrWQNkH6JplJQGn3Rd2I4Pij8GdHkXwHMxm+zV5YG/Jci+bCNrWZEWC4o+umiDkRrRs4dVzH3X4GP7vyjQQ=="
+            "integrity": "sha512-i2wXrWQNkH6JplJQGn3Rd2I4Pij8GdHkXwHMxm+zV5YG/Jci+bCNrWZEWC4o+umiDkRrRs4dVzH3X4GP7vyjQQ==",
+            "dev": true
         },
         "node_modules/@babel/core": {
             "version": "7.14.3",
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.3.tgz",
             "integrity": "sha512-jB5AmTKOCSJIZ72sd78ECEhuPiDMKlQdDI/4QRI6lzYATx5SSogS1oQA2AoPecRCknm30gHi2l+QVvNUu3wZAg==",
+            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/generator": "^7.14.3",
@@ -118,6 +120,7 @@
             "version": "7.14.3",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.3.tgz",
             "integrity": "sha512-bn0S6flG/j0xtQdz3hsjJ624h3W0r3llttBMfyHX3YrZ/KtLYr15bjA0FXkgW7FpvrDuTuElXeVjiKlYRpnOFA==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.14.2",
                 "jsesc": "^2.5.1",
@@ -128,6 +131,7 @@
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
             "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+            "dev": true,
             "bin": {
                 "jsesc": "bin/jsesc"
             },
@@ -139,6 +143,7 @@
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.4.tgz",
             "integrity": "sha512-JgdzOYZ/qGaKTVkn5qEDV/SXAh8KcyUVkCoSWGN8T3bwrgd6m+/dJa2kVGi6RJYJgEYPBdZ84BZp9dUjNWkBaA==",
+            "dev": true,
             "dependencies": {
                 "@babel/compat-data": "^7.14.4",
                 "@babel/helper-validator-option": "^7.12.17",
@@ -153,6 +158,7 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.2.tgz",
             "integrity": "sha512-NYZlkZRydxw+YT56IlhIcS8PAhb+FEUiOzuhFTfqDyPmzAhRge6ua0dQYT/Uh0t/EDHq05/i+e5M2d4XvjgarQ==",
+            "dev": true,
             "dependencies": {
                 "@babel/helper-get-function-arity": "^7.12.13",
                 "@babel/template": "^7.12.13",
@@ -163,6 +169,7 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
             "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.12.13"
             }
@@ -171,6 +178,7 @@
             "version": "7.13.12",
             "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
             "integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.13.12"
             }
@@ -187,6 +195,7 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.2.tgz",
             "integrity": "sha512-OznJUda/soKXv0XhpvzGWDnml4Qnwp16GN+D/kZIdLsWoHj05kyu8Rm5kXmMef+rVJZ0+4pSGLkeixdqNUATDA==",
+            "dev": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.13.12",
                 "@babel/helper-replace-supers": "^7.13.12",
@@ -202,6 +211,7 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
             "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.12.13"
             }
@@ -215,6 +225,7 @@
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.4.tgz",
             "integrity": "sha512-zZ7uHCWlxfEAAOVDYQpEf/uyi1dmeC7fX4nCf2iz9drnCwi1zvwXL3HwWWNXUQEJ1k23yVn3VbddiI9iJEXaTQ==",
+            "dev": true,
             "dependencies": {
                 "@babel/helper-member-expression-to-functions": "^7.13.12",
                 "@babel/helper-optimise-call-expression": "^7.12.13",
@@ -226,6 +237,7 @@
             "version": "7.13.12",
             "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
             "integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.13.12"
             }
@@ -234,6 +246,7 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
             "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.12.13"
             }
@@ -246,12 +259,14 @@
         "node_modules/@babel/helper-validator-option": {
             "version": "7.12.17",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
-            "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw=="
+            "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
+            "dev": true
         },
         "node_modules/@babel/helpers": {
             "version": "7.14.0",
             "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.0.tgz",
             "integrity": "sha512-+ufuXprtQ1D1iZTO/K9+EBRn+qPWMJjZSw/S0KlFrxCw4tkrzv9grgpDHkY9MeQTjTY8i2sp7Jep8DfU6tN9Mg==",
+            "dev": true,
             "dependencies": {
                 "@babel/template": "^7.12.13",
                 "@babel/traverse": "^7.14.0",
@@ -353,6 +368,7 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
             "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/parser": "^7.12.13",
@@ -363,6 +379,7 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.2.tgz",
             "integrity": "sha512-TsdRgvBFHMyHOOzcP9S6QU0QQtjxlRpEYOy3mcCO5RgmC305ki42aSAmfZEMSSYBla2oZ9BMqYlncBaKmD/7iA==",
+            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/generator": "^7.14.2",
@@ -1497,8 +1514,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.0.tgz",
             "integrity": "sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==",
             "dev": true,
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -1514,9 +1529,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/alphanum-sort": {
             "version": "1.0.2",
@@ -4522,6 +4535,7 @@
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
             "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+            "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -4640,6 +4654,7 @@
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -5984,6 +5999,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
             "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+            "dev": true,
             "dependencies": {
                 "minimist": "^1.2.5"
             },
@@ -9545,6 +9561,7 @@
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
             "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -10194,15 +10211,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/svelte": {
-            "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/svelte/-/svelte-2.16.1.tgz",
-            "integrity": "sha512-TpXdfukSkmWkMnH6PPVm7FRW8SSFcTyqBiP+6VN8rtZJ7Lp1Xbf/e3oz73eQBxF0UPZw1aAn1b91lX2XTeD3zg==",
-            "peer": true,
-            "bin": {
-                "svelte": "svelte"
             }
         },
         "node_modules/svelte-extras": {
@@ -11203,12 +11211,14 @@
         "@babel/compat-data": {
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.4.tgz",
-            "integrity": "sha512-i2wXrWQNkH6JplJQGn3Rd2I4Pij8GdHkXwHMxm+zV5YG/Jci+bCNrWZEWC4o+umiDkRrRs4dVzH3X4GP7vyjQQ=="
+            "integrity": "sha512-i2wXrWQNkH6JplJQGn3Rd2I4Pij8GdHkXwHMxm+zV5YG/Jci+bCNrWZEWC4o+umiDkRrRs4dVzH3X4GP7vyjQQ==",
+            "dev": true
         },
         "@babel/core": {
             "version": "7.14.3",
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.3.tgz",
             "integrity": "sha512-jB5AmTKOCSJIZ72sd78ECEhuPiDMKlQdDI/4QRI6lzYATx5SSogS1oQA2AoPecRCknm30gHi2l+QVvNUu3wZAg==",
+            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/generator": "^7.14.3",
@@ -11231,6 +11241,7 @@
             "version": "7.14.3",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.3.tgz",
             "integrity": "sha512-bn0S6flG/j0xtQdz3hsjJ624h3W0r3llttBMfyHX3YrZ/KtLYr15bjA0FXkgW7FpvrDuTuElXeVjiKlYRpnOFA==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.14.2",
                 "jsesc": "^2.5.1",
@@ -11240,7 +11251,8 @@
                 "jsesc": {
                     "version": "2.5.2",
                     "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+                    "dev": true
                 }
             }
         },
@@ -11248,6 +11260,7 @@
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.4.tgz",
             "integrity": "sha512-JgdzOYZ/qGaKTVkn5qEDV/SXAh8KcyUVkCoSWGN8T3bwrgd6m+/dJa2kVGi6RJYJgEYPBdZ84BZp9dUjNWkBaA==",
+            "dev": true,
             "requires": {
                 "@babel/compat-data": "^7.14.4",
                 "@babel/helper-validator-option": "^7.12.17",
@@ -11259,6 +11272,7 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.2.tgz",
             "integrity": "sha512-NYZlkZRydxw+YT56IlhIcS8PAhb+FEUiOzuhFTfqDyPmzAhRge6ua0dQYT/Uh0t/EDHq05/i+e5M2d4XvjgarQ==",
+            "dev": true,
             "requires": {
                 "@babel/helper-get-function-arity": "^7.12.13",
                 "@babel/template": "^7.12.13",
@@ -11269,6 +11283,7 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
             "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.12.13"
             }
@@ -11277,6 +11292,7 @@
             "version": "7.13.12",
             "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
             "integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.13.12"
             }
@@ -11293,6 +11309,7 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.2.tgz",
             "integrity": "sha512-OznJUda/soKXv0XhpvzGWDnml4Qnwp16GN+D/kZIdLsWoHj05kyu8Rm5kXmMef+rVJZ0+4pSGLkeixdqNUATDA==",
+            "dev": true,
             "requires": {
                 "@babel/helper-module-imports": "^7.13.12",
                 "@babel/helper-replace-supers": "^7.13.12",
@@ -11308,6 +11325,7 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
             "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.12.13"
             }
@@ -11321,6 +11339,7 @@
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.4.tgz",
             "integrity": "sha512-zZ7uHCWlxfEAAOVDYQpEf/uyi1dmeC7fX4nCf2iz9drnCwi1zvwXL3HwWWNXUQEJ1k23yVn3VbddiI9iJEXaTQ==",
+            "dev": true,
             "requires": {
                 "@babel/helper-member-expression-to-functions": "^7.13.12",
                 "@babel/helper-optimise-call-expression": "^7.12.13",
@@ -11332,6 +11351,7 @@
             "version": "7.13.12",
             "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
             "integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.13.12"
             }
@@ -11340,6 +11360,7 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
             "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.12.13"
             }
@@ -11352,12 +11373,14 @@
         "@babel/helper-validator-option": {
             "version": "7.12.17",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
-            "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw=="
+            "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
+            "dev": true
         },
         "@babel/helpers": {
             "version": "7.14.0",
             "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.0.tgz",
             "integrity": "sha512-+ufuXprtQ1D1iZTO/K9+EBRn+qPWMJjZSw/S0KlFrxCw4tkrzv9grgpDHkY9MeQTjTY8i2sp7Jep8DfU6tN9Mg==",
+            "dev": true,
             "requires": {
                 "@babel/template": "^7.12.13",
                 "@babel/traverse": "^7.14.0",
@@ -11437,6 +11460,7 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
             "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/parser": "^7.12.13",
@@ -11447,6 +11471,7 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.2.tgz",
             "integrity": "sha512-TsdRgvBFHMyHOOzcP9S6QU0QQtjxlRpEYOy3mcCO5RgmC305ki42aSAmfZEMSSYBla2oZ9BMqYlncBaKmD/7iA==",
+            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/generator": "^7.14.2",
@@ -12390,8 +12415,7 @@
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
             "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "acorn-walk": {
             "version": "8.1.0",
@@ -12426,14 +12450,15 @@
             "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.0.tgz",
             "integrity": "sha512-USH2jBb+C/hIpwD2iRjp0pe0k+MvzG0mlSn/FIdCgQhUb9ALPRjt2KIQdfZDS9r0ZIeUAg7gOu9KL0PFqGqr5Q==",
             "dev": true,
-            "requires": {},
+            "requires": {
+                "ajv": "^8.0.0"
+            },
             "dependencies": {
                 "ajv": {
-                    "version": "https://registry.npmjs.org/ajv/-/ajv-8.6.0.tgz",
+                    "version": "8.6.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.0.tgz",
                     "integrity": "sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==",
                     "dev": true,
-                    "optional": true,
-                    "peer": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "json-schema-traverse": "^1.0.0",
@@ -12445,9 +12470,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
                     "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true
+                    "dev": true
                 }
             }
         },
@@ -13532,8 +13555,7 @@
         "cssnano-utils": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-2.0.1.tgz",
-            "integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ==",
-            "requires": {}
+            "integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ=="
         },
         "csso": {
             "version": "4.2.0",
@@ -14053,15 +14075,13 @@
             "version": "14.1.1",
             "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz",
             "integrity": "sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-config-standard-jsx": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-8.1.0.tgz",
             "integrity": "sha512-ULVC8qH8qCqbU792ZOO6DaiaZyHNS/5CZt3hKqHkEhVlhPEPN3nfBqqxJCyp59XrjIBZPu1chMYe9T2DXZ7TMw==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-config-standard-react": {
             "version": "9.2.0",
@@ -14252,15 +14272,13 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
             "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-plugin-standard": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.1.0.tgz",
             "integrity": "sha512-ZL7+QRixjTR6/528YNGyDotyffm5OQst/sGxKDwGb9Uqs4In5Egi4+jbobhqJoyoCM6/7v/1A5fhQ7ScMtDjaQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-scope": {
             "version": "5.1.1",
@@ -14696,7 +14714,8 @@
         "gensync": {
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+            "dev": true
         },
         "get-caller-file": {
             "version": "2.0.5",
@@ -14775,7 +14794,8 @@
         "globals": {
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "dev": true
         },
         "globby": {
             "version": "11.0.3",
@@ -15748,6 +15768,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
             "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+            "dev": true,
             "requires": {
                 "minimist": "^1.2.5"
             }
@@ -17621,26 +17642,22 @@
         "postcss-discard-comments": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.1.tgz",
-            "integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg==",
-            "requires": {}
+            "integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg=="
         },
         "postcss-discard-duplicates": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.1.tgz",
-            "integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA==",
-            "requires": {}
+            "integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA=="
         },
         "postcss-discard-empty": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.0.1.tgz",
-            "integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw==",
-            "requires": {}
+            "integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw=="
         },
         "postcss-discard-overridden": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.1.tgz",
-            "integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q==",
-            "requires": {}
+            "integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q=="
         },
         "postcss-less": {
             "version": "4.0.1",
@@ -17714,8 +17731,7 @@
         "postcss-normalize-charset": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.0.1.tgz",
-            "integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg==",
-            "requires": {}
+            "integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg=="
         },
         "postcss-normalize-display-values": {
             "version": "5.0.1",
@@ -18441,7 +18457,8 @@
         "semver": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true
         },
         "semver-compare": {
             "version": "1.0.0",
@@ -18932,17 +18949,10 @@
                 "has-flag": "^4.0.0"
             }
         },
-        "svelte": {
-            "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/svelte/-/svelte-2.16.1.tgz",
-            "integrity": "sha512-TpXdfukSkmWkMnH6PPVm7FRW8SSFcTyqBiP+6VN8rtZJ7Lp1Xbf/e3oz73eQBxF0UPZw1aAn1b91lX2XTeD3zg==",
-            "peer": true
-        },
         "svelte-extras": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/svelte-extras/-/svelte-extras-2.0.2.tgz",
-            "integrity": "sha512-yoxNehbDxGEHxJBTWq2RpIPDTHlNNy6eGR7RPSK7qsh8hoyOXbji8uF//l4+I/l2fLP+E8pQTJYrduPXrW3wsw==",
-            "requires": {}
+            "integrity": "sha512-yoxNehbDxGEHxJBTWq2RpIPDTHlNNy6eGR7RPSK7qsh8hoyOXbji8uF//l4+I/l2fLP+E8pQTJYrduPXrW3wsw=="
         },
         "svelte2": {
             "version": "npm:svelte@2.16.1",

--- a/src/publish/create-chart-website.js
+++ b/src/publish/create-chart-website.js
@@ -181,6 +181,12 @@ module.exports = async function createChartWebsite(
     delete publishData.styles;
     delete publishData.theme.fontsCSS;
 
+    const cssFile = await writeFileHashed(
+        `${chart.type}.${chart.theme}.css`,
+        `${fonts}\n${css}`,
+        outDir
+    );
+
     /**
      * Render the visualizations entry: "index.html"
      */
@@ -192,7 +198,7 @@ module.exports = async function createChartWebsite(
         CHART_HEAD: head,
         POLYFILL_SCRIPT: getAssetLink(`../../lib/${polyfillScript}`),
         CORE_SCRIPT: getAssetLink(`../../lib/${coreScript}`),
-        CSS: `${fonts}\n${css}`,
+        CSS: `../../lib/vis/${cssFile}`,
         SCRIPTS: dependencies.map(file => getAssetLink(`../../${file}`)),
         CHART_CLASS: [
             `vis-height-${get(publishData.visualization, 'height', 'fit')}`,
@@ -242,6 +248,7 @@ module.exports = async function createChartWebsite(
         }),
         { path: path.join('lib/', polyfillScript), hashed: true },
         { path: path.join('lib/', coreScript), hashed: true },
+        { path: path.join('lib/vis', cssFile), hashed: true },
         { path: 'index.html', hashed: false },
         { path: dataFile, hashed: false }
     ];

--- a/src/publish/index.pug
+++ b/src/publish/index.pug
@@ -4,7 +4,7 @@ html(lang=CHART_LANGUAGE)
     meta(charset="UTF-8")
     meta(name="robots", content=META_ROBOTS)
     meta(name="viewport", content="width=device-width, initial-scale=1.0")
-    style!=CSS
+    link(rel="stylesheet", href!=CSS)
     | !{CHART_HEAD}
 
   body


### PR DESCRIPTION
This PR brings back an old performance optimization by serving the chart styles from a separate CSS file. The file is stored in `lib/vis` and follows the `${chart.type}.${chart.theme}.${hash}.css` naming schema. Here's a published [test visualization](https://self-hosting-test.s3.amazonaws.com/local-david/30bOS/4/index.html).

Making `index.html` as small as possible is beneficial since it allows us to do more fine-grained caching. This [issue](https://www.notion.so/datawrapper/Use-separate-file-for-CSS-styles-c543804ebec54038bf2dc3bab1716d8c) has also been on the web component backlog