### PR TITLE
Support relative prefix in update-translations

### DIFF
--- a/scripts/update-translations.js
+++ b/scripts/update-translations.js
@@ -186,9 +186,12 @@ const gitStatusCache = new Map();
 const gitNewChanges = new Map();
 
 async function writeTranslationsIfGitClean(file, translations) {
-    if (PREFIX && !file.startsWith(PREFIX)) {
-        // ignore fle
-        return;
+    if (PREFIX) {
+        const relPath = path.relative(path.join(__dirname, '../../..'), file);
+        if (!relPath.startsWith(PREFIX)) {
+            // ignore file
+            return;
+        }
     }
     // read existing translations and compare
     if (fs.existsSync(file)) {


### PR DESCRIPTION
#### Steps to reproduce

1. Run `npm run update-translations -- --prefix=services/datawrapper`
2. See that translations don't get updated.

#### Problem

It's because we check the prefix against an absolute path. So in order for the above command to work, it would need to be called with `--prefix=/home/jakub/foo/bar/services/datawrapper`.

#### Change

Calculate relative path and check if it has the prefix.