### PR TITLE
Don't bake assets into HTML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "2.9.0",
             "license": "UNLICENSED",
             "dependencies": {
-                "@datawrapper/chart-core": "^8.39.1",
+                "@datawrapper/chart-core": "^8.39.2",
                 "@datawrapper/locales": "^1.2.6",
                 "@datawrapper/orm": "^3.25.0",
                 "@datawrapper/schemas": "^1.12.0",
@@ -83,14 +83,12 @@
         "node_modules/@babel/compat-data": {
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.4.tgz",
-            "integrity": "sha512-i2wXrWQNkH6JplJQGn3Rd2I4Pij8GdHkXwHMxm+zV5YG/Jci+bCNrWZEWC4o+umiDkRrRs4dVzH3X4GP7vyjQQ==",
-            "dev": true
+            "integrity": "sha512-i2wXrWQNkH6JplJQGn3Rd2I4Pij8GdHkXwHMxm+zV5YG/Jci+bCNrWZEWC4o+umiDkRrRs4dVzH3X4GP7vyjQQ=="
         },
         "node_modules/@babel/core": {
             "version": "7.14.3",
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.3.tgz",
             "integrity": "sha512-jB5AmTKOCSJIZ72sd78ECEhuPiDMKlQdDI/4QRI6lzYATx5SSogS1oQA2AoPecRCknm30gHi2l+QVvNUu3wZAg==",
-            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/generator": "^7.14.3",
@@ -120,7 +118,6 @@
             "version": "7.14.3",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.3.tgz",
             "integrity": "sha512-bn0S6flG/j0xtQdz3hsjJ624h3W0r3llttBMfyHX3YrZ/KtLYr15bjA0FXkgW7FpvrDuTuElXeVjiKlYRpnOFA==",
-            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.14.2",
                 "jsesc": "^2.5.1",
@@ -131,7 +128,6 @@
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
             "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-            "dev": true,
             "bin": {
                 "jsesc": "bin/jsesc"
             },
@@ -143,7 +139,6 @@
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.4.tgz",
             "integrity": "sha512-JgdzOYZ/qGaKTVkn5qEDV/SXAh8KcyUVkCoSWGN8T3bwrgd6m+/dJa2kVGi6RJYJgEYPBdZ84BZp9dUjNWkBaA==",
-            "dev": true,
             "dependencies": {
                 "@babel/compat-data": "^7.14.4",
                 "@babel/helper-validator-option": "^7.12.17",
@@ -158,7 +153,6 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.2.tgz",
             "integrity": "sha512-NYZlkZRydxw+YT56IlhIcS8PAhb+FEUiOzuhFTfqDyPmzAhRge6ua0dQYT/Uh0t/EDHq05/i+e5M2d4XvjgarQ==",
-            "dev": true,
             "dependencies": {
                 "@babel/helper-get-function-arity": "^7.12.13",
                 "@babel/template": "^7.12.13",
@@ -169,7 +163,6 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
             "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
-            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.12.13"
             }
@@ -178,7 +171,6 @@
             "version": "7.13.12",
             "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
             "integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
-            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.13.12"
             }
@@ -195,7 +187,6 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.2.tgz",
             "integrity": "sha512-OznJUda/soKXv0XhpvzGWDnml4Qnwp16GN+D/kZIdLsWoHj05kyu8Rm5kXmMef+rVJZ0+4pSGLkeixdqNUATDA==",
-            "dev": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.13.12",
                 "@babel/helper-replace-supers": "^7.13.12",
@@ -211,7 +202,6 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
             "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
-            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.12.13"
             }
@@ -225,7 +215,6 @@
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.4.tgz",
             "integrity": "sha512-zZ7uHCWlxfEAAOVDYQpEf/uyi1dmeC7fX4nCf2iz9drnCwi1zvwXL3HwWWNXUQEJ1k23yVn3VbddiI9iJEXaTQ==",
-            "dev": true,
             "dependencies": {
                 "@babel/helper-member-expression-to-functions": "^7.13.12",
                 "@babel/helper-optimise-call-expression": "^7.12.13",
@@ -237,7 +226,6 @@
             "version": "7.13.12",
             "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
             "integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
-            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.13.12"
             }
@@ -246,7 +234,6 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
             "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
-            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.12.13"
             }
