### PR TITLE
Save githead in shared cache

### DIFF
--- a/src/routes/admin/plugins.js
+++ b/src/routes/admin/plugins.js
@@ -24,6 +24,7 @@ function register(server, options) {
     server.app.adminScopes.add('plugin:write');
 
     const styleCache = server.cache({ segment: 'vis-styles', shared: true });
+    const githeadCache = server.cache({ segment: 'vis-githead', shared: true });
 
     // GET /v3/admin/plugins
     server.route({
@@ -174,10 +175,7 @@ function register(server, options) {
             // also update githead cache of visualization
             const githeadPath = path.join(pluginLocation, '.githead');
             if (await fs.pathExists(githeadPath)) {
-                server.app.visualizations.get(vis).githead = await fs.readFile(
-                    githeadPath,
-                    'utf-8'
-                );
+                await githeadCache.set(vis.id, await fs.readFile(githeadPath, 'utf-8'));
             }
         }
 

--- a/src/routes/visualizations/{id}/styles.js
+++ b/src/routes/visualizations/{id}/styles.js
@@ -12,6 +12,12 @@ module.exports = (server, options) => {
         shared: true
     });
 
+    const githeadCache = server.cache({
+        segment: 'vis-githead',
+        expiresIn: 86400000 * 365 /* 1 year */,
+        shared: true
+    });
+
     server.route({
         method: 'GET',
         path: '/styles.css',
@@ -44,7 +50,7 @@ module.exports = (server, options) => {
         const transparent = !!query.transparent;
 
         // try to find a .githead file in vis plugin
-        const githead = vis.githead || 'head';
+        const githead = (await githeadCache.get(vis.id)) || 'head';
 
         const cacheKey = `${query.theme}__${params.id}__${githead}`;
         const cachedCSS = await styleCache.get(cacheKey);


### PR DESCRIPTION
So that we can properly invalidate it across all API instances when needed