### PR TITLE
expose active team with /v3/users/{id} and /v3/me

### DIFF
--- a/src/routes/teams/index.js
+++ b/src/routes/teams/index.js
@@ -4,6 +4,7 @@ const { nanoid } = require('nanoid');
 const { Team, UserTeam } = require('@datawrapper/orm/models');
 
 const { listResponse, teamResponse } = require('../../schemas/response.js');
+const { getUserData } = require('@datawrapper/orm/utils/userData');
 
 module.exports = {
     name: 'routes/teams',
@@ -89,6 +90,10 @@ async function getAllTeams(request, h) {
         method: 'GET',
         url: `/v3/admin/teams?userId=${request.auth.artifacts.id}&${request.url.search.slice(1)}`,
         auth: request.auth
+    });
+    const activeTeam = await getUserData(request.auth.artifacts.id, 'active_team');
+    res.result.list.forEach(team => {
+        if (team.id === activeTeam) team.active = true;
     });
     return h.response(res.result).code(res.statusCode);
 }

--- a/src/routes/users/{id}/index.js
+++ b/src/routes/users/{id}/index.js
@@ -5,6 +5,7 @@ const set = require('lodash/set');
 const { logAction } = require('@datawrapper/orm/utils/action');
 const { User, Chart, Team, UserTeam, Session } = require('@datawrapper/orm/models');
 const { serializeTeam } = require('../../teams/utils');
+const { getUserData } = require('@datawrapper/orm/utils/userData');
 const { noContentResponse, userResponse } = require('../../../schemas/response');
 
 const attributes = ['id', 'email', 'name', 'role', 'language'];
@@ -148,8 +149,12 @@ async function getUser(request, h) {
 
     const { charts, teams, ...data } = user.dataValues;
 
+    const activeTeam = await getUserData(user.id, 'active_team');
+
     if (teams) {
-        data.teams = teams.map(serializeTeam);
+        data.teams = teams
+            .map(serializeTeam)
+            .map(team => ({ ...team, ...(activeTeam === team.id ? { active: true } : {}) }));
     }
 
     if (isAdmin) {
@@ -165,7 +170,8 @@ async function getUser(request, h) {
         ...data,
         role: user.role,
         chartCount: charts.length,
-        url: url.pathname
+        url: url.pathname,
+        activeTeam
     });
 }
 

--- a/src/routes/users/{id}/index.js
+++ b/src/routes/users/{id}/index.js
@@ -143,6 +143,8 @@ async function getUser(request, h) {
             'activate_token',
             'reset_password_token'
         ]);
+    } else {
+        set(options, ['include', 1], { model: Team, attributes: ['id', 'name'] });
     }
 
     const user = await User.findByPk(userId, options);


### PR DESCRIPTION
currently there's no straight forward way to find out which is the active team for a user. This PR

- exposes reduced informaton about a users teams (previously only included for admins)
- sets `active:true` on the currently activated team
- adds `user.activeTeam` to the response for convenience

```json
{
    "id": 1919,
    "email": "user@datawrapper.de",
    "name": null,
    "role": "editor",
    "language": "en-US",
    "teams": [
        {
            "id": "YGMpNNLL",
            "name": "foobar",
            "url": "/v3/teams/YGMpNNLL",
            "active": true
        }
    ],
    "chartCount": 2,
    "url": "/v3/users/1919",
    "activeTeam": "YGMpNNLL"
}
```