@@ -259,14 +246,12 @@
         "node_modules/@babel/helper-validator-option": {
             "version": "7.12.17",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
-            "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
-            "dev": true
+            "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw=="
         },
         "node_modules/@babel/helpers": {
             "version": "7.14.0",
             "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.0.tgz",
             "integrity": "sha512-+ufuXprtQ1D1iZTO/K9+EBRn+qPWMJjZSw/S0KlFrxCw4tkrzv9grgpDHkY9MeQTjTY8i2sp7Jep8DfU6tN9Mg==",
-            "dev": true,
             "dependencies": {
                 "@babel/template": "^7.12.13",
                 "@babel/traverse": "^7.14.0",
@@ -368,7 +353,6 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
             "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
-            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/parser": "^7.12.13",
@@ -379,7 +363,6 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.2.tgz",
             "integrity": "sha512-TsdRgvBFHMyHOOzcP9S6QU0QQtjxlRpEYOy3mcCO5RgmC305ki42aSAmfZEMSSYBla2oZ9BMqYlncBaKmD/7iA==",
-            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/generator": "^7.14.2",
@@ -422,9 +405,9 @@
             }
         },
         "node_modules/@datawrapper/chart-core": {
-            "version": "8.39.1",
-            "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-8.39.1.tgz",
-            "integrity": "sha512-cJi1ycGIRBR71aSy5MxNi8Kb5hsKpyZ26jCiKlZw7TqKiOv/m+lYDTiy7QpkiT1U/Tgag7D/HefEpsoBvvhpIA==",
+            "version": "8.39.2",
+            "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-8.39.2.tgz",
+            "integrity": "sha512-1xS2WQ4fLapzIvCWJuK7uaezQK3u0wHoR8gj8LRViv0xwyLZ9VPlr6KvOF+kREKQUFt9Ugh/PHHT8X8E3gEe6w==",
             "dependencies": {
                 "@datawrapper/expr-eval": "^2.0.4",
                 "@datawrapper/polyfills": "2.1.1",
@@ -1514,6 +1497,8 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.0.tgz",
             "integrity": "sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==",
             "dev": true,
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -1529,7 +1514,9 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "node_modules/alphanum-sort": {
             "version": "1.0.2",
@@ -4535,7 +4522,6 @@
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
             "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-            "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -4654,7 +4640,6 @@
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -5999,7 +5984,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
             "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-            "dev": true,
             "dependencies": {
                 "minimist": "^1.2.5"
             },
@@ -9561,7 +9545,6 @@
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
             "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -11211,14 +11194,12 @@
         "@babel/compat-data": {
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.4.tgz",
-            "integrity": "sha512-i2wXrWQNkH6JplJQGn3Rd2I4Pij8GdHkXwHMxm+zV5YG/Jci+bCNrWZEWC4o+umiDkRrRs4dVzH3X4GP7vyjQQ==",
-            "dev": true
+            "integrity": "sha512-i2wXrWQNkH6JplJQGn3Rd2I4Pij8GdHkXwHMxm+zV5YG/Jci+bCNrWZEWC4o+umiDkRrRs4dVzH3X4GP7vyjQQ=="
         },
         "@babel/core": {
             "version": "7.14.3",
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.3.tgz",
             "integrity": "sha512-jB5AmTKOCSJIZ72sd78ECEhuPiDMKlQdDI/4QRI6lzYATx5SSogS1oQA2AoPecRCknm30gHi2l+QVvNUu3wZAg==",
-            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/generator": "^7.14.3",
@@ -11241,7 +11222,6 @@
             "version": "7.14.3",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.3.tgz",
             "integrity": "sha512-bn0S6flG/j0xtQdz3hsjJ624h3W0r3llttBMfyHX3YrZ/KtLYr15bjA0FXkgW7FpvrDuTuElXeVjiKlYRpnOFA==",
-            "dev": true,
             "requires": {
                 "@babel/types": "^7.14.2",
                 "jsesc": "^2.5.1",
@@ -11251,8 +11231,7 @@
                 "jsesc": {
                     "version": "2.5.2",
                     "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-                    "dev": true
+                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
                 }
             }
         },
@@ -11260,7 +11239,6 @@
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.4.tgz",
             "integrity": "sha512-JgdzOYZ/qGaKTVkn5qEDV/SXAh8KcyUVkCoSWGN8T3bwrgd6m+/dJa2kVGi6RJYJgEYPBdZ84BZp9dUjNWkBaA==",
-            "dev": true,
             "requires": {
                 "@babel/compat-data": "^7.14.4",
                 "@babel/helper-validator-option": "^7.12.17",
@@ -11272,7 +11250,6 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.2.tgz",
             "integrity": "sha512-NYZlkZRydxw+YT56IlhIcS8PAhb+FEUiOzuhFTfqDyPmzAhRge6ua0dQYT/Uh0t/EDHq05/i+e5M2d4XvjgarQ==",
-            "dev": true,
             "requires": {
                 "@babel/helper-get-function-arity": "^7.12.13",
                 "@babel/template": "^7.12.13",
@@ -11283,7 +11260,6 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
             "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
-            "dev": true,
             "requires": {
                 "@babel/types": "^7.12.13"
             }
@@ -11292,7 +11268,6 @@
             "version": "7.13.12",
             "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
             "integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
-            "dev": true,
             "requires": {
                 "@babel/types": "^7.13.12"
             }
@@ -11309,7 +11284,6 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.2.tgz",
             "integrity": "sha512-OznJUda/soKXv0XhpvzGWDnml4Qnwp16GN+D/kZIdLsWoHj05kyu8Rm5kXmMef+rVJZ0+4pSGLkeixdqNUATDA==",
-            "dev": true,
             "requires": {
                 "@babel/helper-module-imports": "^7.13.12",
                 "@babel/helper-replace-supers": "^7.13.12",
@@ -11325,7 +11299,6 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
             "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
-            "dev": true,
             "requires": {
                 "@babel/types": "^7.12.13"
             }
@@ -11339,7 +11312,6 @@
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.4.tgz",
             "integrity": "sha512-zZ7uHCWlxfEAAOVDYQpEf/uyi1dmeC7fX4nCf2iz9drnCwi1zvwXL3HwWWNXUQEJ1k23yVn3VbddiI9iJEXaTQ==",
-            "dev": true,
             "requires": {
                 "@babel/helper-member-expression-to-functions": "^7.13.12",
                 "@babel/helper-optimise-call-expression": "^7.12.13",
@@ -11351,7 +11323,6 @@
             "version": "7.13.12",
             "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
             "integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
-            "dev": true,
             "requires": {
                 "@babel/types": "^7.13.12"
             }
@@ -11360,7 +11331,6 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
             "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
-            "dev": true,
             "requires": {
                 "@babel/types": "^7.12.13"
             }
@@ -11373,14 +11343,12 @@
         "@babel/helper-validator-option": {
             "version": "7.12.17",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
-            "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
-            "dev": true
+            "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw=="
         },
         "@babel/helpers": {
             "version": "7.14.0",
             "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.0.tgz",
             "integrity": "sha512-+ufuXprtQ1D1iZTO/K9+EBRn+qPWMJjZSw/S0KlFrxCw4tkrzv9grgpDHkY9MeQTjTY8i2sp7Jep8DfU6tN9Mg==",
-            "dev": true,
             "requires": {
                 "@babel/template": "^7.12.13",
                 "@babel/traverse": "^7.14.0",
@@ -11460,7 +11428,6 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
             "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
-            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/parser": "^7.12.13",
@@ -11471,7 +11438,6 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.2.tgz",
             "integrity": "sha512-TsdRgvBFHMyHOOzcP9S6QU0QQtjxlRpEYOy3mcCO5RgmC305ki42aSAmfZEMSSYBla2oZ9BMqYlncBaKmD/7iA==",
-            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/generator": "^7.14.2",
@@ -11510,9 +11476,9 @@
             }
         },
         "@datawrapper/chart-core": {
-            "version": "8.39.1",
-            "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-8.39.1.tgz",
-            "integrity": "sha512-cJi1ycGIRBR71aSy5MxNi8Kb5hsKpyZ26jCiKlZw7TqKiOv/m+lYDTiy7QpkiT1U/Tgag7D/HefEpsoBvvhpIA==",
+            "version": "8.39.2",
+            "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-8.39.2.tgz",
+            "integrity": "sha512-1xS2WQ4fLapzIvCWJuK7uaezQK3u0wHoR8gj8LRViv0xwyLZ9VPlr6KvOF+kREKQUFt9Ugh/PHHT8X8E3gEe6w==",
             "requires": {
                 "@datawrapper/expr-eval": "^2.0.4",
                 "@datawrapper/polyfills": "2.1.1",
@@ -12415,7 +12381,8 @@
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
             "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "acorn-walk": {
             "version": "8.1.0",
@@ -12450,15 +12417,14 @@
             "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.0.tgz",
             "integrity": "sha512-USH2jBb+C/hIpwD2iRjp0pe0k+MvzG0mlSn/FIdCgQhUb9ALPRjt2KIQdfZDS9r0ZIeUAg7gOu9KL0PFqGqr5Q==",
             "dev": true,
-            "requires": {
-                "ajv": "^8.0.0"
-            },
+            "requires": {},
             "dependencies": {
                 "ajv": {
-                    "version": "8.6.0",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.0.tgz",
+                    "version": "https://registry.npmjs.org/ajv/-/ajv-8.6.0.tgz",
                     "integrity": "sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==",
                     "dev": true,
+                    "optional": true,
+                    "peer": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "json-schema-traverse": "^1.0.0",
@@ -12470,7 +12436,9 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
                     "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-                    "dev": true
+                    "dev": true,
+                    "optional": true,
+                    "peer": true
                 }
             }
         },
@@ -13555,7 +13523,8 @@
         "cssnano-utils": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-2.0.1.tgz",
-            "integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ=="
+            "integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ==",
+            "requires": {}
         },
         "csso": {
             "version": "4.2.0",
@@ -14075,13 +14044,15 @@
             "version": "14.1.1",
             "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz",
             "integrity": "sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "eslint-config-standard-jsx": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-8.1.0.tgz",
             "integrity": "sha512-ULVC8qH8qCqbU792ZOO6DaiaZyHNS/5CZt3hKqHkEhVlhPEPN3nfBqqxJCyp59XrjIBZPu1chMYe9T2DXZ7TMw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "eslint-config-standard-react": {
             "version": "9.2.0",
@@ -14272,13 +14243,15 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
             "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "eslint-plugin-standard": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.1.0.tgz",
             "integrity": "sha512-ZL7+QRixjTR6/528YNGyDotyffm5OQst/sGxKDwGb9Uqs4In5Egi4+jbobhqJoyoCM6/7v/1A5fhQ7ScMtDjaQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "eslint-scope": {
             "version": "5.1.1",
@@ -14714,8 +14687,7 @@
         "gensync": {
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-            "dev": true
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
         },
         "get-caller-file": {
             "version": "2.0.5",
@@ -14794,8 +14766,7 @@
         "globals": {
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-            "dev": true
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
         },
         "globby": {
             "version": "11.0.3",
@@ -15768,7 +15739,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
             "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-            "dev": true,
             "requires": {
                 "minimist": "^1.2.5"
             }
@@ -17642,22 +17612,26 @@
         "postcss-discard-comments": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.1.tgz",
-            "integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg=="
+            "integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg==",
+            "requires": {}
         },
         "postcss-discard-duplicates": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.1.tgz",
-            "integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA=="
+            "integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA==",
+            "requires": {}
         },
         "postcss-discard-empty": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.0.1.tgz",
-            "integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw=="
+            "integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw==",
+            "requires": {}
         },
         "postcss-discard-overridden": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.1.tgz",
-            "integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q=="
+            "integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q==",
+            "requires": {}
         },
         "postcss-less": {
             "version": "4.0.1",
@@ -17731,7 +17705,8 @@
         "postcss-normalize-charset": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.0.1.tgz",
-            "integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg=="
+            "integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg==",
+            "requires": {}
         },
         "postcss-normalize-display-values": {
             "version": "5.0.1",
@@ -18457,8 +18432,7 @@
         "semver": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "dev": true
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
         "semver-compare": {
             "version": "1.0.0",
@@ -18952,7 +18926,8 @@
         "svelte-extras": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/svelte-extras/-/svelte-extras-2.0.2.tgz",
-            "integrity": "sha512-yoxNehbDxGEHxJBTWq2RpIPDTHlNNy6eGR7RPSK7qsh8hoyOXbji8uF//l4+I/l2fLP+E8pQTJYrduPXrW3wsw=="
+            "integrity": "sha512-yoxNehbDxGEHxJBTWq2RpIPDTHlNNy6eGR7RPSK7qsh8hoyOXbji8uF//l4+I/l2fLP+E8pQTJYrduPXrW3wsw==",
+            "requires": {}
         },
         "svelte2": {
             "version": "npm:svelte@2.16.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "2.9.0",
             "license": "UNLICENSED",
             "dependencies": {
-                "@datawrapper/chart-core": "^8.38.3",
+                "@datawrapper/chart-core": "^8.39.0",
                 "@datawrapper/locales": "^1.2.6",
                 "@datawrapper/orm": "^3.25.0",
                 "@datawrapper/schemas": "^1.12.0",
@@ -83,14 +83,12 @@
         "node_modules/@babel/compat-data": {
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.4.tgz",
-            "integrity": "sha512-i2wXrWQNkH6JplJQGn3Rd2I4Pij8GdHkXwHMxm+zV5YG/Jci+bCNrWZEWC4o+umiDkRrRs4dVzH3X4GP7vyjQQ==",
-            "dev": true
+            "integrity": "sha512-i2wXrWQNkH6JplJQGn3Rd2I4Pij8GdHkXwHMxm+zV5YG/Jci+bCNrWZEWC4o+umiDkRrRs4dVzH3X4GP7vyjQQ=="
         },
         "node_modules/@babel/core": {
             "version": "7.14.3",
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.3.tgz",
             "integrity": "sha512-jB5AmTKOCSJIZ72sd78ECEhuPiDMKlQdDI/4QRI6lzYATx5SSogS1oQA2AoPecRCknm30gHi2l+QVvNUu3wZAg==",
-            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/generator": "^7.14.3",
@@ -120,7 +118,6 @@
             "version": "7.14.3",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.3.tgz",
             "integrity": "sha512-bn0S6flG/j0xtQdz3hsjJ624h3W0r3llttBMfyHX3YrZ/KtLYr15bjA0FXkgW7FpvrDuTuElXeVjiKlYRpnOFA==",
-            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.14.2",
                 "jsesc": "^2.5.1",
@@ -131,7 +128,6 @@
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
             "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-            "dev": true,
             "bin": {
                 "jsesc": "bin/jsesc"
             },
@@ -143,7 +139,6 @@
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.4.tgz",
             "integrity": "sha512-JgdzOYZ/qGaKTVkn5qEDV/SXAh8KcyUVkCoSWGN8T3bwrgd6m+/dJa2kVGi6RJYJgEYPBdZ84BZp9dUjNWkBaA==",
-            "dev": true,
             "dependencies": {
                 "@babel/compat-data": "^7.14.4",
                 "@babel/helper-validator-option": "^7.12.17",
@@ -158,7 +153,6 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.2.tgz",
             "integrity": "sha512-NYZlkZRydxw+YT56IlhIcS8PAhb+FEUiOzuhFTfqDyPmzAhRge6ua0dQYT/Uh0t/EDHq05/i+e5M2d4XvjgarQ==",
-            "dev": true,
             "dependencies": {
                 "@babel/helper-get-function-arity": "^7.12.13",
                 "@babel/template": "^7.12.13",
@@ -169,7 +163,6 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
             "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
-            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.12.13"
             }
@@ -178,7 +171,6 @@
             "version": "7.13.12",
             "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
             "integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
-            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.13.12"
             }
@@ -195,7 +187,6 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.2.tgz",
             "integrity": "sha512-OznJUda/soKXv0XhpvzGWDnml4Qnwp16GN+D/kZIdLsWoHj05kyu8Rm5kXmMef+rVJZ0+4pSGLkeixdqNUATDA==",
-            "dev": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.13.12",
                 "@babel/helper-replace-supers": "^7.13.12",
@@ -211,7 +202,6 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
             "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
-            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.12.13"
             }
@@ -225,7 +215,6 @@
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.4.tgz",
             "integrity": "sha512-zZ7uHCWlxfEAAOVDYQpEf/uyi1dmeC7fX4nCf2iz9drnCwi1zvwXL3HwWWNXUQEJ1k23yVn3VbddiI9iJEXaTQ==",
-            "dev": true,
             "dependencies": {
                 "@babel/helper-member-expression-to-functions": "^7.13.12",
                 "@babel/helper-optimise-call-expression": "^7.12.13",
@@ -237,7 +226,6 @@
             "version": "7.13.12",
             "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
             "integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
-            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.13.12"
             }
@@ -246,7 +234,6 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
             "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
-            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.12.13"
             }
@@ -259,14 +246,12 @@
         "node_modules/@babel/helper-validator-option": {
             "version": "7.12.17",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
-            "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
-            "dev": true
+            "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw=="
         },
         "node_modules/@babel/helpers": {
             "version": "7.14.0",
             "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.0.tgz",
             "integrity": "sha512-+ufuXprtQ1D1iZTO/K9+EBRn+qPWMJjZSw/S0KlFrxCw4tkrzv9grgpDHkY9MeQTjTY8i2sp7Jep8DfU6tN9Mg==",
-            "dev": true,
             "dependencies": {
                 "@babel/template": "^7.12.13",
                 "@babel/traverse": "^7.14.0",
@@ -368,7 +353,6 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
             "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
-            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/parser": "^7.12.13",
@@ -379,7 +363,6 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.2.tgz",
             "integrity": "sha512-TsdRgvBFHMyHOOzcP9S6QU0QQtjxlRpEYOy3mcCO5RgmC305ki42aSAmfZEMSSYBla2oZ9BMqYlncBaKmD/7iA==",
-            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/generator": "^7.14.2",
@@ -422,9 +405,9 @@
             }
         },
         "node_modules/@datawrapper/chart-core": {
-            "version": "8.38.3",
-            "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-8.38.3.tgz",
-            "integrity": "sha512-Y7Hr6ZdtxX0kV4QyZ2HyeXLKFRUHST9ZEdYQPgHld4HJ4TuHmYID6D3cTg69Eu2wN/MHMaiYOkzYO97yi1QqSQ==",
+            "version": "8.39.0",
+            "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-8.39.0.tgz",
+            "integrity": "sha512-Q0ZEo07iDaSE2OzUfNbKzpRYkrQJZdmp502Jf2GtNxkorgb3U28EgkaXm30jC6mr/Lqw3M5TrBwsPwj9mtte/A==",
             "dependencies": {
                 "@datawrapper/expr-eval": "^2.0.4",
                 "@datawrapper/polyfills": "2.1.1",
@@ -1514,6 +1497,8 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.0.tgz",
             "integrity": "sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==",
             "dev": true,
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -1529,7 +1514,9 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "node_modules/alphanum-sort": {
             "version": "1.0.2",
@@ -4535,7 +4522,6 @@
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
             "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-            "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -4654,7 +4640,6 @@
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -5999,7 +5984,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
             "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-            "dev": true,
             "dependencies": {
                 "minimist": "^1.2.5"
             },
@@ -9561,7 +9545,6 @@
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
             "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -11211,14 +11194,12 @@
         "@babel/compat-data": {
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.4.tgz",
-            "integrity": "sha512-i2wXrWQNkH6JplJQGn3Rd2I4Pij8GdHkXwHMxm+zV5YG/Jci+bCNrWZEWC4o+umiDkRrRs4dVzH3X4GP7vyjQQ==",
-            "dev": true
+            "integrity": "sha512-i2wXrWQNkH6JplJQGn3Rd2I4Pij8GdHkXwHMxm+zV5YG/Jci+bCNrWZEWC4o+umiDkRrRs4dVzH3X4GP7vyjQQ=="
         },
         "@babel/core": {
             "version": "7.14.3",
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.3.tgz",
             "integrity": "sha512-jB5AmTKOCSJIZ72sd78ECEhuPiDMKlQdDI/4QRI6lzYATx5SSogS1oQA2AoPecRCknm30gHi2l+QVvNUu3wZAg==",
-            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/generator": "^7.14.3",
@@ -11241,7 +11222,6 @@
             "version": "7.14.3",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.3.tgz",
             "integrity": "sha512-bn0S6flG/j0xtQdz3hsjJ624h3W0r3llttBMfyHX3YrZ/KtLYr15bjA0FXkgW7FpvrDuTuElXeVjiKlYRpnOFA==",
-            "dev": true,
             "requires": {
                 "@babel/types": "^7.14.2",
                 "jsesc": "^2.5.1",
@@ -11251,8 +11231,7 @@
                 "jsesc": {
                     "version": "2.5.2",
                     "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-                    "dev": true
+                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
                 }
             }
         },
@@ -11260,7 +11239,6 @@
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.4.tgz",
             "integrity": "sha512-JgdzOYZ/qGaKTVkn5qEDV/SXAh8KcyUVkCoSWGN8T3bwrgd6m+/dJa2kVGi6RJYJgEYPBdZ84BZp9dUjNWkBaA==",
-            "dev": true,
             "requires": {
                 "@babel/compat-data": "^7.14.4",
                 "@babel/helper-validator-option": "^7.12.17",
@@ -11272,7 +11250,6 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.2.tgz",
             "integrity": "sha512-NYZlkZRydxw+YT56IlhIcS8PAhb+FEUiOzuhFTfqDyPmzAhRge6ua0dQYT/Uh0t/EDHq05/i+e5M2d4XvjgarQ==",
-            "dev": true,
             "requires": {
                 "@babel/helper-get-function-arity": "^7.12.13",
                 "@babel/template": "^7.12.13",
@@ -11283,7 +11260,6 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
             "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
-            "dev": true,
             "requires": {
                 "@babel/types": "^7.12.13"
             }
@@ -11292,7 +11268,6 @@
             "version": "7.13.12",
             "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
             "integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
-            "dev": true,
             "requires": {
                 "@babel/types": "^7.13.12"
             }
@@ -11309,7 +11284,6 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.2.tgz",
             "integrity": "sha512-OznJUda/soKXv0XhpvzGWDnml4Qnwp16GN+D/kZIdLsWoHj05kyu8Rm5kXmMef+rVJZ0+4pSGLkeixdqNUATDA==",
-            "dev": true,
             "requires": {
                 "@babel/helper-module-imports": "^7.13.12",
                 "@babel/helper-replace-supers": "^7.13.12",
@@ -11325,7 +11299,6 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
             "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
-            "dev": true,
             "requires": {
                 "@babel/types": "^7.12.13"
             }
@@ -11339,7 +11312,6 @@
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.4.tgz",
             "integrity": "sha512-zZ7uHCWlxfEAAOVDYQpEf/uyi1dmeC7fX4nCf2iz9drnCwi1zvwXL3HwWWNXUQEJ1k23yVn3VbddiI9iJEXaTQ==",
-            "dev": true,
             "requires": {
                 "@babel/helper-member-expression-to-functions": "^7.13.12",
                 "@babel/helper-optimise-call-expression": "^7.12.13",
@@ -11351,7 +11323,6 @@
             "version": "7.13.12",
             "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
             "integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
-            "dev": true,
             "requires": {
                 "@babel/types": "^7.13.12"
             }
@@ -11360,7 +11331,6 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
             "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
-            "dev": true,
             "requires": {
                 "@babel/types": "^7.12.13"
             }
@@ -11373,14 +11343,12 @@
         "@babel/helper-validator-option": {
             "version": "7.12.17",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
-            "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
-            "dev": true
+            "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw=="
         },
         "@babel/helpers": {
             "version": "7.14.0",
             "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.0.tgz",
             "integrity": "sha512-+ufuXprtQ1D1iZTO/K9+EBRn+qPWMJjZSw/S0KlFrxCw4tkrzv9grgpDHkY9MeQTjTY8i2sp7Jep8DfU6tN9Mg==",
-            "dev": true,
             "requires": {
                 "@babel/template": "^7.12.13",
                 "@babel/traverse": "^7.14.0",
@@ -11460,7 +11428,6 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
             "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
-            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/parser": "^7.12.13",
@@ -11471,7 +11438,6 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.2.tgz",
             "integrity": "sha512-TsdRgvBFHMyHOOzcP9S6QU0QQtjxlRpEYOy3mcCO5RgmC305ki42aSAmfZEMSSYBla2oZ9BMqYlncBaKmD/7iA==",
-            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/generator": "^7.14.2",
@@ -11510,9 +11476,9 @@
             }
         },
         "@datawrapper/chart-core": {
-            "version": "8.38.3",
-            "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-8.38.3.tgz",
-            "integrity": "sha512-Y7Hr6ZdtxX0kV4QyZ2HyeXLKFRUHST9ZEdYQPgHld4HJ4TuHmYID6D3cTg69Eu2wN/MHMaiYOkzYO97yi1QqSQ==",
+            "version": "8.39.0",
+            "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-8.39.0.tgz",
+            "integrity": "sha512-Q0ZEo07iDaSE2OzUfNbKzpRYkrQJZdmp502Jf2GtNxkorgb3U28EgkaXm30jC6mr/Lqw3M5TrBwsPwj9mtte/A==",
             "requires": {
                 "@datawrapper/expr-eval": "^2.0.4",
                 "@datawrapper/polyfills": "2.1.1",
@@ -12415,7 +12381,8 @@
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
             "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "acorn-walk": {
             "version": "8.1.0",
@@ -12450,15 +12417,14 @@
             "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.0.tgz",
             "integrity": "sha512-USH2jBb+C/hIpwD2iRjp0pe0k+MvzG0mlSn/FIdCgQhUb9ALPRjt2KIQdfZDS9r0ZIeUAg7gOu9KL0PFqGqr5Q==",
             "dev": true,
-            "requires": {
-                "ajv": "^8.0.0"
-            },
+            "requires": {},
             "dependencies": {
                 "ajv": {
-                    "version": "8.6.0",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.0.tgz",
+                    "version": "https://registry.npmjs.org/ajv/-/ajv-8.6.0.tgz",
                     "integrity": "sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==",
                     "dev": true,
+                    "optional": true,
+                    "peer": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "json-schema-traverse": "^1.0.0",
@@ -12470,7 +12436,9 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
                     "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-                    "dev": true
+                    "dev": true,
+                    "optional": true,
+                    "peer": true
                 }
             }
         },
@@ -13555,7 +13523,8 @@
         "cssnano-utils": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-2.0.1.tgz",
-            "integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ=="
+            "integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ==",
+            "requires": {}
         },
         "csso": {
             "version": "4.2.0",
@@ -14075,13 +14044,15 @@
             "version": "14.1.1",
             "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz",
             "integrity": "sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "eslint-config-standard-jsx": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-8.1.0.tgz",
             "integrity": "sha512-ULVC8qH8qCqbU792ZOO6DaiaZyHNS/5CZt3hKqHkEhVlhPEPN3nfBqqxJCyp59XrjIBZPu1chMYe9T2DXZ7TMw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "eslint-config-standard-react": {
             "version": "9.2.0",
@@ -14272,13 +14243,15 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
             "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "eslint-plugin-standard": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.1.0.tgz",
             "integrity": "sha512-ZL7+QRixjTR6/528YNGyDotyffm5OQst/sGxKDwGb9Uqs4In5Egi4+jbobhqJoyoCM6/7v/1A5fhQ7ScMtDjaQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "eslint-scope": {
             "version": "5.1.1",
@@ -14714,8 +14687,7 @@
         "gensync": {
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-            "dev": true
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
         },
         "get-caller-file": {
             "version": "2.0.5",
@@ -14794,8 +14766,7 @@
         "globals": {
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-            "dev": true
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
         },
         "globby": {
             "version": "11.0.3",
@@ -15768,7 +15739,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
             "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-            "dev": true,
             "requires": {
                 "minimist": "^1.2.5"
             }
@@ -17642,22 +17612,26 @@
         "postcss-discard-comments": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.1.tgz",
-            "integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg=="
+            "integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg==",
+            "requires": {}
         },
         "postcss-discard-duplicates": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.1.tgz",
-            "integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA=="
+            "integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA==",
+            "requires": {}
         },
         "postcss-discard-empty": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.0.1.tgz",
-            "integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw=="
+            "integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw==",
+            "requires": {}
         },
         "postcss-discard-overridden": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.1.tgz",
-            "integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q=="
+            "integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q==",
+            "requires": {}
         },
         "postcss-less": {
             "version": "4.0.1",
@@ -17731,7 +17705,8 @@
         "postcss-normalize-charset": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.0.1.tgz",
-            "integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg=="
+            "integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg==",
+            "requires": {}
         },
         "postcss-normalize-display-values": {
             "version": "5.0.1",
@@ -18457,8 +18432,7 @@
         "semver": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "dev": true
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
         "semver-compare": {
             "version": "1.0.0",
@@ -18952,7 +18926,8 @@
         "svelte-extras": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/svelte-extras/-/svelte-extras-2.0.2.tgz",
-            "integrity": "sha512-yoxNehbDxGEHxJBTWq2RpIPDTHlNNy6eGR7RPSK7qsh8hoyOXbji8uF//l4+I/l2fLP+E8pQTJYrduPXrW3wsw=="
+            "integrity": "sha512-yoxNehbDxGEHxJBTWq2RpIPDTHlNNy6eGR7RPSK7qsh8hoyOXbji8uF//l4+I/l2fLP+E8pQTJYrduPXrW3wsw==",
+            "requires": {}
         },
         "svelte2": {
             "version": "npm:svelte@2.16.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,12 +83,14 @@
         "node_modules/@babel/compat-data": {
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.4.tgz",
-            "integrity": "sha512-i2wXrWQNkH6JplJQGn3Rd2I4Pij8GdHkXwHMxm+zV5YG/Jci+bCNrWZEWC4o+umiDkRrRs4dVzH3X4GP7vyjQQ=="
+            "integrity": "sha512-i2wXrWQNkH6JplJQGn3Rd2I4Pij8GdHkXwHMxm+zV5YG/Jci+bCNrWZEWC4o+umiDkRrRs4dVzH3X4GP7vyjQQ==",
+            "dev": true
         },
         "node_modules/@babel/core": {
             "version": "7.14.3",
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.3.tgz",
             "integrity": "sha512-jB5AmTKOCSJIZ72sd78ECEhuPiDMKlQdDI/4QRI6lzYATx5SSogS1oQA2AoPecRCknm30gHi2l+QVvNUu3wZAg==",
+            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/generator": "^7.14.3",
@@ -118,6 +120,7 @@
             "version": "7.14.3",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.3.tgz",
             "integrity": "sha512-bn0S6flG/j0xtQdz3hsjJ624h3W0r3llttBMfyHX3YrZ/KtLYr15bjA0FXkgW7FpvrDuTuElXeVjiKlYRpnOFA==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.14.2",
                 "jsesc": "^2.5.1",
@@ -128,6 +131,7 @@
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
             "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+            "dev": true,
             "bin": {
                 "jsesc": "bin/jsesc"
             },
@@ -139,6 +143,7 @@
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.4.tgz",
             "integrity": "sha512-JgdzOYZ/qGaKTVkn5qEDV/SXAh8KcyUVkCoSWGN8T3bwrgd6m+/dJa2kVGi6RJYJgEYPBdZ84BZp9dUjNWkBaA==",
+            "dev": true,
             "dependencies": {
                 "@babel/compat-data": "^7.14.4",
                 "@babel/helper-validator-option": "^7.12.17",
@@ -153,6 +158,7 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.2.tgz",
             "integrity": "sha512-NYZlkZRydxw+YT56IlhIcS8PAhb+FEUiOzuhFTfqDyPmzAhRge6ua0dQYT/Uh0t/EDHq05/i+e5M2d4XvjgarQ==",
+            "dev": true,
             "dependencies": {
                 "@babel/helper-get-function-arity": "^7.12.13",
                 "@babel/template": "^7.12.13",
@@ -163,6 +169,7 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
             "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.12.13"
             }
@@ -171,6 +178,7 @@
             "version": "7.13.12",
             "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
             "integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.13.12"
             }
@@ -187,6 +195,7 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.2.tgz",
             "integrity": "sha512-OznJUda/soKXv0XhpvzGWDnml4Qnwp16GN+D/kZIdLsWoHj05kyu8Rm5kXmMef+rVJZ0+4pSGLkeixdqNUATDA==",
+            "dev": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.13.12",
                 "@babel/helper-replace-supers": "^7.13.12",
@@ -202,6 +211,7 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
             "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.12.13"
             }
@@ -215,6 +225,7 @@
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.4.tgz",
             "integrity": "sha512-zZ7uHCWlxfEAAOVDYQpEf/uyi1dmeC7fX4nCf2iz9drnCwi1zvwXL3HwWWNXUQEJ1k23yVn3VbddiI9iJEXaTQ==",
+            "dev": true,
             "dependencies": {
                 "@babel/helper-member-expression-to-functions": "^7.13.12",
                 "@babel/helper-optimise-call-expression": "^7.12.13",
@@ -226,6 +237,7 @@
             "version": "7.13.12",
             "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
             "integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.13.12"
             }
@@ -234,6 +246,7 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
             "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.12.13"
             }
@@ -246,12 +259,14 @@
         "node_modules/@babel/helper-validator-option": {
             "version": "7.12.17",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
-            "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw=="
+            "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
+            "dev": true
         },
         "node_modules/@babel/helpers": {
             "version": "7.14.0",
             "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.0.tgz",
             "integrity": "sha512-+ufuXprtQ1D1iZTO/K9+EBRn+qPWMJjZSw/S0KlFrxCw4tkrzv9grgpDHkY9MeQTjTY8i2sp7Jep8DfU6tN9Mg==",
+            "dev": true,
             "dependencies": {
                 "@babel/template": "^7.12.13",
                 "@babel/traverse": "^7.14.0",
@@ -353,6 +368,7 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
             "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/parser": "^7.12.13",
@@ -363,6 +379,7 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.2.tgz",
             "integrity": "sha512-TsdRgvBFHMyHOOzcP9S6QU0QQtjxlRpEYOy3mcCO5RgmC305ki42aSAmfZEMSSYBla2oZ9BMqYlncBaKmD/7iA==",
+            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/generator": "^7.14.2",
@@ -1497,8 +1514,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.0.tgz",
             "integrity": "sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==",
             "dev": true,
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -1514,9 +1529,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/alphanum-sort": {
             "version": "1.0.2",
@@ -4522,6 +4535,7 @@
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
             "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+            "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -4640,6 +4654,7 @@
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -5984,6 +5999,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
             "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+            "dev": true,
             "dependencies": {
                 "minimist": "^1.2.5"
             },
@@ -9545,6 +9561,7 @@
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
             "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -11194,12 +11211,14 @@
         "@babel/compat-data": {
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.4.tgz",
-            "integrity": "sha512-i2wXrWQNkH6JplJQGn3Rd2I4Pij8GdHkXwHMxm+zV5YG/Jci+bCNrWZEWC4o+umiDkRrRs4dVzH3X4GP7vyjQQ=="
+            "integrity": "sha512-i2wXrWQNkH6JplJQGn3Rd2I4Pij8GdHkXwHMxm+zV5YG/Jci+bCNrWZEWC4o+umiDkRrRs4dVzH3X4GP7vyjQQ==",
+            "dev": true
         },
         "@babel/core": {
             "version": "7.14.3",
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.3.tgz",
             "integrity": "sha512-jB5AmTKOCSJIZ72sd78ECEhuPiDMKlQdDI/4QRI6lzYATx5SSogS1oQA2AoPecRCknm30gHi2l+QVvNUu3wZAg==",
+            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/generator": "^7.14.3",
@@ -11222,6 +11241,7 @@
             "version": "7.14.3",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.3.tgz",
             "integrity": "sha512-bn0S6flG/j0xtQdz3hsjJ624h3W0r3llttBMfyHX3YrZ/KtLYr15bjA0FXkgW7FpvrDuTuElXeVjiKlYRpnOFA==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.14.2",
                 "jsesc": "^2.5.1",
@@ -11231,7 +11251,8 @@
                 "jsesc": {
                     "version": "2.5.2",
                     "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+                    "dev": true
                 }
             }
         },
@@ -11239,6 +11260,7 @@
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.4.tgz",
             "integrity": "sha512-JgdzOYZ/qGaKTVkn5qEDV/SXAh8KcyUVkCoSWGN8T3bwrgd6m+/dJa2kVGi6RJYJgEYPBdZ84BZp9dUjNWkBaA==",
+            "dev": true,
             "requires": {
                 "@babel/compat-data": "^7.14.4",
                 "@babel/helper-validator-option": "^7.12.17",
@@ -11250,6 +11272,7 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.2.tgz",
             "integrity": "sha512-NYZlkZRydxw+YT56IlhIcS8PAhb+FEUiOzuhFTfqDyPmzAhRge6ua0dQYT/Uh0t/EDHq05/i+e5M2d4XvjgarQ==",
+            "dev": true,
             "requires": {
                 "@babel/helper-get-function-arity": "^7.12.13",
                 "@babel/template": "^7.12.13",
@@ -11260,6 +11283,7 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
             "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.12.13"
             }
@@ -11268,6 +11292,7 @@
             "version": "7.13.12",
             "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
             "integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.13.12"
             }
@@ -11284,6 +11309,7 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.2.tgz",
             "integrity": "sha512-OznJUda/soKXv0XhpvzGWDnml4Qnwp16GN+D/kZIdLsWoHj05kyu8Rm5kXmMef+rVJZ0+4pSGLkeixdqNUATDA==",
+            "dev": true,
             "requires": {
                 "@babel/helper-module-imports": "^7.13.12",
                 "@babel/helper-replace-supers": "^7.13.12",
@@ -11299,6 +11325,7 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
             "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.12.13"
             }
@@ -11312,6 +11339,7 @@
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.4.tgz",
             "integrity": "sha512-zZ7uHCWlxfEAAOVDYQpEf/uyi1dmeC7fX4nCf2iz9drnCwi1zvwXL3HwWWNXUQEJ1k23yVn3VbddiI9iJEXaTQ==",
+            "dev": true,
             "requires": {
                 "@babel/helper-member-expression-to-functions": "^7.13.12",
                 "@babel/helper-optimise-call-expression": "^7.12.13",
@@ -11323,6 +11351,7 @@
             "version": "7.13.12",
             "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
             "integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.13.12"
             }
@@ -11331,6 +11360,7 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
             "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.12.13"
             }
@@ -11343,12 +11373,14 @@
         "@babel/helper-validator-option": {
             "version": "7.12.17",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
-            "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw=="
+            "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
+            "dev": true
         },
         "@babel/helpers": {
             "version": "7.14.0",
             "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.0.tgz",
             "integrity": "sha512-+ufuXprtQ1D1iZTO/K9+EBRn+qPWMJjZSw/S0KlFrxCw4tkrzv9grgpDHkY9MeQTjTY8i2sp7Jep8DfU6tN9Mg==",
+            "dev": true,
             "requires": {
                 "@babel/template": "^7.12.13",
                 "@babel/traverse": "^7.14.0",
@@ -11428,6 +11460,7 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
             "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/parser": "^7.12.13",
@@ -11438,6 +11471,7 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.2.tgz",
             "integrity": "sha512-TsdRgvBFHMyHOOzcP9S6QU0QQtjxlRpEYOy3mcCO5RgmC305ki42aSAmfZEMSSYBla2oZ9BMqYlncBaKmD/7iA==",
+            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/generator": "^7.14.2",
@@ -12381,8 +12415,7 @@
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
             "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "acorn-walk": {
             "version": "8.1.0",
@@ -12417,14 +12450,15 @@
             "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.0.tgz",
             "integrity": "sha512-USH2jBb+C/hIpwD2iRjp0pe0k+MvzG0mlSn/FIdCgQhUb9ALPRjt2KIQdfZDS9r0ZIeUAg7gOu9KL0PFqGqr5Q==",
             "dev": true,
-            "requires": {},
+            "requires": {
+                "ajv": "^8.0.0"
+            },
             "dependencies": {
                 "ajv": {
-                    "version": "https://registry.npmjs.org/ajv/-/ajv-8.6.0.tgz",
+                    "version": "8.6.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.0.tgz",
                     "integrity": "sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==",
                     "dev": true,
-                    "optional": true,
-                    "peer": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "json-schema-traverse": "^1.0.0",
@@ -12436,9 +12470,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
                     "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true
+                    "dev": true
                 }
             }
         },
@@ -13523,8 +13555,7 @@
         "cssnano-utils": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-2.0.1.tgz",
-            "integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ==",
-            "requires": {}
+            "integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ=="
         },
         "csso": {
             "version": "4.2.0",
@@ -14044,15 +14075,13 @@
             "version": "14.1.1",
             "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz",
             "integrity": "sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-config-standard-jsx": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-8.1.0.tgz",
             "integrity": "sha512-ULVC8qH8qCqbU792ZOO6DaiaZyHNS/5CZt3hKqHkEhVlhPEPN3nfBqqxJCyp59XrjIBZPu1chMYe9T2DXZ7TMw==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-config-standard-react": {
             "version": "9.2.0",
@@ -14243,15 +14272,13 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
             "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-plugin-standard": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.1.0.tgz",
             "integrity": "sha512-ZL7+QRixjTR6/528YNGyDotyffm5OQst/sGxKDwGb9Uqs4In5Egi4+jbobhqJoyoCM6/7v/1A5fhQ7ScMtDjaQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-scope": {
             "version": "5.1.1",
@@ -14687,7 +14714,8 @@
         "gensync": {
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+            "dev": true
         },
         "get-caller-file": {
             "version": "2.0.5",
@@ -14766,7 +14794,8 @@
         "globals": {
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "dev": true
         },
         "globby": {
             "version": "11.0.3",
@@ -15739,6 +15768,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
             "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+            "dev": true,
             "requires": {
                 "minimist": "^1.2.5"
             }
@@ -17612,26 +17642,22 @@
         "postcss-discard-comments": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.1.tgz",
-            "integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg==",
-            "requires": {}
+            "integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg=="
         },
         "postcss-discard-duplicates": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.1.tgz",
-            "integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA==",
-            "requires": {}
+            "integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA=="
         },
         "postcss-discard-empty": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.0.1.tgz",
-            "integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw==",
-            "requires": {}
+            "integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw=="
         },
         "postcss-discard-overridden": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.1.tgz",
-            "integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q==",
-            "requires": {}
+            "integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q=="
         },
         "postcss-less": {
             "version": "4.0.1",
@@ -17705,8 +17731,7 @@
         "postcss-normalize-charset": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.0.1.tgz",
-            "integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg==",
-            "requires": {}
+            "integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg=="
         },
         "postcss-normalize-display-values": {
             "version": "5.0.1",
@@ -18432,7 +18457,8 @@
         "semver": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true
         },
         "semver-compare": {
             "version": "1.0.0",
@@ -18926,8 +18952,7 @@
         "svelte-extras": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/svelte-extras/-/svelte-extras-2.0.2.tgz",
-            "integrity": "sha512-yoxNehbDxGEHxJBTWq2RpIPDTHlNNy6eGR7RPSK7qsh8hoyOXbji8uF//l4+I/l2fLP+E8pQTJYrduPXrW3wsw==",
-            "requires": {}
+            "integrity": "sha512-yoxNehbDxGEHxJBTWq2RpIPDTHlNNy6eGR7RPSK7qsh8hoyOXbji8uF//l4+I/l2fLP+E8pQTJYrduPXrW3wsw=="
         },
         "svelte2": {
             "version": "npm:svelte@2.16.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "2.9.0",
             "license": "UNLICENSED",
             "dependencies": {
-                "@datawrapper/chart-core": "^8.39.0",
+                "@datawrapper/chart-core": "^8.39.1",
                 "@datawrapper/locales": "^1.2.6",
                 "@datawrapper/orm": "^3.25.0",
                 "@datawrapper/schemas": "^1.12.0",
@@ -83,12 +83,14 @@
         "node_modules/@babel/compat-data": {
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.4.tgz",
-            "integrity": "sha512-i2wXrWQNkH6JplJQGn3Rd2I4Pij8GdHkXwHMxm+zV5YG/Jci+bCNrWZEWC4o+umiDkRrRs4dVzH3X4GP7vyjQQ=="
+            "integrity": "sha512-i2wXrWQNkH6JplJQGn3Rd2I4Pij8GdHkXwHMxm+zV5YG/Jci+bCNrWZEWC4o+umiDkRrRs4dVzH3X4GP7vyjQQ==",
+            "dev": true
         },
         "node_modules/@babel/core": {
             "version": "7.14.3",
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.3.tgz",
             "integrity": "sha512-jB5AmTKOCSJIZ72sd78ECEhuPiDMKlQdDI/4QRI6lzYATx5SSogS1oQA2AoPecRCknm30gHi2l+QVvNUu3wZAg==",
+            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/generator": "^7.14.3",
@@ -118,6 +120,7 @@
             "version": "7.14.3",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.3.tgz",
             "integrity": "sha512-bn0S6flG/j0xtQdz3hsjJ624h3W0r3llttBMfyHX3YrZ/KtLYr15bjA0FXkgW7FpvrDuTuElXeVjiKlYRpnOFA==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.14.2",
                 "jsesc": "^2.5.1",
@@ -128,6 +131,7 @@
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
             "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+            "dev": true,
             "bin": {
                 "jsesc": "bin/jsesc"
             },
@@ -139,6 +143,7 @@
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.4.tgz",
             "integrity": "sha512-JgdzOYZ/qGaKTVkn5qEDV/SXAh8KcyUVkCoSWGN8T3bwrgd6m+/dJa2kVGi6RJYJgEYPBdZ84BZp9dUjNWkBaA==",
+            "dev": true,
             "dependencies": {
                 "@babel/compat-data": "^7.14.4",
                 "@babel/helper-validator-option": "^7.12.17",
@@ -153,6 +158,7 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.2.tgz",
             "integrity": "sha512-NYZlkZRydxw+YT56IlhIcS8PAhb+FEUiOzuhFTfqDyPmzAhRge6ua0dQYT/Uh0t/EDHq05/i+e5M2d4XvjgarQ==",
+            "dev": true,
             "dependencies": {
                 "@babel/helper-get-function-arity": "^7.12.13",
                 "@babel/template": "^7.12.13",
@@ -163,6 +169,7 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
             "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.12.13"
             }
@@ -171,6 +178,7 @@
             "version": "7.13.12",
             "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
             "integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.13.12"
             }
@@ -187,6 +195,7 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.2.tgz",
             "integrity": "sha512-OznJUda/soKXv0XhpvzGWDnml4Qnwp16GN+D/kZIdLsWoHj05kyu8Rm5kXmMef+rVJZ0+4pSGLkeixdqNUATDA==",
+            "dev": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.13.12",
                 "@babel/helper-replace-supers": "^7.13.12",
@@ -202,6 +211,7 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
             "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.12.13"
             }
@@ -215,6 +225,7 @@
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.4.tgz",
             "integrity": "sha512-zZ7uHCWlxfEAAOVDYQpEf/uyi1dmeC7fX4nCf2iz9drnCwi1zvwXL3HwWWNXUQEJ1k23yVn3VbddiI9iJEXaTQ==",
+            "dev": true,
             "dependencies": {
                 "@babel/helper-member-expression-to-functions": "^7.13.12",
                 "@babel/helper-optimise-call-expression": "^7.12.13",
@@ -226,6 +237,7 @@
             "version": "7.13.12",
             "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
             "integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.13.12"
             }
@@ -234,6 +246,7 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
             "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.12.13"
             }
@@ -246,12 +259,14 @@
         "node_modules/@babel/helper-validator-option": {
             "version": "7.12.17",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
-            "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw=="
+            "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
+            "dev": true
         },
         "node_modules/@babel/helpers": {
             "version": "7.14.0",
             "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.0.tgz",
             "integrity": "sha512-+ufuXprtQ1D1iZTO/K9+EBRn+qPWMJjZSw/S0KlFrxCw4tkrzv9grgpDHkY9MeQTjTY8i2sp7Jep8DfU6tN9Mg==",
+            "dev": true,
             "dependencies": {
                 "@babel/template": "^7.12.13",
                 "@babel/traverse": "^7.14.0",
@@ -353,6 +368,7 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
             "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/parser": "^7.12.13",
@@ -363,6 +379,7 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.2.tgz",
             "integrity": "sha512-TsdRgvBFHMyHOOzcP9S6QU0QQtjxlRpEYOy3mcCO5RgmC305ki42aSAmfZEMSSYBla2oZ9BMqYlncBaKmD/7iA==",
+            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/generator": "^7.14.2",
@@ -405,9 +422,9 @@
             }
         },
         "node_modules/@datawrapper/chart-core": {
-            "version": "8.39.0",
-            "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-8.39.0.tgz",
-            "integrity": "sha512-Q0ZEo07iDaSE2OzUfNbKzpRYkrQJZdmp502Jf2GtNxkorgb3U28EgkaXm30jC6mr/Lqw3M5TrBwsPwj9mtte/A==",
+            "version": "8.39.1",
+            "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-8.39.1.tgz",
+            "integrity": "sha512-cJi1ycGIRBR71aSy5MxNi8Kb5hsKpyZ26jCiKlZw7TqKiOv/m+lYDTiy7QpkiT1U/Tgag7D/HefEpsoBvvhpIA==",
             "dependencies": {
                 "@datawrapper/expr-eval": "^2.0.4",
                 "@datawrapper/polyfills": "2.1.1",
@@ -1497,8 +1514,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.0.tgz",
             "integrity": "sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==",
             "dev": true,
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -1514,9 +1529,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true,
-            "optional": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/alphanum-sort": {
             "version": "1.0.2",
@@ -4522,6 +4535,7 @@
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
             "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+            "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -4640,6 +4654,7 @@
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -5984,6 +5999,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
             "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+            "dev": true,
             "dependencies": {
                 "minimist": "^1.2.5"
             },
@@ -9545,6 +9561,7 @@
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
             "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -11194,12 +11211,14 @@
         "@babel/compat-data": {
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.4.tgz",
-            "integrity": "sha512-i2wXrWQNkH6JplJQGn3Rd2I4Pij8GdHkXwHMxm+zV5YG/Jci+bCNrWZEWC4o+umiDkRrRs4dVzH3X4GP7vyjQQ=="
+            "integrity": "sha512-i2wXrWQNkH6JplJQGn3Rd2I4Pij8GdHkXwHMxm+zV5YG/Jci+bCNrWZEWC4o+umiDkRrRs4dVzH3X4GP7vyjQQ==",
+            "dev": true
         },
         "@babel/core": {
             "version": "7.14.3",
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.3.tgz",
             "integrity": "sha512-jB5AmTKOCSJIZ72sd78ECEhuPiDMKlQdDI/4QRI6lzYATx5SSogS1oQA2AoPecRCknm30gHi2l+QVvNUu3wZAg==",
+            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/generator": "^7.14.3",
@@ -11222,6 +11241,7 @@
             "version": "7.14.3",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.3.tgz",
             "integrity": "sha512-bn0S6flG/j0xtQdz3hsjJ624h3W0r3llttBMfyHX3YrZ/KtLYr15bjA0FXkgW7FpvrDuTuElXeVjiKlYRpnOFA==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.14.2",
                 "jsesc": "^2.5.1",
@@ -11231,7 +11251,8 @@
                 "jsesc": {
                     "version": "2.5.2",
                     "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+                    "dev": true
                 }
             }
         },
@@ -11239,6 +11260,7 @@
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.4.tgz",
             "integrity": "sha512-JgdzOYZ/qGaKTVkn5qEDV/SXAh8KcyUVkCoSWGN8T3bwrgd6m+/dJa2kVGi6RJYJgEYPBdZ84BZp9dUjNWkBaA==",
+            "dev": true,
             "requires": {
                 "@babel/compat-data": "^7.14.4",
                 "@babel/helper-validator-option": "^7.12.17",
@@ -11250,6 +11272,7 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.2.tgz",
             "integrity": "sha512-NYZlkZRydxw+YT56IlhIcS8PAhb+FEUiOzuhFTfqDyPmzAhRge6ua0dQYT/Uh0t/EDHq05/i+e5M2d4XvjgarQ==",
+            "dev": true,
             "requires": {
                 "@babel/helper-get-function-arity": "^7.12.13",
                 "@babel/template": "^7.12.13",
@@ -11260,6 +11283,7 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
             "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.12.13"
             }
@@ -11268,6 +11292,7 @@
             "version": "7.13.12",
             "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
             "integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.13.12"
             }
@@ -11284,6 +11309,7 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.2.tgz",
             "integrity": "sha512-OznJUda/soKXv0XhpvzGWDnml4Qnwp16GN+D/kZIdLsWoHj05kyu8Rm5kXmMef+rVJZ0+4pSGLkeixdqNUATDA==",
+            "dev": true,
             "requires": {
                 "@babel/helper-module-imports": "^7.13.12",
                 "@babel/helper-replace-supers": "^7.13.12",
@@ -11299,6 +11325,7 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
             "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.12.13"
             }
@@ -11312,6 +11339,7 @@
             "version": "7.14.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.4.tgz",
             "integrity": "sha512-zZ7uHCWlxfEAAOVDYQpEf/uyi1dmeC7fX4nCf2iz9drnCwi1zvwXL3HwWWNXUQEJ1k23yVn3VbddiI9iJEXaTQ==",
+            "dev": true,
             "requires": {
                 "@babel/helper-member-expression-to-functions": "^7.13.12",
                 "@babel/helper-optimise-call-expression": "^7.12.13",
@@ -11323,6 +11351,7 @@
             "version": "7.13.12",
             "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
             "integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.13.12"
             }
@@ -11331,6 +11360,7 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
             "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.12.13"
             }
@@ -11343,12 +11373,14 @@
         "@babel/helper-validator-option": {
             "version": "7.12.17",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
-            "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw=="
+            "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
+            "dev": true
         },
         "@babel/helpers": {
             "version": "7.14.0",
             "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.0.tgz",
             "integrity": "sha512-+ufuXprtQ1D1iZTO/K9+EBRn+qPWMJjZSw/S0KlFrxCw4tkrzv9grgpDHkY9MeQTjTY8i2sp7Jep8DfU6tN9Mg==",
+            "dev": true,
             "requires": {
                 "@babel/template": "^7.12.13",
                 "@babel/traverse": "^7.14.0",
@@ -11428,6 +11460,7 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
             "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/parser": "^7.12.13",
@@ -11438,6 +11471,7 @@
             "version": "7.14.2",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.2.tgz",
             "integrity": "sha512-TsdRgvBFHMyHOOzcP9S6QU0QQtjxlRpEYOy3mcCO5RgmC305ki42aSAmfZEMSSYBla2oZ9BMqYlncBaKmD/7iA==",
+            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.12.13",
                 "@babel/generator": "^7.14.2",
@@ -11476,9 +11510,9 @@
             }
         },
         "@datawrapper/chart-core": {
-            "version": "8.39.0",
-            "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-8.39.0.tgz",
-            "integrity": "sha512-Q0ZEo07iDaSE2OzUfNbKzpRYkrQJZdmp502Jf2GtNxkorgb3U28EgkaXm30jC6mr/Lqw3M5TrBwsPwj9mtte/A==",
+            "version": "8.39.1",
+            "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-8.39.1.tgz",
+            "integrity": "sha512-cJi1ycGIRBR71aSy5MxNi8Kb5hsKpyZ26jCiKlZw7TqKiOv/m+lYDTiy7QpkiT1U/Tgag7D/HefEpsoBvvhpIA==",
             "requires": {
                 "@datawrapper/expr-eval": "^2.0.4",
                 "@datawrapper/polyfills": "2.1.1",
@@ -12381,8 +12415,7 @@
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
             "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "acorn-walk": {
             "version": "8.1.0",
@@ -12417,14 +12450,15 @@
             "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.0.tgz",
             "integrity": "sha512-USH2jBb+C/hIpwD2iRjp0pe0k+MvzG0mlSn/FIdCgQhUb9ALPRjt2KIQdfZDS9r0ZIeUAg7gOu9KL0PFqGqr5Q==",
             "dev": true,
-            "requires": {},
+            "requires": {
+                "ajv": "^8.0.0"
+            },
             "dependencies": {
                 "ajv": {
-                    "version": "https://registry.npmjs.org/ajv/-/ajv-8.6.0.tgz",
+                    "version": "8.6.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.0.tgz",
                     "integrity": "sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==",
                     "dev": true,
-                    "optional": true,
-                    "peer": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "json-schema-traverse": "^1.0.0",
@@ -12436,9 +12470,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
                     "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-                    "dev": true,
-                    "optional": true,
-                    "peer": true
+                    "dev": true
                 }
             }
         },
@@ -13523,8 +13555,7 @@
         "cssnano-utils": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-2.0.1.tgz",
-            "integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ==",
-            "requires": {}
+            "integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ=="
         },
         "csso": {
             "version": "4.2.0",
@@ -14044,15 +14075,13 @@
             "version": "14.1.1",
             "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz",
             "integrity": "sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-config-standard-jsx": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-8.1.0.tgz",
             "integrity": "sha512-ULVC8qH8qCqbU792ZOO6DaiaZyHNS/5CZt3hKqHkEhVlhPEPN3nfBqqxJCyp59XrjIBZPu1chMYe9T2DXZ7TMw==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-config-standard-react": {
             "version": "9.2.0",
@@ -14243,15 +14272,13 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
             "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-plugin-standard": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.1.0.tgz",
             "integrity": "sha512-ZL7+QRixjTR6/528YNGyDotyffm5OQst/sGxKDwGb9Uqs4In5Egi4+jbobhqJoyoCM6/7v/1A5fhQ7ScMtDjaQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-scope": {
             "version": "5.1.1",
@@ -14687,7 +14714,8 @@
         "gensync": {
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+            "dev": true
         },
         "get-caller-file": {
             "version": "2.0.5",
@@ -14766,7 +14794,8 @@
         "globals": {
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "dev": true
         },
         "globby": {
             "version": "11.0.3",
@@ -15739,6 +15768,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
             "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+            "dev": true,
             "requires": {
                 "minimist": "^1.2.5"
             }
@@ -17612,26 +17642,22 @@
         "postcss-discard-comments": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.1.tgz",
-            "integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg==",
-            "requires": {}
+            "integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg=="
         },
         "postcss-discard-duplicates": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.1.tgz",
-            "integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA==",
-            "requires": {}
+            "integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA=="
         },
         "postcss-discard-empty": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.0.1.tgz",
-            "integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw==",
-            "requires": {}
+            "integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw=="
         },
         "postcss-discard-overridden": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.1.tgz",
-            "integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q==",
-            "requires": {}
+            "integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q=="
         },
         "postcss-less": {
             "version": "4.0.1",
@@ -17705,8 +17731,7 @@
         "postcss-normalize-charset": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.0.1.tgz",
-            "integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg==",
-            "requires": {}
+            "integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg=="
         },
         "postcss-normalize-display-values": {
             "version": "5.0.1",
@@ -18432,7 +18457,8 @@
         "semver": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true
         },
         "semver-compare": {
             "version": "1.0.0",
@@ -18926,8 +18952,7 @@
         "svelte-extras": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/svelte-extras/-/svelte-extras-2.0.2.tgz",
-            "integrity": "sha512-yoxNehbDxGEHxJBTWq2RpIPDTHlNNy6eGR7RPSK7qsh8hoyOXbji8uF//l4+I/l2fLP+E8pQTJYrduPXrW3wsw==",
-            "requires": {}
+            "integrity": "sha512-yoxNehbDxGEHxJBTWq2RpIPDTHlNNy6eGR7RPSK7qsh8hoyOXbji8uF//l4+I/l2fLP+E8pQTJYrduPXrW3wsw=="
         },
         "svelte2": {
             "version": "npm:svelte@2.16.1",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "url": "git+https://github.com/datawrapper/datawrapper-api.git"
     },
     "dependencies": {
-        "@datawrapper/chart-core": "^8.38.3",
+        "@datawrapper/chart-core": "^8.39.0",
         "@datawrapper/locales": "^1.2.6",
         "@datawrapper/orm": "^3.25.0",
         "@datawrapper/schemas": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "url": "git+https://github.com/datawrapper/datawrapper-api.git"
     },
     "dependencies": {
-        "@datawrapper/chart-core": "^8.39.1",
+        "@datawrapper/chart-core": "^8.39.2",
         "@datawrapper/locales": "^1.2.6",
         "@datawrapper/orm": "^3.25.0",
         "@datawrapper/schemas": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "url": "git+https://github.com/datawrapper/datawrapper-api.git"
     },
     "dependencies": {
-        "@datawrapper/chart-core": "^8.39.0",
+        "@datawrapper/chart-core": "^8.39.1",
         "@datawrapper/locales": "^1.2.6",
         "@datawrapper/orm": "^3.25.0",
         "@datawrapper/schemas": "^1.12.0",

--- a/src/publish/create-chart-website.js
+++ b/src/publish/create-chart-website.js
@@ -105,20 +105,22 @@ module.exports = async function createChartWebsite(
     const assetsFiles = [];
     for (const asset of publishData.assets) {
         const { name, prefix, shared, value } = asset;
-        if (!shared) {
-            assets[name] = {
-                value
-            };
-        } else {
+
+        if (shared) {
             const hashed = await writeFileHashed(name, value, outDir);
-            const assetPath = (prefix ? prefix + '/' : '') + hashed;
+            const assetPath = (shared && prefix ? prefix + '/' : '') + hashed;
 
             assets[name] = {
-                shared: true,
                 url: getAssetLink(`../../lib/${assetPath}`)
             };
-
             assetsFiles.push(`lib/${assetPath}`);
+        } else {
+            await fs.writeFile(path.join(outDir, name), value, { encoding: 'utf-8' });
+
+            assets[name] = {
+                url: name
+            };
+            assetsFiles.push(name);
         }
     }
     publishData.assets = assets;

--- a/src/publish/create-chart-website.js
+++ b/src/publish/create-chart-website.js
@@ -108,7 +108,7 @@ module.exports = async function createChartWebsite(
 
         if (shared) {
             const hashed = await writeFileHashed(name, value, outDir);
-            const assetPath = (shared && prefix ? prefix + '/' : '') + hashed;
+            const assetPath = (prefix ? prefix + '/' : '') + hashed;
 
             assets[name] = {
                 url: getAssetLink(`../../lib/${assetPath}`)

--- a/src/publish/create-chart-website.js
+++ b/src/publish/create-chart-website.js
@@ -226,7 +226,7 @@ module.exports = async function createChartWebsite(
     await fs.writeFile(path.join(outDir, 'index.html'), indexHTML, { encoding: 'utf-8' });
 
     /* write "data.csv", including changes made in step 2 */
-    const dataset = await dwChart(publishData.chart).load(chartData);
+    const dataset = await dwChart(publishData.chart).load(chartData || '');
     const isJSON = get(publishData.chart, 'metadata.data.json');
     const dataFile = `data.${isJSON ? 'json' : 'csv'}`;
     await fs.writeFile(

--- a/src/routes/charts/{id}/publish.js
+++ b/src/routes/charts/{id}/publish.js
@@ -385,7 +385,7 @@ async function publishData(request, h) {
     data.assets = [
         {
             name: `dataset.${get(chart, 'metadata.data.json') ? 'json' : 'csv'}`,
-            value: res.status === 200 ? res.result : '',
+            value: res.result,
             shared: false
         },
         ...(


### PR DESCRIPTION
_(I promise this is the last asset- and hosting-related PR for now)_

There are two types of chart assets: Shared and unshared assets. Shared assets are things like basemaps from our global selection. When published, these are loaded from the global `/lib` directory, so that unrelated visualizations can benefit from using the same asset URL.

Unshared assets are things like chart datasets or custom uploaded basemaps. This PR changes how _unshared_ assets are handled. These have so far been baked into the HTML of the published visualization, which results in suboptimal performance, and increases the size of the `index.html`. Now, these are stored as separate files (i.e. `/:chartId/:version/dataset.csv`, `/:chartId/:version/custom_basemap.json`). This has several advantages:
- for HTTP/2 supporting clients (which are the vast majority), this will result in faster loads
- for all clients, this will result in faster _subsequent_ loads because of improved caching
- we increase the % of bandwidth handled by the CDN since the hard-to-cache `index.html` contains less content and more content lives in separate, versioned assets 